### PR TITLE
Fix WETH for CowSwap Oracle (Gnosis Chain)

### DIFF
--- a/gnosis/protocol/gnosis_protocol_api.py
+++ b/gnosis/protocol/gnosis_protocol_api.py
@@ -130,9 +130,10 @@ class GnosisProtocolAPI:
         from_address = Account.from_key(private_key).address
         if not order.feeAmount:
             fee_amount = self.get_fee(order, from_address)
-            if "errorType" in fee_amount:  # ErrorResponse
+            if isinstance(fee_amount, int):
+                order.feeAmount = fee_amount
+            elif "errorType" in fee_amount:  # ErrorResponse
                 return fee_amount
-            order.feeAmount = fee_amount
 
         signable_hash = eip712_encode_hash(
             order.get_eip712_structured_data(

--- a/gnosis/protocol/gnosis_protocol_api.py
+++ b/gnosis/protocol/gnosis_protocol_api.py
@@ -71,12 +71,13 @@ class GnosisProtocolAPI:
         """
         :return: Wrapped ether checksummed address
         """
-        if self.network == EthereumNetwork.MAINNET:
-            return ChecksumAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
-        elif self.network == EthereumNetwork.RINKEBY:
-            return ChecksumAddress("0xc778417E063141139Fce010982780140Aa0cD5Ab")
-        else:  # XDAI
-            return ChecksumAddress("0x6A023CCd1ff6F2045C3309768eAd9E68F978f6e1")
+        if self.network == EthereumNetwork.GNOSIS:  # WXDAI
+            return ChecksumAddress("0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d")
+        if self.network == EthereumNetwork.GOERLI:  # Goerli WETH9
+            return ChecksumAddress("0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6")
+
+        # Mainnet WETH9
+        return ChecksumAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
 
     def get_quote(
         self, order: Order, from_address: ChecksumAddress

--- a/gnosis/protocol/tests/test_gnosis_protocol_api.py
+++ b/gnosis/protocol/tests/test_gnosis_protocol_api.py
@@ -153,6 +153,8 @@ class TestGnosisProtocolAPI(TestCase):
         if type(order_id) is dict:
             if order_id["errorType"] == "NoLiquidity":
                 pytest.xfail("NoLiquidity Error")
+            elif order_id["errorType"] == "InsufficientBalance":
+                pytest.xfail("InsufficientBalance")
 
         self.assertEqual(order_id[:2], "0x")
         self.assertEqual(len(order_id), 114)


### PR DESCRIPTION
- CowSwap oracle in Gnosis Chain is supposed to use Wrapped XDAI for getting the price, not Wrapped Ether

From now on, `Wrapped XDAI` will be used as the default collateral for `Cowswap` oracle
