### PR TITLE
Bump Django from 3.2.14 to 3.2.15

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 cached-property==1.5.2
-django==3.2.14
+django==3.2.15
 django-filter==22.1
 djangorestframework==3.13.1
 eip712-structs==1.1.0


### PR DESCRIPTION
Release notes: https://docs.djangoproject.com/en/4.0/releases/3.2.15/