### PR TITLE
Fix error using block identifier as `pending`

### DIFF
--- a/gnosis/safe/safe_signature.py
+++ b/gnosis/safe/safe_signature.py
@@ -250,7 +250,8 @@ class SafeSignatureApprovedHash(SafeSignature):
                     ).call(block_identifier=block_identifier)
                     == 1
                 )
-            except BadFunctionCallOutput as e:  # Error using `pending` block identifier
+            except (ValueError, BadFunctionCallOutput, DecodingError) as e:
+                # Error using `pending` block identifier
                 exception = e
         raise exception  # This should never happen
 


### PR DESCRIPTION
- Some providers have problems using the `block_identifier=pending` for ethereum RPC calls
- Exception thrown can be a `ValueError`, not just a `BadFunctionCallOutput`
