### PR TITLE
feat: add new networks and clients

### DIFF
--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -72,6 +72,8 @@ class BlockscoutClient:
         EthereumNetwork.TENET: "https://tenetscan.io/graphiql",
         EthereumNetwork.TENET_TESTNET: "https://testnet.tenetscan.io/graphiql",
         EthereumNetwork.VELAS_EVM_MAINNET: "https://evmexplorer.velas.com/graphiql",
+        EthereumNetwork.CRONOS_MAINNET_BETA: "https://cronos.org/explorer/graphiql",
+        EthereumNetwork.CRONOS_TESTNET: "https://cronos.org/explorer/testnet3/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -57,6 +57,8 @@ class BlockscoutClient:
         EthereumNetwork.SCROLL_SEPOLIA_TESTNET: "https://sepolia-blockscout.scroll.io/",
         EthereumNetwork.MANTLE: "https://explorer.mantle.xyz/graphiql",
         EthereumNetwork.MANTLE_TESTNET: "https://explorer.testnet.mantle.xyz/graphiql",
+        EthereumNetwork.ZETACHAIN_ATHENS_TESTNET: "https://zetachain-athens-3.blockscout.com/",
+        EthereumNetwork.SCROLL: "https://blockscout.scroll.io/",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -66,6 +66,8 @@ class BlockscoutClient:
         EthereumNetwork.LINEA_TESTNET: "https://explorer.goerli.linea.build/graphiql",
         EthereumNetwork.NEON_EVM_MAINNET: "https://neon.blockscout.com/graphiql",
         EthereumNetwork.NEON_EVM_DEVNET: "https://neon-devnet.blockscout.com/graphiql",
+        EthereumNetwork.OASIS_SAPPHIRE: "https://explorer.sapphire.oasis.io/graphiql",
+        EthereumNetwork.OASIS_SAPPHIRE_TESTNET: "https://testnet.explorer.sapphire.oasis.dev/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -74,6 +74,8 @@ class BlockscoutClient:
         EthereumNetwork.VELAS_EVM_MAINNET: "https://evmexplorer.velas.com/graphiql",
         EthereumNetwork.CRONOS_MAINNET_BETA: "https://cronos.org/explorer/graphiql",
         EthereumNetwork.CRONOS_TESTNET: "https://cronos.org/explorer/testnet3/graphiql",
+        EthereumNetwork.THUNDERCORE_MAINNET: "https://explorer-mainnet.thundercore.com/graphiql",
+        EthereumNetwork.THUNDERCORE_TESTNET: "https://explorer-testnet.thundercore.com/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -54,11 +54,11 @@ class BlockscoutClient:
         EthereumNetwork.CROSSBELL: "https://scan.crossbell.io/graphiql",
         EthereumNetwork.ETHEREUM_CLASSIC_MAINNET: "https://blockscout.com/etc/mainnet/graphiql",
         EthereumNetwork.ETHEREUM_CLASSIC_TESTNET_MORDOR: "https://blockscout.com/etc/mordor/graphiql",
-        EthereumNetwork.SCROLL_SEPOLIA_TESTNET: "https://sepolia-blockscout.scroll.io/",
+        EthereumNetwork.SCROLL_SEPOLIA_TESTNET: "https://sepolia-blockscout.scroll.io/graphiql",
         EthereumNetwork.MANTLE: "https://explorer.mantle.xyz/graphiql",
         EthereumNetwork.MANTLE_TESTNET: "https://explorer.testnet.mantle.xyz/graphiql",
