### PR TITLE
Don't log price oracle failures

### DIFF
--- a/gnosis/eth/oracles/cowswap.py
+++ b/gnosis/eth/oracles/cowswap.py
@@ -70,9 +70,9 @@ class CowswapOracle(PriceOracle):
             exception = exc
             result = {}
 
-        error_message = (
+        message = (
             f"Cannot get price from CowSwap {result} "
             f"for token-1={token_address_1} to token-2={token_address_2}"
         )
-        logger.warning(error_message)
-        raise CannotGetPriceFromOracle(error_message) from exception
+        logger.debug(message)
+        raise CannotGetPriceFromOracle(message) from exception

--- a/gnosis/eth/oracles/kyber.py
+++ b/gnosis/eth/oracles/kyber.py
@@ -98,17 +98,17 @@ class KyberOracle(PriceOracle):
                 price = (token_unit / expected_rate) if expected_rate else 0
 
             if price <= 0.0:
-                error_message = (
+                message = (
                     f"price={price} <= 0 from kyber-network-proxy={self.kyber_network_proxy_address} "
                     f"for token-1={token_address_1} to token-2={token_address_2}"
                 )
-                logger.warning(error_message)
-                raise InvalidPriceFromOracle(error_message)
+                logger.debug(message)
+                raise InvalidPriceFromOracle(message)
             return price
         except (ValueError, BadFunctionCallOutput, DecodingError) as e:
-            error_message = (
+            message = (
                 f"Cannot get price from kyber-network-proxy={self.kyber_network_proxy_address} "
                 f"for token-1={token_address_1} to token-2={token_address_2}"
             )
-            logger.warning(error_message)
-            raise CannotGetPriceFromOracle(error_message) from e
+            logger.debug(message)
+            raise CannotGetPriceFromOracle(message) from e

--- a/gnosis/eth/oracles/oracles.py
+++ b/gnosis/eth/oracles/oracles.py
@@ -194,9 +194,9 @@ class UniswapOracle(PriceOracle):
             if uniswap_exchange_address == NULL_ADDRESS:
                 raise ValueError
         except (ValueError, BadFunctionCallOutput, DecodingError) as e:
-            error_message = f"Non existing uniswap exchange for token={token_address}"
-            logger.warning(error_message)
-            raise CannotGetPriceFromOracle(error_message) from e
+            message = f"Non existing uniswap exchange for token={token_address}"
+            logger.debug(message)
+            raise CannotGetPriceFromOracle(message) from e
 
         try:
             balance, token_decimals, token_balance = self._get_balances_using_batching(
@@ -210,12 +210,12 @@ class UniswapOracle(PriceOracle):
 
             price = balance / token_balance / 10 ** (18 - token_decimals)
             if price <= 0.0:
-                error_message = (
+                message = (
                     f"price={price} <= 0 from uniswap-factory={uniswap_exchange_address} "
                     f"for token={token_address}"
                 )
-                logger.warning(error_message)
-                raise InvalidPriceFromOracle(error_message)
+                logger.debug(message)
+                raise InvalidPriceFromOracle(message)
             return price
         except (
             ValueError,
@@ -223,9 +223,9 @@ class UniswapOracle(PriceOracle):
             BadFunctionCallOutput,
             DecodingError,
         ) as e:
-            error_message = f"Cannot get token balance for token={token_address}"
-            logger.warning(error_message)
-            raise CannotGetPriceFromOracle(error_message) from e
+            message = f"Cannot get token balance for token={token_address}"
+            logger.debug(message)
+            raise CannotGetPriceFromOracle(message) from e
 
 
 class UniswapV2Oracle(PricePoolOracle, PriceOracle):
@@ -391,12 +391,12 @@ class UniswapV2Oracle(PricePoolOracle, PriceOracle):
             BadFunctionCallOutput,
             DecodingError,
         ) as e:
-            error_message = (
+            message = (
                 f"Cannot get uniswap v2 price for pair token_1={token_address} "
                 f"token_2={token_address_2}"
             )
-            logger.warning(error_message)
-            raise CannotGetPriceFromOracle(error_message) from e
+            logger.debug(message)
+            raise CannotGetPriceFromOracle(message) from e
 
     def get_price_without_exception(
         self, token_address: str, token_address_2: Optional[str] = None
@@ -458,11 +458,9 @@ class UniswapV2Oracle(PricePoolOracle, PriceOracle):
             BadFunctionCallOutput,
             DecodingError,
         ) as e:
-            error_message = (
-                f"Cannot get uniswap v2 price for pool token={pool_token_address}"
-            )
-            logger.warning(error_message)
-            raise CannotGetPriceFromOracle(error_message) from e
+            message = f"Cannot get uniswap v2 price for pool token={pool_token_address}"
+            logger.debug(message)
+            raise CannotGetPriceFromOracle(message) from e
 
 
 class AaveOracle(PriceOracle):

--- a/gnosis/eth/oracles/uniswap_v3.py
+++ b/gnosis/eth/oracles/uniswap_v3.py
@@ -162,23 +162,23 @@ class UniswapV3Oracle(PriceOracle):
             if (token_balance / 10**token_decimals) < 2 or (
                 token_2_balance / 10**token_2_decimals
             ) < 2:
-                error_message = (
+                message = (
                     f"Not enough liquidity on uniswap v3 for pair token_1={token_address} "
                     f"token_2={token_address_2}, at least 2 units of each token are required"
                 )
-                logger.warning(error_message)
-                raise CannotGetPriceFromOracle(error_message)
+                logger.debug(message)
+                raise CannotGetPriceFromOracle(message)
         except (
             ValueError,
             BadFunctionCallOutput,
             DecodingError,
         ) as e:
-            error_message = (
+            message = (
                 f"Cannot get uniswap v3 price for pair token_1={token_address} "
                 f"token_2={token_address_2}"
             )
-            logger.warning(error_message)
-            raise CannotGetPriceFromOracle(error_message) from e
+            logger.debug(message)
+            raise CannotGetPriceFromOracle(message) from e
 
         # https://docs.uniswap.org/sdk/guides/fetching-prices
         if not reversed:

--- a/gnosis/eth/oracles/utils.py
+++ b/gnosis/eth/oracles/utils.py
@@ -32,6 +32,6 @@ def get_decimals(
         BadFunctionCallOutput,
         DecodingError,
     ) as e:
-        error_message = f"Cannot get decimals for token={token_address}"
-        logger.warning(error_message)
-        raise CannotGetPriceFromOracle(error_message) from e
+        message = f"Cannot get decimals for token={token_address}"
+        logger.debug(message)
+        raise CannotGetPriceFromOracle(message) from e


### PR DESCRIPTION
It's not relevant if a price oracle cannot retrieve the price, as there's already an exception returned for that

- Update price oracle logs from `WARNING` to `DEBUG`
