### PR TITLE
Stop using eip712_structs

### DIFF
--- a/docs/source/gnosis.eth.eip712.rst
+++ b/docs/source/gnosis.eth.eip712.rst
@@ -1,0 +1,10 @@
+gnosis.eth.eip712 package
+============================
+
+Module contents
+---------------
+
+.. automodule:: gnosis.eth.eip712
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -76,6 +76,46 @@ gnosis.eth.constants
 - ``SENTINEL_ADDRESS (0x000...1)``: Used for Gnosis Safe's linked lists (modules, owners...).
 - Maximum an minimum values for `R`, `S` and `V` in ethereum signatures.
 
+gnosis.eth.eip712
+~~~~~~~~~~~~~~~~~~~~
+.. code-block:: python
+    from gnosis.eth.eip712 import eip712_encode_hash
+
+    types = {'EIP712Domain': [{'name': 'name', 'type': 'string'},
+                              {'name': 'version', 'type': 'string'},
+                              {'name': 'chainId', 'type': 'uint256'},
+                              {'name': 'verifyingContract', 'type': 'address'}],
+             'Mailbox': [{'name': 'owner', 'type': 'address'},
+                         {'name': 'messages', 'type': 'Message[]'}],
+             'Message': [{'name': 'sender', 'type': 'address'},
+                         {'name': 'subject', 'type': 'string'},
+                         {'name': 'isSpam', 'type': 'bool'},
+                         {'name': 'body', 'type': 'string'}]}
+
+    msgs = [{'sender': ADDRESS,
+             'subject': 'Hello World',
+             'body': 'The sparrow flies at midnight.',
+             'isSpam': False},
+            {'sender': ADDRESS,
+             'subject': 'You may have already Won! :dumb-emoji:',
+             'body': 'Click here for sweepstakes!',
+             'isSpam': True}]
+
+    mailbox = {'owner': ADDRESS,
+               'messages': msgs}
+
+    payload = {'types': types,
+               'primaryType': 'Mailbox',
+               'domain': {'name': 'MyDApp',
+                          'version': '3.0',
+                          'chainId': 41,
+                          'verifyingContract': ADDRESS},
+               'message': mailbox}
+
+    eip712_hash = eip712_encode_hash(payload)
+
+
+
 gnosis.eth.oracles
 ~~~~~~~~~~~~~~~~~~
 Price oracles for Uniswap, UniswapV2, Kyber, SushiSwap, Aave, Balancer, Curve, Mooniswap, Yearn...

