### PR TITLE
Fix gnosis blockscout

### DIFF
--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -19,62 +19,54 @@ class BlockScoutConfigurationProblem(BlockscoutClientException):
 
 class BlockscoutClient:
     NETWORK_WITH_URL = {
-        EthereumNetwork.GNOSIS: "https://gnosis.blockscout.com/graphiql",
-        EthereumNetwork.POLYGON: "https://polygon-explorer-mainnet.chainstacklabs.com/",
-        EthereumNetwork.MUMBAI: "https://polygon-explorer-mumbai.chainstacklabs.com/",
-        EthereumNetwork.ENERGY_WEB_CHAIN: "https://explorer.energyweb.org/",
-        EthereumNetwork.ENERGY_WEB_VOLTA_TESTNET: "https://volta-explorer.energyweb.org/",
-        EthereumNetwork.POLIS_MAINNET: "https://explorer.polis.tech",
-        EthereumNetwork.BOBABEAM: "https://blockexplorer.bobabeam.boba.network/",
-        EthereumNetwork.BOBA_NETWORK_RINKEBY_TESTNET: "https://blockexplorer.rinkeby.boba.network/",
-        EthereumNetwork.BOBA_NETWORK: "https://blockexplorer.boba.network/",
-        EthereumNetwork.GATHER_DEVNET_NETWORK: "https://devnet-explorer.gather.network/",
-        EthereumNetwork.GATHER_TESTNET_NETWORK: "https://testnet-explorer.gather.network/",
-        EthereumNetwork.GATHER_MAINNET_NETWORK: "https://explorer.gather.network/",
-        EthereumNetwork.METIS_STARDUST_TESTNET: "https://stardust-explorer.metis.io/",
-        EthereumNetwork.METIS_GOERLI_TESTNET: "https://goerli.explorer.metisdevops.link/",
-        EthereumNetwork.METIS_ANDROMEDA_MAINNET: "https://andromeda-explorer.metis.io/",
-        EthereumNetwork.FUSE_MAINNET: "https://explorer.fuse.io/",
-        EthereumNetwork.VELAS_EVM_MAINNET: "https://evmexplorer.velas.com/",
-        EthereumNetwork.REI_NETWORK: "https://scan.rei.network/",
-        EthereumNetwork.REI_CHAIN_TESTNET: "https://scan-test.rei.network/",
-        EthereumNetwork.METER_MAINNET: "https://scan.meter.io/",
-        EthereumNetwork.METER_TESTNET: "https://scan-warringstakes.meter.io/",
-        EthereumNetwork.GODWOKEN_TESTNET_V1: "https://v1.betanet.gwscan.com/",
-        EthereumNetwork.GODWOKEN_MAINNET: "https://v1.gwscan.com/",
-        EthereumNetwork.VENIDIUM_TESTNET: "https://evm-testnet.venidiumexplorer.com/",
-        EthereumNetwork.VENIDIUM_MAINNET: "https://evm.venidiumexplorer.com/",
-        EthereumNetwork.KLAYTN_TESTNET_BAOBAB: "https://baobab.scope.klaytn.com/",
-        EthereumNetwork.KLAYTN_MAINNET_CYPRESS: "https://scope.klaytn.com/",
-        EthereumNetwork.ACALA_NETWORK: "https://blockscout.acala.network/",
-        EthereumNetwork.KARURA_NETWORK_TESTNET: "https://blockscout.karura.network/",
-        EthereumNetwork.ACALA_NETWORK_TESTNET: "https://blockscout.mandala.acala.network/",
-        EthereumNetwork.ASTAR: "https://blockscout.com/astar/",
-        EthereumNetwork.EVMOS: "https://evm.evmos.org",
-        EthereumNetwork.EVMOS_TESTNET: "https://evm.evmos.dev",
-        EthereumNetwork.RABBIT_ANALOG_TESTNET_CHAIN: "https://rabbit.analogscan.com",
-        EthereumNetwork.KCC_MAINNET: "https://scan.kcc.io/",
-        EthereumNetwork.KCC_TESTNET: "https://scan-testnet.kcc.network/",
-        EthereumNetwork.ARBITRUM_ONE: "https://explorer.arbitrum.io",
-        EthereumNetwork.ARBITRUM_NOVA: "https://nova-explorer.arbitrum.io",
-        EthereumNetwork.ARBITRUM_GOERLI: "https://goerli-rollup-explorer.arbitrum.io",
-        EthereumNetwork.CROSSBELL: "https://scan.crossbell.io",
-        EthereumNetwork.ETHEREUM_CLASSIC_MAINNET: "https://blockscout.com/etc/mainnet/",
-        EthereumNetwork.ETHEREUM_CLASSIC_TESTNET_MORDOR: "https://blockscout.com/etc/mordor/",
+        EthereumNetwork.GNOSIS: "https://gnosis.blockscout.com/api/v1/graphql",
+        EthereumNetwork.ENERGY_WEB_CHAIN: "https://explorer.energyweb.org/graphiql",
+        EthereumNetwork.ENERGY_WEB_VOLTA_TESTNET: "https://volta-explorer.energyweb.org/graphiql",
+        EthereumNetwork.POLIS_MAINNET: "https://explorer.polis.tech/graphiql",
+        EthereumNetwork.BOBA_NETWORK: "https://blockexplorer.boba.network/graphiql",
+        EthereumNetwork.GATHER_DEVNET_NETWORK: "https://devnet-explorer.gather.network/graphiql",
+        EthereumNetwork.GATHER_TESTNET_NETWORK: "https://testnet-explorer.gather.network/graphiql",
+        EthereumNetwork.GATHER_MAINNET_NETWORK: "https://explorer.gather.network/graphiql",
+        EthereumNetwork.METIS_GOERLI_TESTNET: "https://goerli.explorer.metisdevops.link/graphiql",
+        EthereumNetwork.METIS_ANDROMEDA_MAINNET: "https://andromeda-explorer.metis.io/graphiql",
+        EthereumNetwork.FUSE_MAINNET: "https://explorer.fuse.io/graphiql",
+        EthereumNetwork.VELAS_EVM_MAINNET: "https://evmexplorer.velas.com/graphiql",
+        EthereumNetwork.REI_NETWORK: "https://scan.rei.network/graphiql",
+        EthereumNetwork.REI_CHAIN_TESTNET: "https://scan-test.rei.network/graphiql",
+        EthereumNetwork.METER_MAINNET: "https://scan.meter.io/graphiql",
+        EthereumNetwork.METER_TESTNET: "https://scan-warringstakes.meter.io/graphiql",
+        EthereumNetwork.GODWOKEN_TESTNET_V1: "https://v1.betanet.gwscan.com/graphiql",
+        EthereumNetwork.GODWOKEN_MAINNET: "https://v1.gwscan.com/graphiql",
+        EthereumNetwork.VENIDIUM_TESTNET: "https://evm-testnet.venidiumexplorer.com/graphiql",
+        EthereumNetwork.VENIDIUM_MAINNET: "https://evm.venidiumexplorer.com/graphiql",
+        EthereumNetwork.KLAYTN_TESTNET_BAOBAB: "https://baobab.scope.klaytn.com/graphiql",
+        EthereumNetwork.KLAYTN_MAINNET_CYPRESS: "https://scope.klaytn.com/graphiql",
+        EthereumNetwork.ACALA_NETWORK: "https://blockscout.acala.network/graphiql",
+        EthereumNetwork.KARURA_NETWORK_TESTNET: "https://blockscout.karura.network/graphiql",
+        EthereumNetwork.ASTAR: "https://blockscout.com/astar/graphiql",
+        EthereumNetwork.EVMOS: "https://evm.evmos.org/graphiql",
+        EthereumNetwork.EVMOS_TESTNET: "https://evm.evmos.dev/graphiql",
+        EthereumNetwork.KCC_MAINNET: "https://scan.kcc.io/graphiql",
+        EthereumNetwork.KCC_TESTNET: "https://scan-testnet.kcc.network/graphiql",
+        EthereumNetwork.ARBITRUM_ONE: "https://explorer.arbitrum.io/graphiql",
+        EthereumNetwork.ARBITRUM_NOVA: "https://nova-explorer.arbitrum.io/graphiql",
+        EthereumNetwork.ARBITRUM_GOERLI: "https://goerli-rollup-explorer.arbitrum.io/graphiql",
+        EthereumNetwork.CROSSBELL: "https://scan.crossbell.io/graphiql",
+        EthereumNetwork.ETHEREUM_CLASSIC_MAINNET: "https://blockscout.com/etc/mainnet/graphiql",
+        EthereumNetwork.ETHEREUM_CLASSIC_TESTNET_MORDOR: "https://blockscout.com/etc/mordor/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):
         self.network = network
-        self.base_url = self.NETWORK_WITH_URL.get(network)
-        if self.base_url is None:
+        self.grahpql_url = self.NETWORK_WITH_URL.get(network)
+        if self.grahpql_url is None:
             raise BlockScoutConfigurationProblem(
                 f"Network {network.name} - {network.value} not supported"
             )
-        self.grahpql_url = self.base_url + "/graphiql"
         self.http_session = requests.Session()
 
     def build_url(self, path: str):
-        return urljoin(self.base_url, path)
+        return urljoin(self.grahpql_url, path)
 
     def _do_request(self, url: str, query: str) -> Optional[Dict[str, Any]]:
         response = self.http_session.post(url, json={"query": query}, timeout=10)


### PR DESCRIPTION
# Bug description
The blockscout client was guessing that every blockscout api in every network had the same path `/graphiql`. 
Currently gnosis chain blockscout explorer api changed the path to `/api/v1/graphql` that was causing the error. 

# How was fixed 
This PR aims is mantain the compatibility to every chain that the old approach works at the same time that fix the path changes, to get this, the PR removes the common path append and configure every url with full path. 

# Removed broken urls
https://polygon-explorer-mainnet.chainstacklabs.com/ 
https://polygon-explorer-mumbai.chainstacklabs.com/ 
https://blockexplorer.bobabeam.boba.network/ 
https://blockexplorer.rinkeby.boba.network/ 
https://stardust-explorer.metis.io/ 
https://blockscout.mandala.acala.network/ 
https://rabbit.analogscan.com/ 
