### PR TITLE
Add Fantom Opera and Fantom Testnet support

### DIFF
--- a/gnosis/eth/clients/etherscan_client.py
+++ b/gnosis/eth/clients/etherscan_client.py
@@ -48,6 +48,8 @@ class EtherscanClient:
         EthereumNetwork.NEON_EVM_MAINNET: "https://neonscan.org",
         EthereumNetwork.SEPOLIA: "https://sepolia.etherscan.io",
         EthereumNetwork.ZKSYNC_V2: "https://explorer.zksync.io/",
+        EthereumNetwork.FANTOM_OPERA: "https://ftmscan.com",
+        EthereumNetwork.FANTOM_TESTNET: "https://testnet.ftmscan.com/",
     }
 
     NETWORK_WITH_API_URL = {
@@ -76,6 +78,8 @@ class EtherscanClient:
         EthereumNetwork.NEON_EVM_MAINNET: "https://api.neonscan.org",
         EthereumNetwork.SEPOLIA: "https://api-sepolia.etherscan.io",
         EthereumNetwork.ZKSYNC_V2: "https://block-explorer-api.mainnet.zksync.io/",
+        EthereumNetwork.FANTOM_OPERA: "https://api.ftmscan.com",
+        EthereumNetwork.FANTOM_TESTNET: "https://api-testnet.ftmscan.com",
     }
     HTTP_HEADERS = {
         "User-Agent": "curl/7.77.0",

--- a/gnosis/safe/addresses.py
+++ b/gnosis/safe/addresses.py
@@ -569,6 +569,15 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 6261, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 6262, "1.3.0"),
     ],
+    EthereumNetwork.FANTOM_OPERA: [
+        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 38810826, "1.3.0+L2"),
+        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 21817262, "1.3.0"),
+        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 4580000, "1.3.0+L2"),
+    ],
+    EthereumNetwork.FANTOM_TESTNET: [
+        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 4627348, "1.3.0"),
+        ("0x5696Ae62C36aF747966522C401FbD57492451f19", 4627348, "1.3.0"),
+    ],
 }
 
 PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
@@ -949,5 +958,13 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     ],
     EthereumNetwork.SCROLL_SEPOLIA_TESTNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 6254),  # v1.3.0
+    ],
+    EthereumNetwork.FANTOM_OPERA: [
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 38810826),  # v1.3.0
+        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 21817221),  # v1.3.0
+    ],
+    EthereumNetwork.FANTOM_TESTNET: [
+        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 4627348),  # v1.3.0
+        ("0x63B5caf390e8AF7133DBE6bA92A69167a854Ac91", 4627348),  # v1.3.0
     ],
 }


### PR DESCRIPTION
Adding support for Fantom Opera and Fantom Testnet networks and their Etherscan compatible client called FTMScan

Reference:
https://github.com/safe-global/safe-deployments/pull/243