### PR TITLE
Fix None values for HexField

### DIFF
--- a/gnosis/eth/django/forms.py
+++ b/gnosis/eth/django/forms.py
@@ -1,5 +1,5 @@
 import binascii
-from typing import Optional
+from typing import Any, Optional
 
 from django import forms
 from django.core import exceptions
@@ -43,11 +43,12 @@ class HexFieldForm(forms.CharField):
         else:
             return ""
 
-    def to_python(self, value: str) -> Optional[HexBytes]:
-        value = value.strip()
+    def to_python(self, value: Optional[Any]) -> Optional[HexBytes]:
         if value in self.empty_values:
             return self.empty_value
         try:
+            if isinstance(value, str):
+                value = value.strip()
             return HexBytes(value)
         except (binascii.Error, TypeError, ValueError):
             raise exceptions.ValidationError(
@@ -67,7 +68,7 @@ class Keccak256FieldForm(HexFieldForm):
         # Keccak field already returns a hex str
         return value
 
-    def to_python(self, value) -> HexBytes:
+    def to_python(self, value: Optional[Any]) -> HexBytes:
         value: Optional[HexBytes] = super().to_python(value)
         if value and len(value) != 32:
             raise ValidationError(

--- a/gnosis/eth/django/tests/test_forms.py
+++ b/gnosis/eth/django/tests/test_forms.py
@@ -52,7 +52,15 @@ class TestForms(TestCase):
         form = HexForm(initial={"value": memoryview(bytes.fromhex("cdef"))})
         self.assertIn('value="0xcdef"', form.as_p())
 
+        form = HexForm(data={"value": 1})
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["value"], HexBytes(1))
+
         form = HexForm(data={"value": ""})
+        self.assertTrue(form.is_valid())
+        self.assertIsNone(form.cleaned_data["value"])
+
+        form = HexForm(data={"value": None})
         self.assertTrue(form.is_valid())
         self.assertIsNone(form.cleaned_data["value"])
 
@@ -73,5 +81,9 @@ class TestForms(TestCase):
         self.assertTrue(form.is_valid())
 
         form = Keccak256Form(data={"value": ""})
+        self.assertTrue(form.is_valid())
+        self.assertIsNone(form.cleaned_data["value"])
+
+        form = HexForm(data={"value": None})
         self.assertTrue(form.is_valid())
         self.assertIsNone(form.cleaned_data["value"])

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ extras_require = {"django": ["django>=2", "django-filter>=2", "djangorestframewo
 
 setup(
     name="safe-eth-py",
-    version="4.3.0",
+    version="4.3.1",
     packages=find_packages(),
     package_data={"gnosis": ["py.typed"]},
     install_requires=requirements,


### PR DESCRIPTION
- Call `strip()` after checking value is an str