-        EthereumNetwork.ZETACHAIN_ATHENS_TESTNET: "https://zetachain-athens-3.blockscout.com/",
-        EthereumNetwork.SCROLL: "https://blockscout.scroll.io/",
+        EthereumNetwork.ZETACHAIN_ATHENS_TESTNET: "https://zetachain-athens-3.blockscout.com/graphiql",
+        EthereumNetwork.SCROLL: "https://blockscout.scroll.io/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -64,6 +64,8 @@ class BlockscoutClient:
         EthereumNetwork.RSK_TESTNET: "https://rootstock-testnet.blockscout.com/graphiql",
         EthereumNetwork.LINEA: "https://explorer.linea.build/graphiql",
         EthereumNetwork.LINEA_TESTNET: "https://explorer.goerli.linea.build/graphiql",
+        EthereumNetwork.NEON_EVM_MAINNET: "https://neon.blockscout.com/graphiql",
+        EthereumNetwork.NEON_EVM_DEVNET: "https://neon-devnet.blockscout.com/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -44,6 +44,7 @@ class BlockscoutClient:
         EthereumNetwork.ACALA_NETWORK: "https://blockscout.acala.network/graphiql",
         EthereumNetwork.KARURA_NETWORK_TESTNET: "https://blockscout.karura.network/graphiql",
         EthereumNetwork.ASTAR: "https://blockscout.com/astar/graphiql",
+        EthereumNetwork.SHIDEN: "https://blockscout.com/shiden/graphiql",
         EthereumNetwork.EVMOS: "https://evm.evmos.org/graphiql",
         EthereumNetwork.EVMOS_TESTNET: "https://evm.evmos.dev/graphiql",
         EthereumNetwork.KCC_MAINNET: "https://scan.kcc.io/graphiql",

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -60,6 +60,8 @@ class BlockscoutClient:
         EthereumNetwork.MANTLE_TESTNET: "https://explorer.testnet.mantle.xyz/graphiql",
         EthereumNetwork.ZETACHAIN_ATHENS_TESTNET: "https://zetachain-athens-3.blockscout.com/graphiql",
         EthereumNetwork.SCROLL: "https://blockscout.scroll.io/graphiql",
+        EthereumNetwork.RSK_MAINNET: "https://rootstock.blockscout.com/graphiql",
+        EthereumNetwork.RSK_TESTNET: "https://rootstock-testnet.blockscout.com/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -62,6 +62,8 @@ class BlockscoutClient:
         EthereumNetwork.SCROLL: "https://blockscout.scroll.io/graphiql",
         EthereumNetwork.RSK_MAINNET: "https://rootstock.blockscout.com/graphiql",
         EthereumNetwork.RSK_TESTNET: "https://rootstock-testnet.blockscout.com/graphiql",
+        EthereumNetwork.LINEA: "https://explorer.linea.build/graphiql",
+        EthereumNetwork.LINEA_TESTNET: "https://explorer.goerli.linea.build/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -69,6 +69,8 @@ class BlockscoutClient:
         EthereumNetwork.OASIS_SAPPHIRE: "https://explorer.sapphire.oasis.io/graphiql",
         EthereumNetwork.OASIS_SAPPHIRE_TESTNET: "https://testnet.explorer.sapphire.oasis.dev/graphiql",
         EthereumNetwork.CASCADIA_TESTNET: "https://explorer.cascadia.foundation/graphiql",
+        EthereumNetwork.TENET: "https://tenetscan.io/graphiql",
+        EthereumNetwork.TENET_TESTNET: "https://testnet.tenetscan.io/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -68,6 +68,7 @@ class BlockscoutClient:
         EthereumNetwork.NEON_EVM_DEVNET: "https://neon-devnet.blockscout.com/graphiql",
         EthereumNetwork.OASIS_SAPPHIRE: "https://explorer.sapphire.oasis.io/graphiql",
         EthereumNetwork.OASIS_SAPPHIRE_TESTNET: "https://testnet.explorer.sapphire.oasis.dev/graphiql",
+        EthereumNetwork.CASCADIA_TESTNET: "https://explorer.cascadia.foundation/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/blockscout_client.py
+++ b/gnosis/eth/clients/blockscout_client.py
@@ -71,6 +71,7 @@ class BlockscoutClient:
         EthereumNetwork.CASCADIA_TESTNET: "https://explorer.cascadia.foundation/graphiql",
         EthereumNetwork.TENET: "https://tenetscan.io/graphiql",
         EthereumNetwork.TENET_TESTNET: "https://testnet.tenetscan.io/graphiql",
