### PR TITLE
Optimize `to_checksum_address` function

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,7 @@ Contains utils for ethereum operations:
 
 - ``get_eth_address_with_key() -> Tuple[str, bytes]``: Returns a tuple of a valid public ethereum checksumed
   address with the private key.
-- ``generate_address_2(from_: Union[str, bytes], salt: Union[str, bytes], init_code: [str, bytes]) -> str``:
+- ``mk_contract_address_2(from_: Union[str, bytes], salt: Union[str, bytes], init_code: [str, bytes]) -> str``:
   Calculates the address of a new contract created using the new CREATE2 opcode.
 
 Ethereum django (REST) utils

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -100,7 +100,7 @@ Contains utils for ethereum operations:
 
 - ``get_eth_address_with_key() -> Tuple[str, bytes]``: Returns a tuple of a valid public ethereum checksumed
   address with the private key.
-- ``generate_address_2(from_: Union[str, bytes], salt: Union[str, bytes], init_code: [str, bytes]) -> str``:
+- ``mk_contract_address_2(from_: Union[str, bytes], salt: Union[str, bytes], init_code: [str, bytes]) -> str``:
   Calculates the address of a new contract created using the new CREATE2 opcode.
 
 Ethereum django (REST) utils

--- a/gnosis/eth/clients/sourcify.py
+++ b/gnosis/eth/clients/sourcify.py
@@ -2,9 +2,9 @@ from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
 import requests
-from web3 import Web3
 
 from .. import EthereumNetwork
+from ..utils import fast_is_checksum_address
 from .contract_metadata import ContractMetadata
 
 
@@ -47,7 +47,7 @@ class Sourcify:
     def get_contract_metadata(
         self, contract_address: str
     ) -> Optional[ContractMetadata]:
