### PR TITLE
Fix memory leak cache for get_contract

### DIFF
--- a/gnosis/safe/safe.py
+++ b/gnosis/safe/safe.py
@@ -2,6 +2,7 @@ import dataclasses
 import math
 from enum import Enum
 from logging import getLogger
+from os import environ
 from typing import Callable, List, NamedTuple, Optional, Union
 
 from cachetools import LRUCache, cached
@@ -816,7 +817,10 @@ class Safe:
         threshold = self.retrieve_threshold()
         return 15000 + data_bytes_length // 32 * 100 + 5000 * threshold
 
-    @cached(cache=LRUCache(maxsize=1024 * 100), key=lambda self: hashkey(self.address))
+    @cached(
+        cache=LRUCache(maxsize=int(environ.get("CONTRACT_CACHE_SIZE", 1024 * 100))),
+        key=lambda self: hashkey(self.address),
+    )
     def get_contract(self) -> Contract:
         v_1_3_0_contract = get_safe_V1_3_0_contract(self.w3, address=self.address)
         version = v_1_3_0_contract.functions.VERSION().call()

--- a/gnosis/safe/tests/test_safe.py
+++ b/gnosis/safe/tests/test_safe.py
@@ -815,3 +815,21 @@ class TestSafe(SafeTestCaseMixin, TestCase):
 
         balance = self.w3.eth.get_balance(to)
         self.assertEqual(value, balance)
+
+    def test_get_contracts_cache_leak(self):
+        safe_deployed = self.deploy_test_safe(
+            owners=[self.ethereum_test_account.address]
+        )
+        Safe.get_contract.cache.clear()
+        for i in range(1, 2):
+            safe = Safe(safe_deployed.address, self.ethereum_client)
+            safe.get_contract()
+        self.assertEqual(Safe.get_contract.cache.currsize, 1)
+
+        safe_deployed = self.deploy_test_safe(
+            owners=[self.ethereum_test_account.address]
+        )
+        for i in range(1, 2):
+            safe = Safe(safe_deployed.address, self.ethereum_client)
+            safe.get_contract()
+        self.assertEqual(Safe.get_contract.cache.currsize, 2)

--- a/gnosis/safe/tests/test_safe.py
+++ b/gnosis/safe/tests/test_safe.py
@@ -816,12 +816,12 @@ class TestSafe(SafeTestCaseMixin, TestCase):
         balance = self.w3.eth.get_balance(to)
         self.assertEqual(value, balance)
 
-    def test_get_contracts_cache_leak(self):
+    def test_cache_size_get_contracts(self):
         safe_deployed = self.deploy_test_safe(
             owners=[self.ethereum_test_account.address]
         )
         Safe.get_contract.cache.clear()
-        for i in range(1, 2):
+        for i in range(0, 2):
             safe = Safe(safe_deployed.address, self.ethereum_client)
             safe.get_contract()
         self.assertEqual(Safe.get_contract.cache.currsize, 1)
@@ -829,7 +829,7 @@ class TestSafe(SafeTestCaseMixin, TestCase):
         safe_deployed = self.deploy_test_safe(
             owners=[self.ethereum_test_account.address]
         )
-        for i in range(1, 2):
+        for i in range(0, 2):
             safe = Safe(safe_deployed.address, self.ethereum_client)
             safe.get_contract()
         self.assertEqual(Safe.get_contract.cache.currsize, 2)

--- a/gnosis/safe/tests/test_safe.py
+++ b/gnosis/safe/tests/test_safe.py
@@ -833,3 +833,5 @@ class TestSafe(SafeTestCaseMixin, TestCase):
             safe = Safe(safe_deployed.address, self.ethereum_client)
             safe.get_contract()
         self.assertEqual(Safe.get_contract.cache.currsize, 2)
+
+        self.assertNotEqual(Safe.get_contract.cache.maxsize, None)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 cached-property==1.5.2
+cachetools==5.2.0
 django==3.2.14
 django-filter==22.1
 djangorestframework==3.13.1


### PR DESCRIPTION
closes #322 
- define maxsize to 1024*100 (Would be enough?)
- add cachetools to requirements
- replaces `@cache ` with `@cached` defining that the key to storage the cache is the `safe_address`
- add a test to check that `currsize` have correct values
- cache `maxsize` defined in environment var