### PR TITLE
Fix threshold test in Safe.create()

### DIFF
--- a/gnosis/safe/safe.py
+++ b/gnosis/safe/safe.py
@@ -128,7 +128,7 @@ class Safe:
         """
 
         assert owners, "At least one owner must be set"
-        assert threshold >= len(owners), "Threshold=%d must be >= %d" % (
+        assert 1 <= threshold <= len(owners), "Threshold=%d must be <= %d" % (
             threshold,
             len(owners),
         )


### PR DESCRIPTION
`Safe.create()` currently asserts that the threshold is equal or greater than the list of owners, which is nonsensical. The Safe threshold can be any number of signers, logically up to the maximum number defined.