-        assert Web3.isChecksumAddress(
+        assert fast_is_checksum_address(
             contract_address
         ), "Expecting a checksummed address"
 

--- a/gnosis/eth/django/filters.py
+++ b/gnosis/eth/django/filters.py
@@ -6,7 +6,8 @@ from django.utils.translation import gettext_lazy as _
 
 import django_filters
 from hexbytes import HexBytes
-from web3 import Web3
+
+from ..utils import fast_is_checksum_address
 
 
 class EthereumAddressFieldForm(CharFieldForm):
@@ -21,7 +22,7 @@ class EthereumAddressFieldForm(CharFieldForm):
         value = super().to_python(value)
         if value in self.empty_values:
             return None
-        elif not Web3.isChecksumAddress(value):
+        elif not fast_is_checksum_address(value):
             raise ValidationError(self.error_messages["invalid"], code="invalid")
         return value
 

--- a/gnosis/eth/django/serializers.py
+++ b/gnosis/eth/django/serializers.py
@@ -5,7 +5,6 @@ from django.utils.translation import gettext_lazy as _
 from hexbytes import HexBytes
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
-from web3 import Web3
 
 from ..constants import (
     SIGNATURE_R_MAX_VALUE,
@@ -15,6 +14,7 @@ from ..constants import (
     SIGNATURE_V_MAX_VALUE,
     SIGNATURE_V_MIN_VALUE,
 )
+from ..utils import fast_is_checksum_address
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +44,7 @@ class EthereumAddressField(serializers.Field):
     def to_internal_value(self, data):
         # Check if address is valid
         try:
-            if Web3.toChecksumAddress(data) != data:
+            if not fast_is_checksum_address(data):
                 raise ValueError
             elif int(data, 16) == 0 and not self.allow_zero_address:
                 raise ValidationError("0x0 address is not allowed")

--- a/gnosis/eth/django/tests/test_forms.py
+++ b/gnosis/eth/django/tests/test_forms.py
@@ -16,7 +16,7 @@ class Keccak256Form(forms.Form):
 
 class TestForms(TestCase):
     def test_ethereum_address_field_form(self):
-        form = EthereumAddressForm(data={"value": "not a ethereum address"})
+        form = EthereumAddressForm(data={"value": "not an ethereum address"})
         self.assertFalse(form.is_valid())
         self.assertEqual(
             form.errors["value"], ["Enter a valid checksummed Ethereum Address."]

--- a/gnosis/eth/django/tests/test_models.py
+++ b/gnosis/eth/django/tests/test_models.py
@@ -7,6 +7,7 @@ from faker import Faker
 from web3 import Web3
 
 from ...constants import NULL_ADDRESS, SENTINEL_ADDRESS
+from ...utils import fast_is_checksum_address
 from .models import EthereumAddress, EthereumAddressV2, Keccak256Hash, Sha3Hash, Uint256
 
 faker = Faker()
@@ -17,10 +18,10 @@ class TestModels(TestCase):
         for EthereumAddressModel in (EthereumAddress, EthereumAddressV2):
             with self.subTest(EthereumAddressModel=EthereumAddressModel):
                 address = Account.create().address
-                self.assertTrue(Web3.isChecksumAddress(address))
+                self.assertTrue(fast_is_checksum_address(address))
                 ethereum_address = EthereumAddressModel.objects.create(value=address)
                 ethereum_address.refresh_from_db()
-                self.assertTrue(Web3.isChecksumAddress(ethereum_address.value))
+                self.assertTrue(fast_is_checksum_address(ethereum_address.value))
                 self.assertEqual(address, ethereum_address.value)
 
                 # Test addresses

--- a/gnosis/eth/django/validators.py
+++ b/gnosis/eth/django/validators.py
@@ -1,10 +1,10 @@
 from django.core.exceptions import ValidationError
 
-from web3 import Web3
+from ..utils import fast_is_checksum_address
 
 
 def validate_checksumed_address(address):
-    if not Web3.isChecksumAddress(address):
+    if not fast_is_checksum_address(address):
         raise ValidationError(
             "%(address)s has an invalid checksum",
             params={"address": address},

--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -54,7 +54,11 @@ from web3.types import (
     Wei,
 )
 
-from gnosis.eth.utils import mk_contract_address
+from gnosis.eth.utils import (
+    fast_is_checksum_address,
+    fast_to_checksum_address,
+    mk_contract_address,
+)
 
 from .constants import (
     ERC20_721_TRANSFER_TOPIC,
@@ -434,7 +438,7 @@ class Erc20Manager(EthereumClientManager):
                 try:
                     from_to_data = b"".join(topics[1:])
                     _from, to = (
-                        Web3.toChecksumAddress(address)
+                        fast_to_checksum_address(address)
                         for address in eth_abi.decode_abi(
                             ["address", "address"], from_to_data
                         )
@@ -452,7 +456,9 @@ class Erc20Manager(EthereumClientManager):
                 _from, to, token_id = eth_abi.decode_abi(
                     ["address", "address", "uint256"], b"".join(topics[1:])
                 )
-                _from, to = [Web3.toChecksumAddress(address) for address in (_from, to)]
+                _from, to = [
+                    fast_to_checksum_address(address) for address in (_from, to)
+                ]
                 return {"from": _from, "to": to, "tokenId": token_id}
         return None
 
@@ -892,7 +898,7 @@ class ParityManager(EthereumClientManager):
 
         # CALL, DELEGATECALL, CREATE or CREATE2
         if "from" in action:
-            decoded["from"] = self.w3.toChecksumAddress(action["from"])
+            decoded["from"] = fast_to_checksum_address(action["from"])
         if "gas" in action:
             decoded["gas"] = int(action["gas"], 16)
         if "value" in action:
@@ -904,7 +910,7 @@ class ParityManager(EthereumClientManager):
         if "input" in action:
             decoded["input"] = HexBytes(action["input"])
         if "to" in action:
-            decoded["to"] = self.w3.toChecksumAddress(action["to"])
+            decoded["to"] = fast_to_checksum_address(action["to"])
 
         # CREATE or CREATE2
         if "init" in action:
@@ -912,13 +918,11 @@ class ParityManager(EthereumClientManager):
 
         # SELF-DESTRUCT
         if "address" in action:
-            decoded["address"] = self.w3.toChecksumAddress(action["address"])
+            decoded["address"] = fast_to_checksum_address(action["address"])
         if "balance" in action:
             decoded["balance"] = int(action["balance"], 16)
         if "refundAddress" in action:
-            decoded["refundAddress"] = self.w3.toChecksumAddress(
-                action["refundAddress"]
-            )
+            decoded["refundAddress"] = fast_to_checksum_address(action["refundAddress"])
 
         return decoded
 
@@ -935,7 +939,7 @@ class ParityManager(EthereumClientManager):
         if "code" in result:
             decoded["code"] = HexBytes(result["code"])
         if "address" in result:
-            decoded["address"] = self.w3.toChecksumAddress(result["address"])
+            decoded["address"] = fast_to_checksum_address(result["address"])
 
         return decoded
 
@@ -1898,7 +1902,7 @@ class EthereumClient:
         :return: tx_hash
         """
 
-        assert Web3.isChecksumAddress(to)
+        assert fast_is_checksum_address(to)
 
         account = Account.from_key(private_key)
 

--- a/gnosis/eth/oracles/oracles.py
+++ b/gnosis/eth/oracles/oracles.py
@@ -9,7 +9,6 @@ from eth_abi.exceptions import DecodingError
 from eth_abi.packed import encode_abi_packed
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
-from web3 import Web3
 from web3.contract import Contract
 from web3.exceptions import BadFunctionCallOutput
 
@@ -23,6 +22,7 @@ from ..contracts import (
     get_uniswap_v2_pair_contract,
     get_uniswap_v2_router_contract,
 )
+from ..utils import fast_bytes_to_checksum_address, fast_keccak
 from .abis.aave_abis import AAVE_ATOKEN_ABI
 from .abis.balancer_abis import balancer_pool_abi
 from .abis.cream_abis import cream_ctoken_abi
@@ -380,16 +380,16 @@ class UniswapV2Oracle(PricePoolOracle, PriceOracle):
         """
         if token_address.lower() > token_address_2.lower():
             token_address, token_address_2 = token_address_2, token_address
-        salt = Web3.keccak(
+        salt = fast_keccak(
             encode_abi_packed(["address", "address"], [token_address, token_address_2])
         )
-        address = Web3.keccak(
+        address = fast_keccak(
             encode_abi_packed(
                 ["bytes", "address", "bytes", "bytes"],
                 [HexBytes("ff"), self.factory_address, salt, self.pair_init_code],
             )
         )[-20:]
-        return Web3.toChecksumAddress(address)
+        return fast_bytes_to_checksum_address(address)
 
     def get_decimals(self, token_address: str, token_address_2: str) -> Tuple[int, int]:
         if not (

--- a/gnosis/eth/tests/test_ethereum_client.py
+++ b/gnosis/eth/tests/test_ethereum_client.py
@@ -22,7 +22,7 @@ from ..ethereum_client import (
     SenderAccountNotFoundInNode,
 )
 from ..exceptions import BatchCallException, InvalidERC20Info
-from ..utils import get_eth_address_with_key
+from ..utils import fast_to_checksum_address, get_eth_address_with_key
 from .ethereum_test_case import EthereumTestCaseMixin
 from .mocks.mock_internal_txs import creation_internal_txs, internal_txs_errored
 from .mocks.mock_log_receipts import invalid_log_receipt, log_receipts
@@ -531,7 +531,7 @@ class TestParityManager(EthereumTestCaseMixin, TestCase):
         self.assertEqual(decoded_traces[0]["result"]["output"], HexBytes(""))
         self.assertEqual(
             decoded_traces[1]["result"]["address"],
-            self.w3.toChecksumAddress(example_traces[1]["result"]["address"]),
+            fast_to_checksum_address(example_traces[1]["result"]["address"]),
         )
         self.assertEqual(
             decoded_traces[1]["result"]["code"],

--- a/gnosis/eth/tests/test_utils.py
+++ b/gnosis/eth/tests/test_utils.py
@@ -1,27 +1,44 @@
+import os
+
 from django.test import TestCase
 
 from eth_abi.packed import encode_abi_packed
 from eth_account import Account
+from eth_utils import to_checksum_address
 from hexbytes import HexBytes
 
 from ..contracts import get_proxy_1_0_0_deployed_bytecode, get_proxy_factory_contract
-from ..utils import compare_byte_code, decode_string_or_bytes32, generate_address_2
+from ..utils import (
+    compare_byte_code,
+    decode_string_or_bytes32,
+    fast_bytes_to_checksum_address,
+    fast_is_checksum_address,
+    fast_keccak,
+    fast_to_checksum_address,
+    generate_address_2,
+    mk_contract_address,
+    mk_contract_address_2,
+)
 from .ethereum_test_case import EthereumTestCaseMixin
 
 
 class TestUtils(EthereumTestCaseMixin, TestCase):
-    def test_generate_address_2(self):
+    def test_mk_contract_address_2(self):
         from_ = "0x8942595A2dC5181Df0465AF0D7be08c8f23C93af"
         salt = self.w3.keccak(text="aloha")
         init_code = "0x00abcd"
         expected = "0x8D02C796Dd019916F65EBa1C9D65a7079Ece00E0"
-        address2 = generate_address_2(from_, salt, init_code)
+        address2 = mk_contract_address_2(from_, salt, init_code)
         self.assertEqual(address2, expected)
 
         from_ = HexBytes("0x8942595A2dC5181Df0465AF0D7be08c8f23C93af")
         salt = self.w3.keccak(text="aloha").hex()
         init_code = HexBytes("0x00abcd")
         expected = "0x8D02C796Dd019916F65EBa1C9D65a7079Ece00E0"
+        address2 = mk_contract_address_2(from_, salt, init_code)
+        self.assertEqual(address2, expected)
+
+        # Make sure deprecated function is working
         address2 = generate_address_2(from_, salt, init_code)
         self.assertEqual(address2, expected)
 
@@ -72,7 +89,7 @@ class TestUtils(EthereumTestCaseMixin, TestCase):
         deployment_data = encode_abi_packed(
             ["bytes", "uint256"], [proxy_creation_code, int(master_copy, 16)]
         )
-        address2 = generate_address_2(
+        address2 = mk_contract_address_2(
             proxy_factory_contract.address, salt, deployment_data
         )
         self.assertEqual(proxy_address, address2)
@@ -103,4 +120,74 @@ class TestUtils(EthereumTestCaseMixin, TestCase):
         )
         self.assertTrue(
             compare_byte_code(proxy_with_metadata, proxy_with_different_metadata)
+        )
+
+    def test_fast_keccak(self):
+        text = "chidori"
+        self.assertEqual(
+            fast_keccak(text.encode()),
+            HexBytes(
+                "0xd20148e42186a9e7698e652e255c809851633d62bad625a55d05efd7f718449c"
+            ),
+        )
+
+        binary = b""
+        self.assertEqual(
+            fast_keccak(binary),
+            HexBytes(
+                "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+            ),
+        )
+
+        binary = b"1234"
+        self.assertEqual(
+            fast_keccak(binary),
+            HexBytes(
+                "0x387a8233c96e1fc0ad5e284353276177af2186e7afa85296f106336e376669f7"
+            ),
+        )
+
+    def test_fast_to_checksum_address(self):
+        for _ in range(10):
+            address = os.urandom(20).hex()
+            self.assertEqual(
+                fast_to_checksum_address(address), to_checksum_address(address)
+            )
+
+    def test_fast_bytes_to_checksum_address(self):
+        with self.assertRaises(ValueError):
+            fast_bytes_to_checksum_address(os.urandom(19))
+
+        with self.assertRaises(ValueError):
+            fast_bytes_to_checksum_address(os.urandom(21))
+
+        for _ in range(10):
+            address = os.urandom(20)
+            self.assertEqual(
+                fast_bytes_to_checksum_address(address), to_checksum_address(address)
+            )
+
+    def test_fast_is_checksum_address(self):
+        self.assertFalse(fast_is_checksum_address(None))
+        self.assertFalse(fast_is_checksum_address(""))
+        self.assertFalse(
+            fast_is_checksum_address(0x6ED857DC1DA2C41470A95589BB482152000773E9)
+        )
+        self.assertFalse(fast_is_checksum_address(2))
+        self.assertFalse(fast_is_checksum_address("2"))
+        self.assertFalse(
+            fast_is_checksum_address("0x6ed857dc1da2c41470A95589bB482152000773e9")
+        )
+        self.assertTrue(
+            fast_is_checksum_address("0x6ED857dc1da2c41470A95589bB482152000773e9")
+        )
+
+    def test_mk_contract_address(self):
+        self.assertEqual(
+            mk_contract_address("0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B", 129),
+            "0x5A317285cD83092fD40153C4B7c3Df64d8482Da8",
+        )
+        self.assertEqual(
+            mk_contract_address("0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B", 399),
+            "0xF03b503CC9Ee8aAA3B17856942a440be0c77Cd84",
         )

--- a/gnosis/safe/multi_send.py
+++ b/gnosis/safe/multi_send.py
@@ -10,6 +10,7 @@ from gnosis.eth import EthereumClient
 from gnosis.eth.contracts import get_multi_send_contract
 from gnosis.eth.ethereum_client import EthereumTxSent
 from gnosis.eth.typing import EthereumData
+from gnosis.eth.utils import fast_bytes_to_checksum_address, fast_is_checksum_address
 
 logger = getLogger(__name__)
 
@@ -115,7 +116,7 @@ class MultiSendTx:
         """
         encoded_multisend_tx = HexBytes(encoded_multisend_tx)
         operation = MultiSendOperation(encoded_multisend_tx[0])
-        to = Web3.toChecksumAddress(encoded_multisend_tx[1 : 1 + 20])
+        to = fast_bytes_to_checksum_address(encoded_multisend_tx[1 : 1 + 20])
         value = int.from_bytes(encoded_multisend_tx[21 : 21 + 32], byteorder="big")
         data_length = int.from_bytes(
             encoded_multisend_tx[21 + 32 : 21 + 32 * 2], byteorder="big"
@@ -149,7 +150,7 @@ class MultiSendTx:
         operation = MultiSendOperation(
             int.from_bytes(encoded_multisend_tx[:32], byteorder="big")
         )
-        to = Web3.toChecksumAddress(encoded_multisend_tx[32:64][-20:])
+        to = fast_bytes_to_checksum_address(encoded_multisend_tx[32:64][-20:])
         value = int.from_bytes(encoded_multisend_tx[64:96], byteorder="big")
         data_length = int.from_bytes(encoded_multisend_tx[128:160], byteorder="big")
         data = encoded_multisend_tx[160 : 160 + data_length]
@@ -165,7 +166,7 @@ class MultiSend:
     dummy_w3 = Web3()
 
     def __init__(self, address: str, ethereum_client: EthereumClient):
-        assert Web3.isChecksumAddress(address), (
+        assert fast_is_checksum_address(address), (
             "%s proxy factory address not valid" % address
         )
 

--- a/gnosis/safe/proxy_factory.py
+++ b/gnosis/safe/proxy_factory.py
@@ -3,7 +3,6 @@ from typing import Optional
 
 from eth_account.signers.local import LocalAccount
 from eth_typing import ChecksumAddress
-from web3 import Web3
 from web3.contract import Contract
 
 from gnosis.eth import EthereumClient
@@ -18,7 +17,7 @@ from gnosis.eth.contracts import (
     get_proxy_factory_V1_1_1_contract,
 )
 from gnosis.eth.ethereum_client import EthereumTxSent
-from gnosis.eth.utils import compare_byte_code
+from gnosis.eth.utils import compare_byte_code, fast_is_checksum_address
 
 try:
     from functools import cache
@@ -33,7 +32,7 @@ logger = getLogger(__name__)
 
 class ProxyFactory:
     def __init__(self, address: ChecksumAddress, ethereum_client: EthereumClient):
-        assert Web3.isChecksumAddress(address), (
+        assert fast_is_checksum_address(address), (
             "%s proxy factory address not valid" % address
         )
 

--- a/gnosis/safe/safe_create2_tx.py
+++ b/gnosis/safe/safe_create2_tx.py
@@ -15,7 +15,7 @@ from gnosis.eth.contracts import (
     get_safe_V1_1_1_contract,
     get_safe_V1_3_0_contract,
 )
-from gnosis.eth.utils import generate_address_2
+from gnosis.eth.utils import fast_is_checksum_address, mk_contract_address_2
 
 logger = getLogger(__name__)
 
@@ -54,8 +54,8 @@ class SafeCreate2TxBuilder:
         :param master_copy_address: `Gnosis Safe` master copy address
         :param proxy_factory_address: `Gnosis Proxy Factory` address
         """
-        assert Web3.isChecksumAddress(master_copy_address)
-        assert Web3.isChecksumAddress(proxy_factory_address)
+        assert fast_is_checksum_address(master_copy_address)
+        assert fast_is_checksum_address(proxy_factory_address)
 
         self.w3 = w3
         self.master_copy_address = master_copy_address
@@ -110,8 +110,8 @@ class SafeCreate2TxBuilder:
         fallback_handler = fallback_handler or NULL_ADDRESS
         payment_receiver = payment_receiver or NULL_ADDRESS
         payment_token = payment_token or NULL_ADDRESS
-        assert Web3.isChecksumAddress(payment_receiver)
-        assert Web3.isChecksumAddress(payment_token)
+        assert fast_is_checksum_address(payment_receiver)
+        assert fast_is_checksum_address(payment_token)
 
         # Get bytes for `setup(address[] calldata _owners, uint256 _threshold, address to, bytes calldata data,
         # address paymentToken, uint256 payment, address payable paymentReceiver)`
@@ -222,7 +222,7 @@ class SafeCreate2TxBuilder:
             ["bytes", "uint256"],
             [proxy_creation_code, int(self.master_copy_address, 16)],
         )
-        return generate_address_2(
+        return mk_contract_address_2(
             self.proxy_factory_contract.address, salt, deployment_data
         )
 

--- a/gnosis/safe/safe_signature.py
+++ b/gnosis/safe/safe_signature.py
@@ -7,12 +7,12 @@ from eth_abi import decode_single, encode_single
 from eth_abi.exceptions import DecodingError
 from eth_account.messages import defunct_hash_message
 from eth_typing import ChecksumAddress
-from eth_utils import to_checksum_address
 from hexbytes import HexBytes
 from web3.exceptions import BadFunctionCallOutput
 
 from gnosis.eth import EthereumClient
 from gnosis.eth.contracts import get_safe_contract, get_safe_V1_1_1_contract
+from gnosis.eth.utils import fast_to_checksum_address
 from gnosis.safe.signatures import (
     get_signing_address,
     signature_split,
@@ -61,7 +61,9 @@ def uint_to_address(value: int) -> ChecksumAddress:
     encoded = encode_single("uint", value)
     # Remove padding bytes, as Solidity will ignore it but `eth_abi` will not
     encoded_without_padding_bytes = b"\x00" * 12 + encoded[-20:]
-    return to_checksum_address(decode_single("address", encoded_without_padding_bytes))
+    return fast_to_checksum_address(
+        decode_single("address", encoded_without_padding_bytes)
+    )
 
 
 class SafeSignature(ABC):

--- a/gnosis/safe/safe_tx.py
+++ b/gnosis/safe/safe_tx.py
@@ -5,7 +5,6 @@ from eip712_structs.struct import StructTuple
 from eth_account import Account
 from hexbytes import HexBytes
 from packaging.version import Version
-from web3 import Web3
 from web3.exceptions import BadFunctionCallOutput, ContractLogicError
 from web3.types import BlockIdentifier, TxParams, Wei
 
@@ -14,6 +13,7 @@ from gnosis.eth.constants import NULL_ADDRESS
 from gnosis.eth.contracts import get_safe_contract
 
 from ..eth.ethereum_client import TxSpeed
+from ..eth.utils import fast_keccak
 from .exceptions import (
     CouldNotFinishInitialization,
     CouldNotPayGasWithEther,
@@ -201,7 +201,7 @@ class SafeTx:
     def safe_tx_hash(self) -> HexBytes:
         message, domain = self._eip712_payload
         signable_bytes = message.signable_bytes(domain)
-        return HexBytes(Web3.keccak(signable_bytes))
+        return HexBytes(fast_keccak(signable_bytes))
 
     @property
     def signers(self) -> List[str]:

--- a/gp_cli.py
+++ b/gp_cli.py
@@ -1,3 +1,6 @@
+from gnosis.eth.utils import fast_keccak
+
+
 def confirm_prompt(question: str) -> bool:
     reply = None
     while reply not in ("y", "n"):
@@ -10,8 +13,6 @@ if __name__ == "__main__":
     import os
     import sys
     import time
-
-    from web3 import Web3
 
     from gnosis.eth import EthereumNetwork
     from gnosis.eth.constants import NULL_ADDRESS
@@ -54,7 +55,7 @@ if __name__ == "__main__":
         sellAmount=amount_wei,
         buyAmount=buy_amount,
         validTo=int(time.time()) + (60 * 60),  # Valid for 1 hour
-        appData=Web3.keccak(text="gp-cli"),
+        appData=fast_keccak(text="gp-cli"),
         feeAmount=0,
         kind="sell",  # `sell` or `buy`
         partiallyFillable=not args.require_full_fill,

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ hexbytes==0.2.2
 packaging
 psycopg2-binary==2.9.3
 py-evm==0.5.0a3
+pysha3>=1.0.0
 requests==2.28.0
 typing-extensions==3.10.0.2
 web3==5.29.2

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {"django": ["django>=2", "django-filter>=2", "djangorestframewo
 
 setup(
     name="safe-eth-py",
-    version="4.0.1",
+    version="4.1.0",
     packages=find_packages(),
     package_data={"gnosis": ["py.typed"]},
     install_requires=requirements,

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,9 @@ requirements = [
     "eip712_structs",
     "packaging",
     "py-evm>=0.5.0a3",
-    "typing-extensions>=3.10; python_version < '3.8'",
+    "pysha3>=1.0.0",
     "requests>=2",
+    "typing-extensions>=3.10; python_version < '3.8'",
     "web3>=5.23.0",
 ]
 


### PR DESCRIPTION
While developing Safe Tx Service we found out that a lot of time was spent on converting addresses from `bytes` to `ChecksumAddress`. Biggest part of this time was overhead added on `eth_utils` library to `keccak256` function.

So we decided to use `pysha3` library (way faster than `pycryptodome`) directly. That's why we implemented new methods:

- fast_keccak
- fast_keccak_hex
- fast_to_checksum_address
- fast_bytes_to_checksum_address
- fast_is_checksum_address

This is also very relevant for the `EthereumAddressV2Field`, as it stores addresses as `bytes` on database and returns them as `ChecksumAddress`

Related to:
  - https://github.com/ethereum/eth-utils/issues/95
  - https://github.com/ethereum/eth-hash/issues/35
