### PR TITLE
Skip get balancer price test if fails

### DIFF
--- a/gnosis/eth/tests/test_oracles.py
+++ b/gnosis/eth/tests/test_oracles.py
@@ -411,6 +411,7 @@ class TestYearnOracle(EthereumTestCaseMixin, TestCase):
 
 
 class TestBalancerOracle(EthereumTestCaseMixin, TestCase):
+    @pytest.mark.xfail(reason="Could fail due to unbalanced pool")
     def test_get_pool_token_price(self):
         mainnet_node = just_test_if_mainnet_node()
         ethereum_client = EthereumClient(mainnet_node)


### PR DESCRIPTION
Get price from  balancer token pool `Balancer 80% BAL + 20% WETH` is failing due unbalanced pool. 
Adding a skip test if this happens.