### PR TITLE
Add Uniswap V3 Oracle

### DIFF
--- a/gnosis/eth/contracts/__init__.py
+++ b/gnosis/eth/contracts/__init__.py
@@ -30,12 +30,7 @@ from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract
 
-try:
-    from functools import cache
-except ImportError:
-    from functools import lru_cache
-
-    cache = lru_cache(maxsize=None)
+from gnosis.util import cache
 
 
 def load_contract_interface(file_name):

--- a/gnosis/eth/ethereum_client.py
+++ b/gnosis/eth/ethereum_client.py
@@ -59,7 +59,7 @@ from gnosis.eth.utils import (
     fast_to_checksum_address,
     mk_contract_address,
 )
-from gnosis.util import chunks
+from gnosis.util import cache, cached_property, chunks
 
 from .constants import (
     ERC20_721_TRANSFER_TOPIC,
@@ -90,20 +90,6 @@ from .exceptions import (
 )
 from .typing import BalanceDict, EthereumData, EthereumHash
 from .utils import decode_string_or_bytes32
-
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
-
-
-try:
-    from functools import cache
-except ImportError:
-    from functools import lru_cache
-
-    cache = lru_cache(maxsize=None)
-
 
 logger = getLogger(__name__)
 

--- a/gnosis/eth/oracles/__init__.py
+++ b/gnosis/eth/oracles/__init__.py
@@ -22,6 +22,7 @@ from .oracles import (
     YearnOracle,
     ZerionComposedOracle,
 )
+from .uniswap_v3 import UniswapV3Oracle
 
 __all__ = [
     "AaveOracle",
@@ -42,6 +43,7 @@ __all__ = [
     "UnderlyingToken",
     "UniswapOracle",
     "UniswapV2Oracle",
+    "UniswapV3Oracle",
     "UsdPricePoolOracle",
     "YearnOracle",
     "ZerionComposedOracle",

--- a/gnosis/eth/oracles/abis/uniswap_v3.py
+++ b/gnosis/eth/oracles/abis/uniswap_v3.py
@@ -1,0 +1,1323 @@
+uniswap_v3_factory_abi = [
+    {"inputs": [], "stateMutability": "nonpayable", "type": "constructor"},
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "uint24",
+                "name": "fee",
+                "type": "uint24",
+            },
+            {
+                "indexed": True,
+                "internalType": "int24",
+                "name": "tickSpacing",
+                "type": "int24",
+            },
+        ],
+        "name": "FeeAmountEnabled",
+        "type": "event",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "oldOwner",
+                "type": "address",
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "newOwner",
+                "type": "address",
+            },
+        ],
+        "name": "OwnerChanged",
+        "type": "event",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "token0",
+                "type": "address",
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "token1",
+                "type": "address",
+            },
+            {
+                "indexed": True,
+                "internalType": "uint24",
+                "name": "fee",
+                "type": "uint24",
+            },
+            {
+                "indexed": False,
+                "internalType": "int24",
+                "name": "tickSpacing",
+                "type": "int24",
+            },
+            {
+                "indexed": False,
+                "internalType": "address",
+                "name": "pool",
+                "type": "address",
+            },
+        ],
+        "name": "PoolCreated",
+        "type": "event",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "tokenA", "type": "address"},
+            {"internalType": "address", "name": "tokenB", "type": "address"},
+            {"internalType": "uint24", "name": "fee", "type": "uint24"},
+        ],
+        "name": "createPool",
+        "outputs": [{"internalType": "address", "name": "pool", "type": "address"}],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint24", "name": "fee", "type": "uint24"},
+            {"internalType": "int24", "name": "tickSpacing", "type": "int24"},
+        ],
+        "name": "enableFeeAmount",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "uint24", "name": "", "type": "uint24"}],
+        "name": "feeAmountTickSpacing",
+        "outputs": [{"internalType": "int24", "name": "", "type": "int24"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "", "type": "address"},
+            {"internalType": "address", "name": "", "type": "address"},
+            {"internalType": "uint24", "name": "", "type": "uint24"},
+        ],
+        "name": "getPool",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "parameters",
+        "outputs": [
+            {"internalType": "address", "name": "factory", "type": "address"},
+            {"internalType": "address", "name": "token0", "type": "address"},
+            {"internalType": "address", "name": "token1", "type": "address"},
+            {"internalType": "uint24", "name": "fee", "type": "uint24"},
+            {"internalType": "int24", "name": "tickSpacing", "type": "int24"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "_owner", "type": "address"}],
+        "name": "setOwner",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+]
+
+
+uniswap_v3_router_abi = [
+    {
+        "inputs": [
+            {"internalType": "address", "name": "_factoryV2", "type": "address"},
+            {"internalType": "address", "name": "factoryV3", "type": "address"},
+            {"internalType": "address", "name": "_positionManager", "type": "address"},
+            {"internalType": "address", "name": "_WETH9", "type": "address"},
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor",
+    },
+    {
+        "inputs": [],
+        "name": "WETH9",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "token", "type": "address"}],
+        "name": "approveMax",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "token", "type": "address"}],
+        "name": "approveMaxMinusOne",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "token", "type": "address"}],
+        "name": "approveZeroThenMax",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "address", "name": "token", "type": "address"}],
+        "name": "approveZeroThenMaxMinusOne",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "bytes", "name": "data", "type": "bytes"}],
+        "name": "callPositionManager",
+        "outputs": [{"internalType": "bytes", "name": "result", "type": "bytes"}],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "bytes[]", "name": "paths", "type": "bytes[]"},
+            {"internalType": "uint128[]", "name": "amounts", "type": "uint128[]"},
+            {
+                "internalType": "uint24",
+                "name": "maximumTickDivergence",
+                "type": "uint24",
+            },
+            {"internalType": "uint32", "name": "secondsAgo", "type": "uint32"},
+        ],
+        "name": "checkOracleSlippage",
+        "outputs": [],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "bytes", "name": "path", "type": "bytes"},
+            {
+                "internalType": "uint24",
+                "name": "maximumTickDivergence",
+                "type": "uint24",
+            },
+            {"internalType": "uint32", "name": "secondsAgo", "type": "uint32"},
+        ],
+        "name": "checkOracleSlippage",
+        "outputs": [],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {"internalType": "bytes", "name": "path", "type": "bytes"},
+                    {"internalType": "address", "name": "recipient", "type": "address"},
+                    {"internalType": "uint256", "name": "amountIn", "type": "uint256"},
+                    {
+                        "internalType": "uint256",
+                        "name": "amountOutMinimum",
+                        "type": "uint256",
+                    },
+                ],
+                "internalType": "struct IV3SwapRouter.ExactInputParams",
+                "name": "params",
+                "type": "tuple",
+            }
+        ],
+        "name": "exactInput",
+        "outputs": [
+            {"internalType": "uint256", "name": "amountOut", "type": "uint256"}
+        ],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {"internalType": "address", "name": "tokenIn", "type": "address"},
+                    {"internalType": "address", "name": "tokenOut", "type": "address"},
+                    {"internalType": "uint24", "name": "fee", "type": "uint24"},
+                    {"internalType": "address", "name": "recipient", "type": "address"},
+                    {"internalType": "uint256", "name": "amountIn", "type": "uint256"},
+                    {
+                        "internalType": "uint256",
+                        "name": "amountOutMinimum",
+                        "type": "uint256",
+                    },
+                    {
+                        "internalType": "uint160",
+                        "name": "sqrtPriceLimitX96",
+                        "type": "uint160",
+                    },
+                ],
+                "internalType": "struct IV3SwapRouter.ExactInputSingleParams",
+                "name": "params",
+                "type": "tuple",
+            }
+        ],
+        "name": "exactInputSingle",
+        "outputs": [
+            {"internalType": "uint256", "name": "amountOut", "type": "uint256"}
+        ],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {"internalType": "bytes", "name": "path", "type": "bytes"},
+                    {"internalType": "address", "name": "recipient", "type": "address"},
+                    {"internalType": "uint256", "name": "amountOut", "type": "uint256"},
+                    {
+                        "internalType": "uint256",
+                        "name": "amountInMaximum",
+                        "type": "uint256",
+                    },
+                ],
+                "internalType": "struct IV3SwapRouter.ExactOutputParams",
+                "name": "params",
+                "type": "tuple",
+            }
+        ],
+        "name": "exactOutput",
+        "outputs": [{"internalType": "uint256", "name": "amountIn", "type": "uint256"}],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {"internalType": "address", "name": "tokenIn", "type": "address"},
+                    {"internalType": "address", "name": "tokenOut", "type": "address"},
+                    {"internalType": "uint24", "name": "fee", "type": "uint24"},
+                    {"internalType": "address", "name": "recipient", "type": "address"},
+                    {"internalType": "uint256", "name": "amountOut", "type": "uint256"},
+                    {
+                        "internalType": "uint256",
+                        "name": "amountInMaximum",
+                        "type": "uint256",
+                    },
+                    {
+                        "internalType": "uint160",
+                        "name": "sqrtPriceLimitX96",
+                        "type": "uint160",
+                    },
+                ],
+                "internalType": "struct IV3SwapRouter.ExactOutputSingleParams",
+                "name": "params",
+                "type": "tuple",
+            }
+        ],
+        "name": "exactOutputSingle",
+        "outputs": [{"internalType": "uint256", "name": "amountIn", "type": "uint256"}],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "factory",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "factoryV2",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "uint256", "name": "amount", "type": "uint256"},
+        ],
+        "name": "getApprovalType",
+        "outputs": [
+            {
+                "internalType": "enum IApproveAndCall.ApprovalType",
+                "name": "",
+                "type": "uint8",
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {"internalType": "address", "name": "token0", "type": "address"},
+                    {"internalType": "address", "name": "token1", "type": "address"},
+                    {"internalType": "uint256", "name": "tokenId", "type": "uint256"},
+                    {
+                        "internalType": "uint256",
+                        "name": "amount0Min",
+                        "type": "uint256",
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount1Min",
+                        "type": "uint256",
+                    },
+                ],
+                "internalType": "struct IApproveAndCall.IncreaseLiquidityParams",
+                "name": "params",
+                "type": "tuple",
+            }
+        ],
+        "name": "increaseLiquidity",
+        "outputs": [{"internalType": "bytes", "name": "result", "type": "bytes"}],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {
+                "components": [
+                    {"internalType": "address", "name": "token0", "type": "address"},
+                    {"internalType": "address", "name": "token1", "type": "address"},
+                    {"internalType": "uint24", "name": "fee", "type": "uint24"},
+                    {"internalType": "int24", "name": "tickLower", "type": "int24"},
+                    {"internalType": "int24", "name": "tickUpper", "type": "int24"},
+                    {
+                        "internalType": "uint256",
+                        "name": "amount0Min",
+                        "type": "uint256",
+                    },
+                    {
+                        "internalType": "uint256",
+                        "name": "amount1Min",
+                        "type": "uint256",
+                    },
+                    {"internalType": "address", "name": "recipient", "type": "address"},
+                ],
+                "internalType": "struct IApproveAndCall.MintParams",
+                "name": "params",
+                "type": "tuple",
+            }
+        ],
+        "name": "mint",
+        "outputs": [{"internalType": "bytes", "name": "result", "type": "bytes"}],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "bytes32", "name": "previousBlockhash", "type": "bytes32"},
+            {"internalType": "bytes[]", "name": "data", "type": "bytes[]"},
+        ],
+        "name": "multicall",
+        "outputs": [{"internalType": "bytes[]", "name": "", "type": "bytes[]"}],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "deadline", "type": "uint256"},
+            {"internalType": "bytes[]", "name": "data", "type": "bytes[]"},
+        ],
+        "name": "multicall",
+        "outputs": [{"internalType": "bytes[]", "name": "", "type": "bytes[]"}],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "bytes[]", "name": "data", "type": "bytes[]"}],
+        "name": "multicall",
+        "outputs": [{"internalType": "bytes[]", "name": "results", "type": "bytes[]"}],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "positionManager",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "uint256", "name": "value", "type": "uint256"},
+        ],
+        "name": "pull",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "refundETH",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "uint256", "name": "value", "type": "uint256"},
+            {"internalType": "uint256", "name": "deadline", "type": "uint256"},
+            {"internalType": "uint8", "name": "v", "type": "uint8"},
+            {"internalType": "bytes32", "name": "r", "type": "bytes32"},
+            {"internalType": "bytes32", "name": "s", "type": "bytes32"},
+        ],
+        "name": "selfPermit",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "uint256", "name": "nonce", "type": "uint256"},
+            {"internalType": "uint256", "name": "expiry", "type": "uint256"},
+            {"internalType": "uint8", "name": "v", "type": "uint8"},
+            {"internalType": "bytes32", "name": "r", "type": "bytes32"},
+            {"internalType": "bytes32", "name": "s", "type": "bytes32"},
+        ],
+        "name": "selfPermitAllowed",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "uint256", "name": "nonce", "type": "uint256"},
+            {"internalType": "uint256", "name": "expiry", "type": "uint256"},
+            {"internalType": "uint8", "name": "v", "type": "uint8"},
+            {"internalType": "bytes32", "name": "r", "type": "bytes32"},
+            {"internalType": "bytes32", "name": "s", "type": "bytes32"},
+        ],
+        "name": "selfPermitAllowedIfNecessary",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "uint256", "name": "value", "type": "uint256"},
+            {"internalType": "uint256", "name": "deadline", "type": "uint256"},
+            {"internalType": "uint8", "name": "v", "type": "uint8"},
+            {"internalType": "bytes32", "name": "r", "type": "bytes32"},
+            {"internalType": "bytes32", "name": "s", "type": "bytes32"},
+        ],
+        "name": "selfPermitIfNecessary",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "amountIn", "type": "uint256"},
+            {"internalType": "uint256", "name": "amountOutMin", "type": "uint256"},
+            {"internalType": "address[]", "name": "path", "type": "address[]"},
+            {"internalType": "address", "name": "to", "type": "address"},
+        ],
+        "name": "swapExactTokensForTokens",
+        "outputs": [
+            {"internalType": "uint256", "name": "amountOut", "type": "uint256"}
+        ],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "amountOut", "type": "uint256"},
+            {"internalType": "uint256", "name": "amountInMax", "type": "uint256"},
+            {"internalType": "address[]", "name": "path", "type": "address[]"},
+            {"internalType": "address", "name": "to", "type": "address"},
+        ],
+        "name": "swapTokensForExactTokens",
+        "outputs": [{"internalType": "uint256", "name": "amountIn", "type": "uint256"}],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "uint256", "name": "amountMinimum", "type": "uint256"},
+            {"internalType": "address", "name": "recipient", "type": "address"},
+        ],
+        "name": "sweepToken",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "uint256", "name": "amountMinimum", "type": "uint256"},
+        ],
+        "name": "sweepToken",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "uint256", "name": "amountMinimum", "type": "uint256"},
+            {"internalType": "uint256", "name": "feeBips", "type": "uint256"},
+            {"internalType": "address", "name": "feeRecipient", "type": "address"},
+        ],
+        "name": "sweepTokenWithFee",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "token", "type": "address"},
+            {"internalType": "uint256", "name": "amountMinimum", "type": "uint256"},
+            {"internalType": "address", "name": "recipient", "type": "address"},
+            {"internalType": "uint256", "name": "feeBips", "type": "uint256"},
+            {"internalType": "address", "name": "feeRecipient", "type": "address"},
+        ],
+        "name": "sweepTokenWithFee",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "int256", "name": "amount0Delta", "type": "int256"},
+            {"internalType": "int256", "name": "amount1Delta", "type": "int256"},
+            {"internalType": "bytes", "name": "_data", "type": "bytes"},
+        ],
+        "name": "uniswapV3SwapCallback",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "amountMinimum", "type": "uint256"},
+            {"internalType": "address", "name": "recipient", "type": "address"},
+        ],
+        "name": "unwrapWETH9",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "amountMinimum", "type": "uint256"}
+        ],
+        "name": "unwrapWETH9",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "amountMinimum", "type": "uint256"},
+            {"internalType": "address", "name": "recipient", "type": "address"},
+            {"internalType": "uint256", "name": "feeBips", "type": "uint256"},
+            {"internalType": "address", "name": "feeRecipient", "type": "address"},
+        ],
+        "name": "unwrapWETH9WithFee",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint256", "name": "amountMinimum", "type": "uint256"},
+            {"internalType": "uint256", "name": "feeBips", "type": "uint256"},
+            {"internalType": "address", "name": "feeRecipient", "type": "address"},
+        ],
+        "name": "unwrapWETH9WithFee",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "uint256", "name": "value", "type": "uint256"}],
+        "name": "wrapETH",
+        "outputs": [],
+        "stateMutability": "payable",
+        "type": "function",
+    },
+    {"stateMutability": "payable", "type": "receive"},
+]
+
+uniswap_v3_pool_abi = [
+    {"inputs": [], "stateMutability": "nonpayable", "type": "constructor"},
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address",
+            },
+            {
+                "indexed": True,
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24",
+            },
+            {
+                "indexed": True,
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint128",
+                "name": "amount",
+                "type": "uint128",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "amount0",
+                "type": "uint256",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "amount1",
+                "type": "uint256",
+            },
+        ],
+        "name": "Burn",
+        "type": "event",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address",
+            },
+            {
+                "indexed": False,
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address",
+            },
+            {
+                "indexed": True,
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24",
+            },
+            {
+                "indexed": True,
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint128",
+                "name": "amount0",
+                "type": "uint128",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint128",
+                "name": "amount1",
+                "type": "uint128",
+            },
+        ],
+        "name": "Collect",
+        "type": "event",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address",
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint128",
+                "name": "amount0",
+                "type": "uint128",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint128",
+                "name": "amount1",
+                "type": "uint128",
+            },
+        ],
+        "name": "CollectProtocol",
+        "type": "event",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address",
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "amount0",
+                "type": "uint256",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "amount1",
+                "type": "uint256",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "paid0",
+                "type": "uint256",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "paid1",
+                "type": "uint256",
+            },
+        ],
+        "name": "Flash",
+        "type": "event",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": False,
+                "internalType": "uint16",
+                "name": "observationCardinalityNextOld",
+                "type": "uint16",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint16",
+                "name": "observationCardinalityNextNew",
+                "type": "uint16",
+            },
+        ],
+        "name": "IncreaseObservationCardinalityNext",
+        "type": "event",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": False,
+                "internalType": "uint160",
+                "name": "sqrtPriceX96",
+                "type": "uint160",
+            },
+            {
+                "indexed": False,
+                "internalType": "int24",
+                "name": "tick",
+                "type": "int24",
+            },
+        ],
+        "name": "Initialize",
+        "type": "event",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": False,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address",
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "owner",
+                "type": "address",
+            },
+            {
+                "indexed": True,
+                "internalType": "int24",
+                "name": "tickLower",
+                "type": "int24",
+            },
+            {
+                "indexed": True,
+                "internalType": "int24",
+                "name": "tickUpper",
+                "type": "int24",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint128",
+                "name": "amount",
+                "type": "uint128",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "amount0",
+                "type": "uint256",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint256",
+                "name": "amount1",
+                "type": "uint256",
+            },
+        ],
+        "name": "Mint",
+        "type": "event",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": False,
+                "internalType": "uint8",
+                "name": "feeProtocol0Old",
+                "type": "uint8",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint8",
+                "name": "feeProtocol1Old",
+                "type": "uint8",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint8",
+                "name": "feeProtocol0New",
+                "type": "uint8",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint8",
+                "name": "feeProtocol1New",
+                "type": "uint8",
+            },
+        ],
+        "name": "SetFeeProtocol",
+        "type": "event",
+    },
+    {
+        "anonymous": False,
+        "inputs": [
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "sender",
+                "type": "address",
+            },
+            {
+                "indexed": True,
+                "internalType": "address",
+                "name": "recipient",
+                "type": "address",
+            },
+            {
+                "indexed": False,
+                "internalType": "int256",
+                "name": "amount0",
+                "type": "int256",
+            },
+            {
+                "indexed": False,
+                "internalType": "int256",
+                "name": "amount1",
+                "type": "int256",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint160",
+                "name": "sqrtPriceX96",
+                "type": "uint160",
+            },
+            {
+                "indexed": False,
+                "internalType": "uint128",
+                "name": "liquidity",
+                "type": "uint128",
+            },
+            {
+                "indexed": False,
+                "internalType": "int24",
+                "name": "tick",
+                "type": "int24",
+            },
+        ],
+        "name": "Swap",
+        "type": "event",
+    },
+    {
+        "inputs": [
+            {"internalType": "int24", "name": "tickLower", "type": "int24"},
+            {"internalType": "int24", "name": "tickUpper", "type": "int24"},
+            {"internalType": "uint128", "name": "amount", "type": "uint128"},
+        ],
+        "name": "burn",
+        "outputs": [
+            {"internalType": "uint256", "name": "amount0", "type": "uint256"},
+            {"internalType": "uint256", "name": "amount1", "type": "uint256"},
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "recipient", "type": "address"},
+            {"internalType": "int24", "name": "tickLower", "type": "int24"},
+            {"internalType": "int24", "name": "tickUpper", "type": "int24"},
+            {"internalType": "uint128", "name": "amount0Requested", "type": "uint128"},
+            {"internalType": "uint128", "name": "amount1Requested", "type": "uint128"},
+        ],
+        "name": "collect",
+        "outputs": [
+            {"internalType": "uint128", "name": "amount0", "type": "uint128"},
+            {"internalType": "uint128", "name": "amount1", "type": "uint128"},
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "recipient", "type": "address"},
+            {"internalType": "uint128", "name": "amount0Requested", "type": "uint128"},
+            {"internalType": "uint128", "name": "amount1Requested", "type": "uint128"},
+        ],
+        "name": "collectProtocol",
+        "outputs": [
+            {"internalType": "uint128", "name": "amount0", "type": "uint128"},
+            {"internalType": "uint128", "name": "amount1", "type": "uint128"},
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "factory",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "fee",
+        "outputs": [{"internalType": "uint24", "name": "", "type": "uint24"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "feeGrowthGlobal0X128",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "feeGrowthGlobal1X128",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "recipient", "type": "address"},
+            {"internalType": "uint256", "name": "amount0", "type": "uint256"},
+            {"internalType": "uint256", "name": "amount1", "type": "uint256"},
+            {"internalType": "bytes", "name": "data", "type": "bytes"},
+        ],
+        "name": "flash",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint16",
+                "name": "observationCardinalityNext",
+                "type": "uint16",
+            }
+        ],
+        "name": "increaseObservationCardinalityNext",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint160", "name": "sqrtPriceX96", "type": "uint160"}
+        ],
+        "name": "initialize",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "liquidity",
+        "outputs": [{"internalType": "uint128", "name": "", "type": "uint128"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "maxLiquidityPerTick",
+        "outputs": [{"internalType": "uint128", "name": "", "type": "uint128"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "recipient", "type": "address"},
+            {"internalType": "int24", "name": "tickLower", "type": "int24"},
+            {"internalType": "int24", "name": "tickUpper", "type": "int24"},
+            {"internalType": "uint128", "name": "amount", "type": "uint128"},
+            {"internalType": "bytes", "name": "data", "type": "bytes"},
+        ],
+        "name": "mint",
+        "outputs": [
+            {"internalType": "uint256", "name": "amount0", "type": "uint256"},
+            {"internalType": "uint256", "name": "amount1", "type": "uint256"},
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "name": "observations",
+        "outputs": [
+            {"internalType": "uint32", "name": "blockTimestamp", "type": "uint32"},
+            {"internalType": "int56", "name": "tickCumulative", "type": "int56"},
+            {
+                "internalType": "uint160",
+                "name": "secondsPerLiquidityCumulativeX128",
+                "type": "uint160",
+            },
+            {"internalType": "bool", "name": "initialized", "type": "bool"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint32[]", "name": "secondsAgos", "type": "uint32[]"}
+        ],
+        "name": "observe",
+        "outputs": [
+            {"internalType": "int56[]", "name": "tickCumulatives", "type": "int56[]"},
+            {
+                "internalType": "uint160[]",
+                "name": "secondsPerLiquidityCumulativeX128s",
+                "type": "uint160[]",
+            },
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
+        "name": "positions",
+        "outputs": [
+            {"internalType": "uint128", "name": "liquidity", "type": "uint128"},
+            {
+                "internalType": "uint256",
+                "name": "feeGrowthInside0LastX128",
+                "type": "uint256",
+            },
+            {
+                "internalType": "uint256",
+                "name": "feeGrowthInside1LastX128",
+                "type": "uint256",
+            },
+            {"internalType": "uint128", "name": "tokensOwed0", "type": "uint128"},
+            {"internalType": "uint128", "name": "tokensOwed1", "type": "uint128"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "protocolFees",
+        "outputs": [
+            {"internalType": "uint128", "name": "token0", "type": "uint128"},
+            {"internalType": "uint128", "name": "token1", "type": "uint128"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "uint8", "name": "feeProtocol0", "type": "uint8"},
+            {"internalType": "uint8", "name": "feeProtocol1", "type": "uint8"},
+        ],
+        "name": "setFeeProtocol",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "slot0",
+        "outputs": [
+            {"internalType": "uint160", "name": "sqrtPriceX96", "type": "uint160"},
+            {"internalType": "int24", "name": "tick", "type": "int24"},
+            {"internalType": "uint16", "name": "observationIndex", "type": "uint16"},
+            {
+                "internalType": "uint16",
+                "name": "observationCardinality",
+                "type": "uint16",
+            },
+            {
+                "internalType": "uint16",
+                "name": "observationCardinalityNext",
+                "type": "uint16",
+            },
+            {"internalType": "uint8", "name": "feeProtocol", "type": "uint8"},
+            {"internalType": "bool", "name": "unlocked", "type": "bool"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "int24", "name": "tickLower", "type": "int24"},
+            {"internalType": "int24", "name": "tickUpper", "type": "int24"},
+        ],
+        "name": "snapshotCumulativesInside",
+        "outputs": [
+            {"internalType": "int56", "name": "tickCumulativeInside", "type": "int56"},
+            {
+                "internalType": "uint160",
+                "name": "secondsPerLiquidityInsideX128",
+                "type": "uint160",
+            },
+            {"internalType": "uint32", "name": "secondsInside", "type": "uint32"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [
+            {"internalType": "address", "name": "recipient", "type": "address"},
+            {"internalType": "bool", "name": "zeroForOne", "type": "bool"},
+            {"internalType": "int256", "name": "amountSpecified", "type": "int256"},
+            {"internalType": "uint160", "name": "sqrtPriceLimitX96", "type": "uint160"},
+            {"internalType": "bytes", "name": "data", "type": "bytes"},
+        ],
+        "name": "swap",
+        "outputs": [
+            {"internalType": "int256", "name": "amount0", "type": "int256"},
+            {"internalType": "int256", "name": "amount1", "type": "int256"},
+        ],
+        "stateMutability": "nonpayable",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "int16", "name": "", "type": "int16"}],
+        "name": "tickBitmap",
+        "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "tickSpacing",
+        "outputs": [{"internalType": "int24", "name": "", "type": "int24"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [{"internalType": "int24", "name": "", "type": "int24"}],
+        "name": "ticks",
+        "outputs": [
+            {"internalType": "uint128", "name": "liquidityGross", "type": "uint128"},
+            {"internalType": "int128", "name": "liquidityNet", "type": "int128"},
+            {
+                "internalType": "uint256",
+                "name": "feeGrowthOutside0X128",
+                "type": "uint256",
+            },
+            {
+                "internalType": "uint256",
+                "name": "feeGrowthOutside1X128",
+                "type": "uint256",
+            },
+            {"internalType": "int56", "name": "tickCumulativeOutside", "type": "int56"},
+            {
+                "internalType": "uint160",
+                "name": "secondsPerLiquidityOutsideX128",
+                "type": "uint160",
+            },
+            {"internalType": "uint32", "name": "secondsOutside", "type": "uint32"},
+            {"internalType": "bool", "name": "initialized", "type": "bool"},
+        ],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "token0",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+    {
+        "inputs": [],
+        "name": "token1",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]

--- a/gnosis/eth/oracles/uniswap_v3.py
+++ b/gnosis/eth/oracles/uniswap_v3.py
@@ -1,0 +1,182 @@
+import functools
+import logging
+from typing import Optional
+
+from eth_abi.exceptions import DecodingError
+from eth_typing import ChecksumAddress
+from web3.contract import Contract
+from web3.exceptions import BadFunctionCallOutput
+
+from gnosis.util import cached_property
+
+from .. import EthereumClient
+from ..constants import NULL_ADDRESS
+from ..contracts import get_erc20_contract
+from .abis.uniswap_v3 import (
+    uniswap_v3_factory_abi,
+    uniswap_v3_pool_abi,
+    uniswap_v3_router_abi,
+)
+from .oracles import CannotGetPriceFromOracle, PriceOracle
+
+logger = logging.getLogger(__name__)
+
+
+class UniswapV3Oracle(PriceOracle):
+    # https://docs.uniswap.org/protocol/reference/deployments
+    UNISWAP_V3_ROUTER = "0x68b3465833fb72A70ecDF485E0e4C7bD8665Fc45"
+
+    # Cache to optimize calculation: https://docs.uniswap.org/sdk/guides/fetching-prices#understanding-sqrtprice
+    PRICE_CONVERSION_CONSTANT = 2**192
+
+    def __init__(
+        self,
+        ethereum_client: EthereumClient,
+        uniswap_v3_router_address: Optional[ChecksumAddress] = None,
+    ):
+        """
+        :param ethereum_client:
+        """
+        self.ethereum_client = ethereum_client
+        self.w3 = ethereum_client.w3
+
+        self.router_address = uniswap_v3_router_address or self.UNISWAP_V3_ROUTER
+        self.factory = self.get_factory()
+
+    @classmethod
+    def is_available(
+        cls,
+        ethereum_client: EthereumClient,
+        uniswap_v3_router_address: Optional[ChecksumAddress] = None,
+    ) -> bool:
+        """
+        :param ethereum_client:
+        :param uniswap_v3_router_address:
+        :return: `True` is Uniswap V3 is available for the EthereumClient provided, `False` otherwise
+        """
+        return ethereum_client.is_contract(
+            uniswap_v3_router_address or cls.UNISWAP_V3_ROUTER
+        )
+
+    @functools.lru_cache(maxsize=5120)
+    def get_decimals(self, token_address: str) -> int:
+        try:
+            return (
+                get_erc20_contract(self.w3, token_address).functions.decimals().call()
+            )
+        except (
+            ValueError,
+            BadFunctionCallOutput,
+            DecodingError,
+        ) as e:
+            error_message = f"Cannot get decimals for token={token_address}"
+            logger.warning(error_message)
+            raise CannotGetPriceFromOracle(error_message) from e
+
+    def get_factory(self) -> Contract:
+        """
+        Factory contract creates the pools for token pairs
+
+        :return: Uniswap V3 Factory Contract
+        """
+        try:
+            factory_address = self.router.functions.factory().call()
+        except BadFunctionCallOutput:
+            raise ValueError(
+                f"Uniswap V3 Router Contract {self.router_address} does not exist"
+            )
+        return self.w3.eth.contract(factory_address, abi=uniswap_v3_factory_abi)
+
+    @cached_property
+    def router(self) -> Contract:
+        """
+        Router knows about the `Uniswap Factory` and `Wrapped Eth` addresses for the network
+
+        :return: Uniswap V3 Router Contract
+        """
+        return self.w3.eth.contract(self.router_address, abi=uniswap_v3_router_abi)
+
+    @cached_property
+    def weth_address(self) -> ChecksumAddress:
+        """
+        :return: Wrapped ether checksummed address
+        """
+        return self.router.functions.WETH9().call()
+
+    @functools.lru_cache(maxsize=512)
+    def get_pool_address(
+        self, token_address: str, token_address_2: str, fee: Optional[int] = 3000
+    ) -> Optional[ChecksumAddress]:
+        """
+        Get pool address for tokens with a given fee (by default, 0.3)
+
+        :param token_address:
+        :param token_address_2:
+        :param fee: Uniswap V3 uses 0.3 as the default fee
+        :return: Pool address
+        """
+
+        pool_address = self.factory.functions.getPool(
+            token_address, token_address_2, fee
+        ).call()
+        if pool_address == NULL_ADDRESS:
+            return None
+
+        return pool_address
+
+    def get_price(
+        self, token_address: str, token_address_2: Optional[str] = None
+    ) -> float:
+        """
+        :param token_address:
+        :param token_address_2:
+        :return: price for `token_address` related to `token_address_2`. If `token_address_2` is not
+            provided, `Wrapped Eth` address will be used
+        """
+        token_address_2 = token_address_2 or self.weth_address
+        if token_address == token_address_2:
+            return 1.0
+
+        reversed = token_address.lower() > token_address_2.lower()
+
+        # Make it cache friendly as order does not matter
+        args = (
+            (token_address_2, token_address)
+            if reversed
+            else (token_address, token_address_2)
+        )
+        pool_address = self.get_pool_address(*args)
+
+        if not pool_address:
+            raise CannotGetPriceFromOracle(
+                f"Uniswap V3 pool does not exist for {token_address} and {token_address_2}"
+            )
+
+        pool_contract = self.w3.eth.contract(pool_address, abi=uniswap_v3_pool_abi)
+
+        try:
+            sqrt_price_x96, _, _, _, _, _, _ = pool_contract.functions.slot0().call()
+        except (
+            ValueError,
+            BadFunctionCallOutput,
+            DecodingError,
+        ) as e:
+            error_message = (
+                f"Cannot get uniswap v2 price for pair token_1={token_address} "
+                f"token_2={token_address_2}"
+            )
+            logger.warning(error_message)
+            raise CannotGetPriceFromOracle(error_message) from e
+
+        # Decimals needs to be adjusted
+        token_decimals = self.get_decimals(token_address)
+        token_2_decimals = self.get_decimals(token_address_2)
+
+        # https://docs.uniswap.org/sdk/guides/fetching-prices
+        if not reversed:
+            # Multiplying by itself is way faster than exponential
+            price = (sqrt_price_x96 * sqrt_price_x96) / self.PRICE_CONVERSION_CONSTANT
+        else:
+            price = self.PRICE_CONVERSION_CONSTANT / (sqrt_price_x96 * sqrt_price_x96)
+
+        return price * 10 ** (token_decimals - token_2_decimals)

--- a/gnosis/eth/tests/oracles/test_uniswap_v3.py
+++ b/gnosis/eth/tests/oracles/test_uniswap_v3.py
@@ -1,0 +1,68 @@
+from django.test import TestCase
+
+from eth_account import Account
+
+from ... import EthereumClient
+from ...oracles import CannotGetPriceFromOracle, UniswapV3Oracle
+from ..ethereum_test_case import EthereumTestCaseMixin
+from ..test_oracles import (
+    dai_token_mainnet_address,
+    usdc_token_mainnet_address,
+    usdt_token_mainnet_address,
+    weth_token_mainnet_address,
+)
+from ..utils import just_test_if_mainnet_node
+
+
+class TestUniswapV3Oracle(EthereumTestCaseMixin, TestCase):
+    def test_get_price(self):
+        mainnet_node = just_test_if_mainnet_node()
+        ethereum_client = EthereumClient(mainnet_node)
+
+        self.assertTrue(UniswapV3Oracle.is_available(ethereum_client))
+
+        uniswap_v3_oracle = UniswapV3Oracle(ethereum_client)
+
+        price = uniswap_v3_oracle.get_price(weth_token_mainnet_address)
+        self.assertEqual(price, 1.0)
+
+        price = uniswap_v3_oracle.get_price(dai_token_mainnet_address)
+        self.assertLess(price, 1)
+        self.assertGreater(price, 0)
+
+        price = uniswap_v3_oracle.get_price(
+            weth_token_mainnet_address, dai_token_mainnet_address
+        )
+        self.assertGreater(price, 1)
+
+        # Test with 2 stablecoins with same decimals
+        price = uniswap_v3_oracle.get_price(
+            usdt_token_mainnet_address, usdc_token_mainnet_address
+        )
+        self.assertAlmostEqual(price, 1.0, delta=0.5)
+
+        # Test with 2 stablecoins with different decimals
+        price = uniswap_v3_oracle.get_price(
+            dai_token_mainnet_address, usdc_token_mainnet_address
+        )
+        self.assertAlmostEqual(price, 1.0, delta=0.5)
+
+        price = uniswap_v3_oracle.get_price(
+            usdc_token_mainnet_address, dai_token_mainnet_address
+        )
+        self.assertAlmostEqual(price, 1.0, delta=0.5)
+
+        random_token = Account.create().address
+        with self.assertRaisesMessage(
+            CannotGetPriceFromOracle,
+            f"Uniswap V3 pool does not exist for {random_token} and 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+        ):
+            uniswap_v3_oracle.get_price(random_token)
+
+    def test_get_price_contract_not_deployed(self):
+        self.assertFalse(UniswapV3Oracle.is_available(self.ethereum_client))
+        with self.assertRaisesMessage(
+            ValueError,
+            f"Uniswap V3 Router Contract {UniswapV3Oracle.UNISWAP_V3_ROUTER} does not exist",
+        ):
+            UniswapV3Oracle(self.ethereum_client)

--- a/gnosis/eth/tests/test_oracles.py
+++ b/gnosis/eth/tests/test_oracles.py
@@ -31,6 +31,7 @@ weth_token_mainnet_address = "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"
 wbtc_token_mainnet_address = "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599"
 
 dai_token_mainnet_address = "0x6B175474E89094C44Da98b954EedeAC495271d0F"
+usdc_token_mainnet_address = "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48"
 usdt_token_mainnet_address = "0xdAC17F958D2ee523a2206206994597C13D831ec7"
 
 

--- a/gnosis/protocol/gnosis_protocol_api.py
+++ b/gnosis/protocol/gnosis_protocol_api.py
@@ -17,13 +17,6 @@ try:
 except ImportError:
     from typing_extensions import TypedDict
 
-try:
-    from functools import cache
-except ImportError:
-    from functools import lru_cache
-
-    cache = lru_cache(maxsize=None)
-
 
 class TradeResponse(TypedDict):
     blockNumber: int

--- a/gnosis/safe/safe.py
+++ b/gnosis/safe/safe.py
@@ -30,6 +30,7 @@ from gnosis.eth.utils import (
     get_eth_address_with_key,
 )
 from gnosis.safe.proxy_factory import ProxyFactory
+from gnosis.util import cached_property
 
 from ..eth.typing import EthereumData
 from .exceptions import (
@@ -40,12 +41,6 @@ from .exceptions import (
 from .safe_create2_tx import SafeCreate2Tx, SafeCreate2TxBuilder
 from .safe_creation_tx import InvalidERC20Token, SafeCreationTx
 from .safe_tx import SafeTx
-
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
-
 
 logger = getLogger(__name__)
 

--- a/gnosis/safe/safe_tx.py
+++ b/gnosis/safe/safe_tx.py
@@ -11,6 +11,7 @@ from web3.types import BlockIdentifier, TxParams, Wei
 from gnosis.eth import EthereumClient
 from gnosis.eth.constants import NULL_ADDRESS
 from gnosis.eth.contracts import get_safe_contract
+from gnosis.util import cached_property
 
 from ..eth.ethereum_client import TxSpeed
 from ..eth.utils import fast_keccak
@@ -36,11 +37,6 @@ from .exceptions import (
 )
 from .safe_signature import SafeSignature
 from .signatures import signature_to_bytes
-
-try:
-    from functools import cached_property
-except ImportError:
-    from cached_property import cached_property
 
 
 class EIP712SafeTx(EIP712Struct):

--- a/gnosis/util/__init__.py
+++ b/gnosis/util/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa F401
-from .util import chunks
+from .util import cache, cached_property, chunks
 
-__all__ = ["chunks"]
+__all__ = ["chunks", "cached_property", "cache"]

--- a/gnosis/util/util.py
+++ b/gnosis/util/util.py
@@ -1,5 +1,18 @@
 from typing import Any, Iterable, List
 
+try:
+    from functools import cached_property  # noqa F401
+except ImportError:
+    from cached_property import cached_property  # noqa F401
+
+
+try:
+    from functools import cache
+except ImportError:
+    from functools import lru_cache
+
+    cache = lru_cache(maxsize=None)
+
 
 def chunks(elements: List[Any], n: int) -> Iterable[Any]:
     """


### PR DESCRIPTION
- Add Uniswap V3 ABIs
- Add Uniswap V3 to a new file (other oracles should be refactored to 1 oracle per file)
- Remove unlimited caches for Oracles
- Refactor cache and cached_property decorator logic