--- a/gnosis/eth/eip712/__init__.py
+++ b/gnosis/eth/eip712/__init__.py
@@ -1,0 +1,178 @@
+"""
+Based on https://github.com/jvinet/eip712, adjustments by https://github.com/uxio0
+
+Routines for EIP712 encoding and signing.
+
+Copyright (C) 2022 Judd Vinet <jvinet@zeroflux.org>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+import re
+from typing import Any, Dict, List, Union
+
+from eth_abi import encode_abi
+from eth_account import Account
+from eth_typing import Hash32, HexStr
+
+from ..utils import fast_keccak
+
+
+def encode_data(primary_type: str, data, types):
+    """
+    Encode structured data as per Ethereum's signTypeData_v4.
+
+    https://docs.metamask.io/guide/signing-data.html#sign-typed-data-v4
+
+    This code is ported from the Javascript "eth-sig-util" package.
+    """
+    encoded_types = ["bytes32"]
+    encoded_values = [hash_type(primary_type, types)]
+
+    def _encode_field(name, typ, value):
+        if typ in types:
+            if value is None:
+                return [
+                    "bytes32",
+                    "0x0000000000000000000000000000000000000000000000000000000000000000",
+                ]
+            else:
+                return ["bytes32", fast_keccak(encode_data(typ, value, types))]
+
+        if value is None:
+            raise Exception(f"Missing value for field {name} of type {type}")
+
+        if typ == "bytes":
+            return ["bytes32", fast_keccak(value)]
+
+        if typ == "string":
+            # Convert string to bytes.
+            value = value.encode("utf-8")
+            return ["bytes32", fast_keccak(value)]
+
+        if typ.endswith("]"):
+            parsed_type = typ[:-2]
+            type_value_pairs = dict(
+                [_encode_field(name, parsed_type, v) for v in value]
+            )
+            h = fast_keccak(
+                encode_abi(
+                    list(type_value_pairs.keys()), list(type_value_pairs.values())
+                )
+            )
+            return ["bytes32", h]
+
+        return [typ, value]
+
+    for field in types[primary_type]:
+        typ, val = _encode_field(field["name"], field["type"], data[field["name"]])
+        encoded_types.append(typ)
+        encoded_values.append(val)
+
+    return encode_abi(encoded_types, encoded_values)
+
+
+def encode_type(primary_type: str, types) -> str:
+    result = ""
+    deps = find_type_dependencies(primary_type, types)
+    deps = sorted([d for d in deps if d != primary_type])
+    deps = [primary_type] + deps
+    for typ in deps:
+        children = types[typ]
+        if not children:
+            raise Exception(f"No type definition specified: {type}")
+
+        defs = [f"{t['type']} {t['name']}" for t in types[typ]]
+        result += typ + "(" + ",".join(defs) + ")"
+    return result
+
+
+def find_type_dependencies(primary_type: str, types, results=None):
+    if results is None:
+        results = []
+
+    primary_type = re.split(r"\W", primary_type)[0]
+    if primary_type in results or not types.get(primary_type):
+        return results
+    results.append(primary_type)
+
+    for field in types[primary_type]:
+        deps = find_type_dependencies(field["type"], types, results)
+        for dep in deps:
+            if dep not in results:
+                results.append(dep)
+
+    return results
+
+
+def hash_type(primary_type: str, types) -> Hash32:
+    return fast_keccak(encode_type(primary_type, types).encode())
+
+
+def hash_struct(primary_type: str, data, types) -> Hash32:
+    return fast_keccak(encode_data(primary_type, data, types))
+
+
+def eip712_encode(typed_data: Dict[str, Any]) -> List[bytes]:
+    """
+    Given a dict of structured data and types, return a 3-element list of
+    the encoded, signable data.
+
+      0: The magic & version (0x1901)
+      1: The encoded types
+      2: The encoded data
+    """
+    parts = [
+        bytes.fromhex("1901"),
+        hash_struct("EIP712Domain", typed_data["domain"], typed_data["types"]),
+    ]
+    if typed_data["primaryType"] != "EIP712Domain":
+        parts.append(
+            hash_struct(
+                typed_data["primaryType"], typed_data["message"], typed_data["types"]
+            )
+        )
+    return parts
+
+
+def eip712_encode_hash(typed_data: Dict[str, Any]) -> Hash32:
+    """
+    :param typed_data: EIP712 structured data and types
+    :return: Keccak256 hash of encoded signable data
+    """
+    return fast_keccak(b"".join(eip712_encode(typed_data)))
+
+
+def eip712_signature(
+    payload: Dict[str, Any], private_key: Union[HexStr, bytes]
+) -> bytes:
+    """
+    Given a bytes object and a private key, return a signature suitable for
+    EIP712 and EIP191 messages.
+    """
+    if isinstance(payload, (list, tuple)):
+        payload = b"".join(payload)
+
+    if isinstance(private_key, str) and private_key.startswith("0x"):
+        private_key = private_key[2:]
+    elif isinstance(private_key, bytes):
+        private_key = bytes.hex()
+
+    account = Account.from_key(private_key)
+    hashed_payload = fast_keccak(payload)
+    return account.signHash(hashed_payload)["signature"]

--- a/gnosis/protocol/gnosis_protocol_api.py
+++ b/gnosis/protocol/gnosis_protocol_api.py
@@ -2,14 +2,13 @@ from functools import cached_property
 from typing import Any, Dict, List, Optional, TypedDict, Union, cast
 
 import requests
-from eip712_structs import make_domain
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_typing import AnyAddress, ChecksumAddress, HexStr
 from hexbytes import HexBytes
-from web3 import Web3
 
 from gnosis.eth import EthereumNetwork, EthereumNetworkNotSupported
+from gnosis.eth.eip712 import eip712_encode_hash
 
 from .order import Order, OrderKind
 
@@ -42,13 +41,13 @@ class GnosisProtocolAPI:
     Client for GnosisProtocol API. More info: https://docs.cowswap.exchange/
     """
 
