### PR TITLE
Set version 4.9.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = safe-eth-py
-version = 4.9.0
+version = 4.9.1
 description = Safe Ecosystem Foundation utilities for Ethereum projects
 long_description = file: README.rst
 long_description_content_type = text/x-rst; charset=UTF-8


### PR DESCRIPTION
# Commit included 
[Fix wrong domain separator for contract version 1.1.1 ](https://github.com/safe-global/safe-eth-py/commit/c0001208cb66c03ccae30b627b17c78c34bb5fe0)