### PR TITLE
Add EIP712 support for bytes and uint formatted as string

### DIFF
--- a/gnosis/eth/eip712/__init__.py
+++ b/gnosis/eth/eip712/__init__.py
@@ -57,6 +57,14 @@ def encode_data(primary_type: str, data, types):
         if value is None:
             raise Exception(f"Missing value for field {name} of type {type}")
 
+        # Accept string bytes
+        if "bytes" in typ and isinstance(value, str):
+            value = bytes.fromhex(value.replace("0x", ""))
+
+        # Accept string uint
+        if "uint" in typ and isinstance(value, str):
+            value = int(value)
+
         if typ == "bytes":
             return ["bytes32", fast_keccak(value)]
 

--- a/gnosis/eth/tests/eip712/test_eip712.py
+++ b/gnosis/eth/tests/eip712/test_eip712.py
@@ -118,7 +118,6 @@ class TestEIP712(TestCase):
                 {"name": "maxByte", "type": "bytes32"},
             ],
         }
-        # test string uint (chainId)
         payload = {
             "types": types_with_bytes,
             "primaryType": "Message",

--- a/gnosis/eth/tests/eip712/test_eip712.py
+++ b/gnosis/eth/tests/eip712/test_eip712.py
@@ -4,6 +4,43 @@ from gnosis.eth.eip712 import eip712_encode_hash
 
 
 class TestEIP712(TestCase):
+    address = "0x8e12f01dae5fe7f1122dc42f2cb084f2f9e8aa03"
+    types = {
+        "EIP712Domain": [
+            {"name": "name", "type": "string"},
+            {"name": "version", "type": "string"},
+            {"name": "chainId", "type": "uint256"},
+            {"name": "verifyingContract", "type": "address"},
+        ],
+        "Mailbox": [
+            {"name": "owner", "type": "address"},
+            {"name": "messages", "type": "Message[]"},
+        ],
+        "Message": [
+            {"name": "sender", "type": "address"},
+            {"name": "subject", "type": "string"},
+            {"name": "isSpam", "type": "bool"},
+            {"name": "body", "type": "string"},
+        ],
+    }
+
+    msgs = [
+        {
+            "sender": address,
+            "subject": "Hello World",
+            "body": "The sparrow flies at midnight.",
+            "isSpam": False,
+        },
+        {
+            "sender": address,
+            "subject": "You may have already Won! :dumb-emoji:",
+            "body": "Click here for sweepstakes!",
+            "isSpam": True,
+        },
+    ]
+
+    mailbox = {"owner": address, "messages": msgs}
+
     def test_eip712_encode_hash(self):
         for value in [
             {},
@@ -11,8 +48,6 @@ class TestEIP712(TestCase):
         ]:
             with self.assertRaises(ValueError):
                 eip712_encode_hash(value)
-
-        address = "0x8e12f01dae5fe7f1122dc42f2cb084f2f9e8aa03"
 
         wrong_types = {
             "EIP712Domain": [
@@ -33,42 +68,6 @@ class TestEIP712(TestCase):
             ],
         }
 
-        types = {
-            "EIP712Domain": [
-                {"name": "name", "type": "string"},
-                {"name": "version", "type": "string"},
-                {"name": "chainId", "type": "uint256"},
-                {"name": "verifyingContract", "type": "address"},
-            ],
-            "Mailbox": [
-                {"name": "owner", "type": "address"},
-                {"name": "messages", "type": "Message[]"},
-            ],
-            "Message": [
-                {"name": "sender", "type": "address"},
-                {"name": "subject", "type": "string"},
-                {"name": "isSpam", "type": "bool"},
-                {"name": "body", "type": "string"},
-            ],
-        }
-
-        msgs = [
-            {
-                "sender": address,
-                "subject": "Hello World",
-                "body": "The sparrow flies at midnight.",
-                "isSpam": False,
-            },
-            {
-                "sender": address,
-                "subject": "You may have already Won! :dumb-emoji:",
-                "body": "Click here for sweepstakes!",
-                "isSpam": True,
-            },
-        ]
-
-        mailbox = {"owner": address, "messages": msgs}
-
         payload = {
             "types": wrong_types,
             "primaryType": "Mailbox",
@@ -76,16 +75,63 @@ class TestEIP712(TestCase):
                 "name": "MyDApp",
                 "version": "3.0",
                 "chainId": 41,
-                "verifyingContract": address,
+                "verifyingContract": self.address,
             },
-            "message": mailbox,
+            "message": self.mailbox,
         }
 
         with self.assertRaises(ValueError):
             eip712_encode_hash(payload)
 
-        payload["types"] = types
+        payload["types"] = self.types
         self.assertEqual(
             eip712_encode_hash(payload),
             b"\xd5N\xcbf7\xfa\x99\n\xae\x02\x86\xd4 \xacpe\x8d\xb9\x95\xaem\t\xcc\x9b\xb1\xda\xcf6J\x14\x17\xd0",
+        )
+
+    def test_eip712_encode_hash_string_uint(self):
+        # test string uint (chainId)
+        payload = {
+            "types": self.types,
+            "primaryType": "Mailbox",
+            "domain": {
+                "name": "MyDApp",
+                "version": "3.0",
+                "chainId": "41",
+                "verifyingContract": self.address,
+            },
+            "message": self.mailbox,
+        }
+
+        self.assertEqual(
+            eip712_encode_hash(payload),
+            b"\xd5N\xcbf7\xfa\x99\n\xae\x02\x86\xd4 \xacpe\x8d\xb9\x95\xaem\t\xcc\x9b\xb1\xda\xcf6J\x14\x17\xd0",
+        )
+
+    def test_eip712_encode_hash_string_bytes(self):
+        types_with_bytes = {
+            "EIP712Domain": [
+                {"name": "name", "type": "string"},
+            ],
+            "Message": [
+                {"name": "oneByte", "type": "bytes1"},
+                {"name": "maxByte", "type": "bytes32"},
+            ],
+        }
+        # test string uint (chainId)
+        payload = {
+            "types": types_with_bytes,
+            "primaryType": "Message",
+            "domain": {
+                "name": "MyDApp",
+            },
+            "message": {
+                "oneByte": "0x01",
+                "maxByte": "0x6214da6089b8d8aaa6e6268977746aa0af19fd1ef5d56e225bb3390a697c3ec1",
+            },
+        }
+
+        self.assertEqual(
+            eip712_encode_hash(payload).hex(),
+            "2950cf06416c6c20059f24a965e3baf51a24f4ef49a1e7b1a47ee13ee08cde1f",
         )


### PR DESCRIPTION
Closes #424 
# Description
`eip712_encode_hash` is using `eth-abi`  that doesn't support the type `bytes` and `uint` formatted as string. 
Type `bytes` and `bytesN` on `eth-abi` only accept python bytes, this was fixed including a conversion for bytes formatted on string to python bytes.
Type `uint` only accept Numbers, this was fixed converting from string to python Integer.
# Additional changes
- Add test for string uint
- Add test for string bytes