-    settlement_contract_addresses = {
+    SETTLEMENT_CONTRACT_ADDRESSES = {
         EthereumNetwork.MAINNET: "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
         EthereumNetwork.GOERLI: "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
         EthereumNetwork.XDAI: "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
     }
 
-    api_base_urls = {
+    API_BASE_URLS = {
         EthereumNetwork.MAINNET: "https://api.cow.fi/mainnet/api/v1/",
         EthereumNetwork.GOERLI: "https://api.cow.fi/goerli/api/v1/",
         EthereumNetwork.XDAI: "https://api.cow.fi/xdai/api/v1/",
@@ -56,12 +55,14 @@ class GnosisProtocolAPI:
 
     def __init__(self, ethereum_network: EthereumNetwork):
         self.network = ethereum_network
-        if self.network not in self.api_base_urls:
+        if self.network not in self.API_BASE_URLS:
             raise EthereumNetworkNotSupported(
                 f"{self.network.name} network not supported by Gnosis Protocol"
             )
-        self.domain_separator = self.build_domain_separator(self.network)
-        self.base_url = self.api_base_urls[self.network]
+        self.settlement_contract_address = self.SETTLEMENT_CONTRACT_ADDRESSES[
+            self.network
+        ]
+        self.base_url = self.API_BASE_URLS[self.network]
         self.http_session = requests.Session()
 
     @cached_property
@@ -76,24 +77,15 @@ class GnosisProtocolAPI:
         else:  # XDAI
             return ChecksumAddress("0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1")
 
-    @classmethod
-    def build_domain_separator(cls, ethereum_network: EthereumNetwork):
-        return make_domain(
-            name="Gnosis Protocol",
-            version="v2",
-            chainId=str(ethereum_network.value),
-            verifyingContract=cls.settlement_contract_addresses[ethereum_network],
-        )
-
     def get_fee(self, order: Order) -> int:
-        if order["kind"] == "sell":
-            amount = order["sellAmount"]
+        if order.is_sell_order():
+            amount = order.sellAmount
         else:
-            amount = order["buyAmount"]
+            amount = order.buyAmount
         url = (
             self.base_url
-            + f'fee/?sellToken={order["sellToken"]}&buyToken={order["buyToken"]}'
-            f'&amount={amount}&kind={order["kind"]}'
+            + f"fee/?sellToken={order.sellToken}&buyToken={order.buyToken}"
+            f"&amount={amount}&kind={order.kind}"
         )
         result = self.http_session.get(url).json()
         if "amount" in result:
@@ -110,28 +102,31 @@ class GnosisProtocolAPI:
         :return: UUID for the order as an hex hash
         """
         assert (
-            order["buyAmount"] and order["sellAmount"]
+            order.buyAmount and order.sellAmount
         ), "Order buyAmount and sellAmount cannot be empty"
 
         url = self.base_url + "orders/"
-        order["feeAmount"] = order["feeAmount"] or self.get_fee(order)
-        signable_bytes = order.signable_bytes(domain=self.domain_separator)
-        signable_hash = Web3.keccak(signable_bytes)
+        order.feeAmount = order.feeAmount or self.get_fee(order)
+        signable_hash = eip712_encode_hash(
+            order.get_eip712_structured_data(
+                self.network.value, self.settlement_contract_address
+            )
+        )
         message = encode_defunct(primitive=signable_hash)
         signed_message = Account.from_key(private_key).sign_message(message)
 
         data_json = {
-            "sellToken": order["sellToken"].lower(),
-            "buyToken": order["buyToken"].lower(),
-            "sellAmount": str(order["sellAmount"]),
-            "buyAmount": str(order["buyAmount"]),
-            "validTo": order["validTo"],
-            "appData": HexBytes(order["appData"]).hex()
-            if isinstance(order["appData"], bytes)
-            else order["appData"],
-            "feeAmount": str(order["feeAmount"]),
-            "kind": order["kind"],
-            "partiallyFillable": order["partiallyFillable"],
+            "sellToken": order.sellToken.lower(),
+            "buyToken": order.buyToken.lower(),
+            "sellAmount": str(order.sellAmount),
+            "buyAmount": str(order.buyAmount),
+            "validTo": order.validTo,
+            "appData": HexBytes(order.appData).hex()
+            if isinstance(order.appData, bytes)
+            else order.appData,
+            "feeAmount": str(order.feeAmount),
+            "kind": order.kind,
+            "partiallyFillable": order.partiallyFillable,
             "signature": signed_message.signature.hex(),
             "signingScheme": "ethsign",
             "from": Account.from_key(private_key).address,

--- a/gnosis/protocol/order.py
+++ b/gnosis/protocol/order.py
@@ -1,21 +1,79 @@
+from dataclasses import dataclass
 from enum import Enum
+from typing import Any, Dict, Literal
 
-from eip712_structs import Address, Boolean, Bytes, EIP712Struct, String, Uint
+from eth_typing import ChecksumAddress, Hash32
 
 
-class Order(EIP712Struct):
-    sellToken = Address()
-    buyToken = Address()
-    receiver = Address()
-    sellAmount = Uint(256)
-    buyAmount = Uint(256)
-    validTo = Uint(32)
-    appData = Bytes(32)
-    feeAmount = Uint(256)
-    kind = String()  # `sell` or `buy`
-    partiallyFillable = Boolean()
-    sellTokenBalance = String()  # `erc20`, `external` or `internal`
-    buyTokenBalance = String()  # `erc20` or `internal`
+@dataclass
+class Order:
+    sellToken: ChecksumAddress
+    buyToken: ChecksumAddress
+    receiver: ChecksumAddress
+    sellAmount: int
+    buyAmount: int
+    validTo: int
+    appData: Hash32
+    feeAmount: int
+    kind: Literal["sell", "buy"]
+    partiallyFillable: bool
+    sellTokenBalance: Literal["erc20", "external", "internal"]
+    buyTokenBalance: Literal["erc20", "internal"]
+
+    def is_sell_order(self) -> bool:
+        return self.kind == "sell"
+
+    def get_eip712_structured_data(
+        self, chain_id: int, verifying_contract: ChecksumAddress
+    ) -> Dict[str, Any]:
+        types = {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+                {"name": "version", "type": "string"},
+                {"name": "chainId", "type": "uint256"},
+                {"name": "verifyingContract", "type": "address"},
+            ],
+            "Order": [
+                {"name": "sellToken", "type": "address"},
+                {"name": "buyToken", "type": "address"},
+                {"name": "receiver", "type": "address"},
+                {"name": "sellAmount", "type": "uint256"},
+                {"name": "buyAmount", "type": "uint256"},
+                {"name": "validTo", "type": "uint32"},
+                {"name": "appData", "type": "bytes32"},
+                {"name": "feeAmount", "type": "uint256"},
+                {"name": "kind", "type": "string"},
+                {"name": "partiallyFillable", "type": "bool"},
+                {"name": "sellTokenBalance", "type": "string"},
+                {"name": "buyTokenBalance", "type": "string"},
+            ],
+        }
+        message = {
+            "sellToken": self.sellToken,
+            "buyToken": self.buyToken,
+            "receiver": self.receiver,
+            "sellAmount": self.sellAmount,
+            "buyAmount": self.buyAmount,
+            "validTo": self.validTo,
+            "appData": self.appData,
+            "feeAmount": self.feeAmount,
+            "kind": self.kind,
+            "partiallyFillable": self.partiallyFillable,
+            "sellTokenBalance": self.sellTokenBalance,
+            "buyTokenBalance": self.buyTokenBalance,
+        }
+
+        return {
+            "types": types,
+            "primaryType": "Order",
+            "domain": {
+                "name": "Gnosis Protocol",
+                "version": "v2",
+                "chainId": chain_id,
+                "verifyingContract": verifying_contract,
+            },
+            "message": message,
+        }
 
 
 class OrderKind(Enum):

--- a/gnosis/protocol/tests/test_gnosis_protocol_api.py
+++ b/gnosis/protocol/tests/test_gnosis_protocol_api.py
@@ -117,7 +117,7 @@ class TestGnosisProtocolAPI(TestCase):
             order, Account().create().key
         )
         self.assertEqual(
-            order["feeAmount"], 0
+            order.feeAmount, 0
         )  # Cannot estimate, as buy token is the same as the sell token
         self.assertEqual(
             result,
@@ -127,9 +127,10 @@ class TestGnosisProtocolAPI(TestCase):
             },
         )
 
-        order["sellToken"] = self.goerli_gnosis_protocol_api.weth_address
-        order["buyToken"] = self.rinkeby_dai_address
-        self.assertEqual(
-            self.goerli_gnosis_protocol_api.place_order(order, Account().create().key),
-            {"errorType": "NoLiquidity", "description": "not enough liquidity"},
+        order.sellToken = self.goerli_gnosis_protocol_api.weth_address
+        order.buyToken = self.rinkeby_dai_address
+        order_id = self.goerli_gnosis_protocol_api.place_order(
+            order, Account().create().key
         )
+        self.assertEqual(order_id[:2], "0x")
+        self.assertEqual(len(order_id), 114)

--- a/gnosis/safe/safe_tx.py
+++ b/gnosis/safe/safe_tx.py
@@ -1,8 +1,6 @@
 from functools import cached_property
 from typing import Any, Dict, List, NoReturn, Optional, Tuple, Type
 
-from eip712_structs import Address, Bytes, EIP712Struct, Uint, make_domain
-from eip712_structs.struct import StructTuple
 from eth_account import Account
 from hexbytes import HexBytes
 from packaging.version import Version
@@ -12,9 +10,9 @@ from web3.types import BlockIdentifier, TxParams, Wei
 from gnosis.eth import EthereumClient
 from gnosis.eth.constants import NULL_ADDRESS
 from gnosis.eth.contracts import get_safe_contract
+from gnosis.eth.eip712 import eip712_encode_hash
+from gnosis.eth.ethereum_client import TxSpeed
 
-from ..eth.ethereum_client import TxSpeed
-from ..eth.utils import fast_keccak
 from .exceptions import (
     CouldNotFinishInitialization,
     CouldNotPayGasWithEther,
@@ -37,36 +35,6 @@ from .exceptions import (
 )
 from .safe_signature import SafeSignature
 from .signatures import signature_to_bytes
-
-
-class EIP712SafeTx(EIP712Struct):
-    to = Address()
-    value = Uint(256)
-    data = Bytes()
-    operation = Uint(8)
-    safeTxGas = Uint(256)
-    baseGas = Uint(256)  # `dataGas` was renamed to `baseGas` in 1.0.0
-    gasPrice = Uint(256)
-    gasToken = Address()
-    refundReceiver = Address()
-    nonce = Uint(256)
-
-
-class EIP712LegacySafeTx(EIP712Struct):
-    to = Address()
-    value = Uint(256)
-    data = Bytes()
-    operation = Uint(8)
-    safeTxGas = Uint(256)
-    dataGas = Uint(256)
-    gasPrice = Uint(256)
-    gasToken = Address()
-    refundReceiver = Address()
-    nonce = Uint(256)
-
-
-EIP712SafeTx.type_name = "SafeTx"
-EIP712LegacySafeTx.type_name = "SafeTx"
 
 
 class SafeTx:
@@ -165,39 +133,58 @@ class SafeTx:
             return self.contract.functions.VERSION().call()
 
     @property
-    def _eip712_payload(self) -> StructTuple:
-        data = self.data.hex() if self.data else ""
+    def eip712_structured_data(self) -> Dict[str, Any]:
         safe_version = Version(self.safe_version)
-        cls = EIP712SafeTx if safe_version >= Version("1.0.0") else EIP712LegacySafeTx
-        message = cls(
-            to=self.to,
-            value=self.value,
-            data=data,
-            operation=self.operation,
-            safeTxGas=self.safe_tx_gas,
-            baseGas=self.base_gas,
-            dataGas=self.base_gas,
-            gasPrice=self.gas_price,
-            gasToken=self.gas_token,
-            refundReceiver=self.refund_receiver,
-            nonce=self.safe_nonce,
-        )
-        domain = make_domain(
-            verifyingContract=self.safe_address,
-            chainId=self.chain_id if safe_version >= Version("1.3.0") else None,
-        )
-        return StructTuple(message, domain)
 
-    @property
-    def eip712_structured_data(self) -> Dict:
-        message, domain = self._eip712_payload
-        return message.to_message(domain)
+        # Safes >= 1.0.0 Renamed `baseGas` to `dataGas`
+        base_gas_key = "baseGas" if safe_version >= Version("1.0.0") else "dataGas"
+
+        types = {
+            "EIP712Domain": [{"name": "verifyingContract", "type": "address"}],
+            "SafeTx": [
+                {"name": "to", "type": "address"},
+                {"name": "value", "type": "uint256"},
+                {"name": "data", "type": "bytes"},
+                {"name": "operation", "type": "uint8"},
+                {"name": "safeTxGas", "type": "uint256"},
+                {"name": base_gas_key, "type": "uint256"},
+                {"name": "gasPrice", "type": "uint256"},
+                {"name": "gasToken", "type": "address"},
+                {"name": "refundReceiver", "type": "address"},
+                {"name": "nonce", "type": "uint256"},
+            ],
+        }
+        message = {
+            "to": self.to,
+            "value": self.value,
+            "data": self.data,
+            "operation": self.operation,
+            "safeTxGas": self.safe_tx_gas,
+            base_gas_key: self.base_gas,
+            "dataGas": self.base_gas,
+            "gasPrice": self.gas_price,
+            "gasToken": self.gas_token,
+            "refundReceiver": self.refund_receiver,
+            "nonce": self.safe_nonce,
+        }
+
+        payload = {
+            "types": types,
+            "primaryType": "SafeTx",
+            "domain": {"verifyingContract": self.safe_address},
+            "message": message,
+        }
+
+        # Enable chainId from v1.3.0 onwards
+        if safe_version >= Version("1.3.0"):
+            payload["domain"]["chainId"] = self.chain_id
+            types["EIP712Domain"].insert(0, {"name": "chainId", "type": "uint256"})
+
+        return payload
 
     @property
     def safe_tx_hash(self) -> HexBytes:
-        message, domain = self._eip712_payload
-        signable_bytes = message.signable_bytes(domain)
-        return HexBytes(fast_keccak(signable_bytes))
+        return HexBytes(eip712_encode_hash(self.eip712_structured_data))
 
     @property
     def signers(self) -> List[str]:

--- a/gp_cli.py
+++ b/gp_cli.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
         buyTokenBalance="erc20",  # `erc20` or `internal`
     )
 
-    order["feeAmount"] = gnosis_protocol_api.get_fee(order)
+    order.feeAmount = gnosis_protocol_api.get_fee(order)
 
     if confirm_prompt(
         f"Exchanging {amount_wei} {from_token} to {buy_amount} {to_token}?"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 django==3.2.16
 django-filter==22.1
 djangorestframework==3.14.0
-eip712-structs==1.1.0
 hexbytes==0.2.3
 packaging
 psycopg2-binary==2.9.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ packages = find:
 platforms = any
 include_package_data = True
 install_requires =
-    eip712_structs
     packaging
     py-evm==0.5.0a3
     pysha3>=1.0.0


### PR DESCRIPTION
- Copy library from https://github.com/jvinet/eip712 and do some adjustments (removing dependencies, adding `typing` hints, rewriting some code, adding new methods)
- EIP712 structs is not updated and it doesn't support Dictionary inputs (classes need to be declared so it's not easy to use with input data)