### PR TITLE
Fix infinite loop in `retrieve_modules`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = safe-eth-py
-version = 5.4.1
+version = 5.4.2
 description = Safe Ecosystem Foundation utilities for Ethereum projects
 long_description = file: README.rst
 long_description_content_type = text/x-rst; charset=UTF-8


### PR DESCRIPTION
- When a Safe was unitialized `retrieve_modules` could get into an infinite loop
