### PR TITLE
Don't increment the gas for Safe creation

### DIFF
--- a/gnosis/safe/safe.py
+++ b/gnosis/safe/safe.py
@@ -182,7 +182,6 @@ class Safe:
         tx = proxy_contract.constructor(
             master_copy_address, initializer
         ).build_transaction({"from": deployer_account.address})
-        tx["gas"] = tx["gas"] * 100000
         tx_hash = ethereum_client.send_unsigned_transaction(
             tx, private_key=deployer_account.key
         )


### PR DESCRIPTION
- This was posibly a fix for nodes not estimating Safe creation propertly
- It doesn't make sense to keep this around
