### PR TITLE
Use new quote API for cowswap oracle

### DIFF
--- a/gnosis/eth/oracles/cowswap.py
+++ b/gnosis/eth/oracles/cowswap.py
@@ -56,10 +56,14 @@ class CowswapOracle(PriceOracle):
             result = self.api.get_estimated_amount(
                 token_address_1, token_address_2, OrderKind.SELL, 10**token_1_decimals
             )
-            if "amount" in result:
+            if "buyAmount" in result:
                 # Decimals needs to be adjusted
                 token_2_decimals = get_decimals(token_address_2, self.ethereum_client)
-                return float(result["amount"]) / 10**token_2_decimals
+                return (
+                    float(result["buyAmount"])
+                    / result["sellAmount"]
+                    * 10 ** (token_1_decimals - token_2_decimals)
+                )
 
             exception = None
         except IOError as exc:

--- a/gnosis/eth/tests/oracles/test_cowswap.py
+++ b/gnosis/eth/tests/oracles/test_cowswap.py
@@ -55,7 +55,9 @@ class TestCowswapOracle(EthereumTestCaseMixin, TestCase):
         )
         self.assertAlmostEqual(price, 1.0, delta=0.5)
 
-        with mock.patch.object(Session, "get", side_effect=IOError("Connection Error")):
+        with mock.patch.object(
+            Session, "post", side_effect=IOError("Connection Error")
+        ):
             with self.assertRaisesMessage(
                 CannotGetPriceFromOracle,
                 f"Cannot get price from CowSwap "

--- a/gnosis/protocol/tests/test_gnosis_protocol_api.py
+++ b/gnosis/protocol/tests/test_gnosis_protocol_api.py
@@ -63,7 +63,7 @@ class TestGnosisProtocolAPI(TestCase):
             OrderKind.SELL,
             int(1e18),
         )
-        amount = int(response["amount"]) / 1e18
+        amount = float(response["buyAmount"]) / response["sellAmount"]
         self.assertGreater(amount, 0)
         self.assertLess(amount, 1)
 


### PR DESCRIPTION
- Markets API was deprecated, quote API is used now
- Closes https://github.com/safe-global/safe-eth-py/issues/440