### PR TITLE
Fix safeProxyFactory address on base goerli

### DIFF
--- a/gnosis/safe/addresses.py
+++ b/gnosis/safe/addresses.py
@@ -500,7 +500,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 42293264),  # v1.3.0
     ],
     EthereumNetwork.BASE_GOERLI_TESTNET: [
-        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 938848),  # v1.3.0
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 938696),  # v1.3.0
     ],
     EthereumNetwork.KAVA_EVM: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 2116356),  # v1.3.0


### PR DESCRIPTION
`SafeProxyFactory` address on `base goerli` was wrong
The address used `0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2` is the deterministic address that is generated when is deployed using the default singleton factory, but` base goerli `contracts were deployed using safe singleton factory, then the correct address is `0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC`
In the block explorer for base we can see that this address `0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2` is not deployed https://goerli.basescan.org/address/0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2 
But the correct address `0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC` is deployed https://goerli.basescan.org/address/0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC