### PR TITLE
add meter mainnet and testnet

### DIFF
--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -36,6 +36,8 @@ class BlockscoutClient:
         EthereumNetwork.VELAS_MAINNET: "https://evmexplorer.velas.com/",
         EthereumNetwork.REI_MAINNET: "https://scan.rei.network/",
         EthereumNetwork.REI_TESTNET: "https://scan-test.rei.network/",
+        EthereumNetwork.METER: "https://scan.meter.io/",
+        EthereumNetwork.METER_TESTNET: "https://scan-warringstakes.meter.io/"
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/ethereum_network.py
+++ b/gnosis/eth/ethereum_network.py
@@ -61,6 +61,7 @@ class EthereumNetwork(Enum):
     PC = 78
     GENECHAIN = 80
     METER = 82
+    METER_TESTNET = 83
     GTTEST_TESTNET = 85
     GT = 86
     TOMO = 88


### PR DESCRIPTION
Hi, please I would like to add Meter mainnet and testnet to Gnosis Safe.

Meter Mainnet
chainId = 82
rpcUrl: https://rpc.meter.io/
explorer: https://scan.meter.io/

Meter Testnet
chainId = 83
rpcUrl: https://rpctest.meter.io/
explorer: https://scan-warringstakes.meter.io/