+        EthereumNetwork.VELAS_EVM_MAINNET: "https://evmexplorer.velas.com/graphiql",
     }
 
     def __init__(self, network: EthereumNetwork):

--- a/gnosis/eth/clients/etherscan_client.py
+++ b/gnosis/eth/clients/etherscan_client.py
@@ -54,6 +54,8 @@ class EtherscanClient:
         EthereumNetwork.LINEA_TESTNET: "https://goerli.lineascan.build",
         EthereumNetwork.MANTLE: "https://explorer.mantle.xyz",
         EthereumNetwork.MANTLE_TESTNET: "https://explorer.testnet.mantle.xyz",
+        EthereumNetwork.SCROLL_SEPOLIA_TESTNET: "https://sepolia.scrollscan.dev",
+        EthereumNetwork.SCROLL: "https://scrollscan.com",
     }
 
     NETWORK_WITH_API_URL = {
@@ -88,6 +90,8 @@ class EtherscanClient:
         EthereumNetwork.LINEA_TESTNET: "https://api-testnet.lineascan.build",
         EthereumNetwork.MANTLE: "https://explorer.mantle.xyz",
         EthereumNetwork.MANTLE_TESTNET: "https://explorer.testnet.mantle.xyz",
+        EthereumNetwork.SCROLL_SEPOLIA_TESTNET: "https://api-sepolia.scrollscan.dev",
+        EthereumNetwork.SCROLL: "https://api.scrollscan.com",
     }
     HTTP_HEADERS = {
         "User-Agent": "curl/7.77.0",

--- a/gnosis/safe/addresses.py
+++ b/gnosis/safe/addresses.py
@@ -595,6 +595,14 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 2362236, "1.3.0+L2"),
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 2362238, "1.3.0"),
     ],
+    EthereumNetwork.ZETACHAIN_ATHENS_TESTNET: [
+        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 1962980, "1.3.0+L2"),
+        ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 1962981, "1.3.0"),
+    ],
+    EthereumNetwork.SCROLL: [
+        ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 187, "1.3.0+L2"),
+        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 189, "1.3.0"),
+    ],
 }
 
 PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
@@ -989,5 +997,11 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     ],
     EthereumNetwork.RSK_TESTNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 2362232),  # v1.3.0
+    ],
+    EthereumNetwork.ZETACHAIN_ATHENS_TESTNET: [
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 1962972),  # v1.3.0
+    ],
+    EthereumNetwork.SCROLL: [
+        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 179),  # v1.3.0
     ],
 }


### PR DESCRIPTION
Pull request contains:

- Master Copies and Proxy Factories for 2 networks(https://github.com/safe-global/safe-deployments/pull/304):
  - ZETACHAIN_ATHENS_TESTNET
  - SCROLL

- addition of Blockscout clients for:
  - SHIDEN
  - SCROLL
  - SCROLL_SEPOLIA_TESTNET
  - ZETACHAIN_ATHENS_TESTNET
  - RSK_MAINNET
  - RSK_TESTNET
  - LINEA
  - LINEA_TESTNET
  - NEON_EVM_MAINNET
  - NEON_EVM_DEVNET
  - OASIS_SAPPHIRE
  - OASIS_SAPPHIRE_TESTNET
  - CASCADIA_TESTNET
  - TENET
  - TENET_TESTNET
  - VELAS_EVM_MAINNET
  - CRONOS_MAINNET_BETA
  - CRONOS_TESTNET
  - THUNDERCORE_MAINNET
  - THUNDERCORE_TESTNET

- addition of Etherscan clients for:
  - SCROLL
  - SCROLL_SEPOLIA_TESTNET