### PR TITLE
Feat: Add Superfluid Oracle token adapter 

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -58,6 +58,7 @@ jobs:
         SOURCE_FOLDER: gnosis
         DJANGO_SETTINGS_MODULE: config.settings.test
         ETHEREUM_MAINNET_NODE: ${{ secrets.ETHEREUM_MAINNET_NODE }}
+        ETHEREUM_POLYGON_NODE: ${{ secrets.ETHEREUM_POLYGON_NODE }}
     - name: Test packaging
       run: pip install -e .
     - name: Send results to coveralls

--- a/gnosis/eth/oracles/__init__.py
+++ b/gnosis/eth/oracles/__init__.py
@@ -23,6 +23,7 @@ from .oracles import (
     YearnOracle,
     ZerionComposedOracle,
 )
+from .superfluid import SuperfluidOracle
 from .sushiswap import SushiswapOracle
 from .uniswap_v3 import UniswapV3Oracle
 
@@ -46,4 +47,5 @@ __all__ = [
     "UniswapV3Oracle",
     "YearnOracle",
     "ZerionComposedOracle",
+    "SuperfluidOracle",
 ]

--- a/gnosis/eth/oracles/abis/superfluid_abis.py
+++ b/gnosis/eth/oracles/abis/superfluid_abis.py
@@ -1,0 +1,9 @@
+super_token_abi = [
+    {
+        "inputs": [],
+        "name": "getUnderlyingToken",
+        "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+        "stateMutability": "view",
+        "type": "function",
+    },
+]

--- a/gnosis/eth/oracles/superfluid.py
+++ b/gnosis/eth/oracles/superfluid.py
@@ -1,0 +1,47 @@
+from eth_abi.exceptions import DecodingError
+from web3.exceptions import BadFunctionCallOutput
+
+from .. import EthereumClient, EthereumNetwork
+from .abis.superfluid_abis import super_token_abi
+from .exceptions import CannotGetPriceFromOracle
+from .oracles import PriceOracle
+
+
+class SuperfluidOracle(PriceOracle):
+    def __init__(self, ethereum_client: EthereumClient, price_oracle: PriceOracle):
+        """
+        :param ethereum_client:
+        :param price_oracle: Price oracle to get the price for the components of Superfluid Tokens
+        """
+        self.ethereum_client = ethereum_client
+        self.w3 = ethereum_client.w3
+        self.price_oracle = price_oracle
+
+    @classmethod
+    def is_available(
+        cls,
+        ethereum_client: EthereumClient,
+    ) -> bool:
+        """
+        :param ethereum_client:
+        :return: `True` if Oracle is available for the EthereumClient provided, `False` otherwise
+        """
+        return (
+            ethereum_client.get_network() == EthereumNetwork.MATIC
+            or EthereumNetwork.XDAI
+            or EthereumNetwork.ARBITRUM
+            or EthereumNetwork.OPTIMISTIC
+        )
+
+    def get_price(self, token_address: str) -> float:
+        try:
+            underlying_token = (
+                self.w3.eth.contract(token_address, abi=super_token_abi)
+                .functions.getUnderlyingToken()
+                .call()
+            )
+            return self.price_oracle.get_price(underlying_token)
+        except (ValueError, BadFunctionCallOutput, DecodingError):
+            raise CannotGetPriceFromOracle(
+                f"Cannot get price for {token_address}. It is not a wrapper Super Token"
+            )

--- a/gnosis/eth/tests/oracles/test_superfluid.py
+++ b/gnosis/eth/tests/oracles/test_superfluid.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+
+from eth_account import Account
+
+from ... import EthereumClient
+from ...oracles import CannotGetPriceFromOracle, SuperfluidOracle, SushiswapOracle
+from ..ethereum_test_case import EthereumTestCaseMixin
+from ..utils import just_test_if_polygon_node
+
+gno_token_mainnet_address = "0x6810e776880C02933D47DB1b9fc05908e5386b96"
+
+
+class TestSuperfluidOracle(EthereumTestCaseMixin, TestCase):
+    def test_get_price(self):
+        polygon_node = just_test_if_polygon_node()
+        ethereum_client_polygon = EthereumClient(polygon_node)
+
+        self.assertTrue(SuperfluidOracle.is_available(ethereum_client_polygon))
+
+        sushi_oracle_polygon = SushiswapOracle(ethereum_client_polygon)
+        superfluid_oracle_polygon = SuperfluidOracle(
+            ethereum_client_polygon, sushi_oracle_polygon
+        )
+        uscdcx_address_polygon = "0xCAa7349CEA390F89641fe306D93591f87595dc1F"
+        price = superfluid_oracle_polygon.get_price(uscdcx_address_polygon)
+        self.assertGreater(price, 0.0)
+
+        error_message = "It is not a wrapper Super Token"
+        with self.assertRaisesMessage(CannotGetPriceFromOracle, error_message):
+            superfluid_oracle_polygon.get_price(gno_token_mainnet_address)
+
+        with self.assertRaisesMessage(CannotGetPriceFromOracle, error_message):
+            superfluid_oracle_polygon.get_price(Account.create().address)

--- a/gnosis/eth/tests/utils.py
+++ b/gnosis/eth/tests/utils.py
@@ -40,6 +40,36 @@ def just_test_if_mainnet_node() -> str:
     return mainnet_node_url
 
 
+def just_test_if_polygon_node() -> str:
+    polygon_node_url = os.environ.get("ETHEREUM_POLYGON_NODE")
+    if hasattr(just_test_if_polygon_node, "checked"):  # Just check node first time
+        return polygon_node_url
+
+    if not polygon_node_url:
+        pytest.skip(
+            "Polygon node not defined, cannot test oracles", allow_module_level=True
+        )
+    else:
+        try:
+            if not requests.post(
+                polygon_node_url,
+                timeout=5,
+                json={
+                    "jsonrpc": "2.0",
+                    "method": "eth_blockNumber",
+                    "params": [],
+                    "id": 1,
+                },
+            ).ok:
+                pytest.skip("Cannot connect to poylgon node", allow_module_level=True)
+        except IOError:
+            pytest.skip(
+                "Problem connecting to the polygon node", allow_module_level=True
+            )
+    just_test_if_polygon_node.checked = True
+    return polygon_node_url
+
+
 def send_tx(w3: Web3, tx: TxParams, account: LocalAccount) -> bytes:
     tx["from"] = account.address
     if "nonce" not in tx:


### PR DESCRIPTION
As a continuation from here: https://github.com/safe-global/safe-transaction-service/issues/772#issuecomment-1087463359 

This work contributes towards adding a price data for Superfluid Super Tokens with the price data of their underlying tokens.
This PR adds the Superfluid Oracle token adapter and related test.

Related Issue: https://github.com/safe-global/safe-transaction-service/issues/772 

Original issue: https://github.com/superfluid-finance/protocol-monorepo/issues/732

