### PR TITLE
feat: Add zkEVM safe singleton

### DIFF
--- a/gnosis/safe/addresses.py
+++ b/gnosis/safe/addresses.py
@@ -133,7 +133,7 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         (
             "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
             79000,
-            "1.3.0+L2"
+            "1.3.0+L2",
         ),  # default singleton address
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 79000, "1.3.0"),
     ],

--- a/gnosis/safe/addresses.py
+++ b/gnosis/safe/addresses.py
@@ -638,7 +638,14 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 13736914),  # v1.3.0
     ],
     EthereumNetwork.POLYGON_ZKEVM: [
-        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 79000),  # v1.3.0
+        (
+            "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
+            4460053,
+        ),  # v1.3.0 safe singleton address
+        (
+            "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
+            79000,
+        ),  # v1.3.0 default singleton address
     ],
     EthereumNetwork.ARBITRUM_ONE: [
         (

--- a/gnosis/safe/addresses.py
+++ b/gnosis/safe/addresses.py
@@ -125,7 +125,16 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 14306478, "1.3.0"),
     ],
     EthereumNetwork.POLYGON_ZKEVM: [
-        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 79000, "1.3.0+L2"),
+        (
+            "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
+            4460434,
+            "1.3.0+L2",
+        ),  # safe singleton address
+        (
+            "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+            79000,
+            "1.3.0+L2"
+        ),  # default singleton address
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 79000, "1.3.0"),
     ],
     EthereumNetwork.MUMBAI: [


### PR DESCRIPTION
Safe singleton & all related contract were deployed:
https://zkevm.polygonscan.com/address/0xfb1bffC9d739B8D520DaF37dF666da4C687191EA#code

```
$ hardhat deploy-contracts --network custom
reusing "SimulateTxAccessor" at 0x727a77a074D1E6c4530e814F89E618a3298FC044
reusing "GnosisSafeProxyFactory" at 0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC
reusing "DefaultCallbackHandler" at 0x3d8E605B02032A941Cfe26897Ca94d77a5BC24b3
reusing "CompatibilityFallbackHandler" at 0x017062a1dE2FE6b99BE3d9d37841FeD19F573804
reusing "CreateCall" at 0xB19D6FFc2182150F8Eb585b79D4ABcd7C5640A9d
reusing "MultiSend" at 0x998739BFdAAdde7C933B942a68053933098f9EDa
reusing "MultiSendCallOnly" at 0xA1dabEF33b3B82c7814B6D82A79e50F4AC44102B
reusing "SignMessageLib" at 0x98FFBBF51bb33A056B08ddf711f289936AafF717
reusing "GnosisSafeL2" at 0xfb1bffC9d739B8D520DaF37dF666da4C687191EA
reusing "GnosisSafe" at 0x69f4D1788e39c87893C980c06EdF4b7f686e2938
```