### PR TITLE
Bump postgres version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.5'
 
 services:
   db:
-    image: postgres:10-alpine
+    image: postgres:15-alpine
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
The current django version don't support `postgresql-10` : 
`FAILED gnosis/safe/tests/api/test_transaction_service_api.py::TestTransactionServiceAPI::test_get_balances - django.db.utils.NotSupportedError: PostgreSQL 11 or later is required (found 10.23).`
The version 13 was chosen to be aligned with our github actions https://github.com/safe-global/safe-eth-py/blob/master/.github/workflows/python.yml#L41 