### PR TITLE
Add missing v1.4.1 addresses

### DIFF
--- a/gnosis/safe/addresses.py
+++ b/gnosis/safe/addresses.py
@@ -15,8 +15,8 @@ SAFE_SIMULATE_TX_ACCESSOR_ADDRESS: ChecksumAddress = (
 
 MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
     EthereumNetwork.MAINNET: [
-        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 17486982, "1.4.1+L2"),
-        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 17487000, "1.4.1"),
+        ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 17486982, "1.4.1+L2"),
+        ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 17487000, "1.4.1"),
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
             14981217,
@@ -55,8 +55,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x2727D69C0BD14B1dDd28371B8D97e808aDc1C2f7", 3055781, "0.0.2"),
     ],
     EthereumNetwork.GOERLI: [
-        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 9134479, "1.4.1+L2"),
-        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 9134480, "1.4.1"),
+        ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 9134479, "1.4.1+L2"),
+        ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 9134480, "1.4.1"),
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
             6900544,
@@ -93,8 +93,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x8942595A2dC5181Df0465AF0D7be08c8f23C93af", 9465686, "0.1.0"),
     ],
     EthereumNetwork.GNOSIS: [
-        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 28204126, "1.4.1+L2"),
-        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 28204128, "1.4.1"),
+        ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 28204126, "1.4.1+L2"),
+        ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 28204128, "1.4.1"),
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
             27679972,
@@ -133,8 +133,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F", 6876642, "1.1.1"),
     ],
     EthereumNetwork.POLYGON: [
-        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 44367857, "1.4.1+L2"),
-        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 44367925, "1.4.1"),
+        ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 44367857, "1.4.1+L2"),
+        ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 44367925, "1.4.1"),
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
             34516629,
@@ -194,8 +194,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 155, "1.3.0"),
     ],
     EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET: [
-        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 31484712, "1.4.1+L2"),
-        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 31484715, "1.4.1"),
+        ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 31484712, "1.4.1+L2"),
+        ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 31484715, "1.4.1"),
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
             28092011,
@@ -420,8 +420,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 595211, "1.3.0"),
     ],
     EthereumNetwork.BASE_GOERLI_TESTNET: [
-        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 7330635, "1.4.1+L2"),
-        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 7330643, "1.4.1"),
+        ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 7330635, "1.4.1+L2"),
+        ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 7330643, "1.4.1"),
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 938848, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 939064, "1.3.0"),
     ],
@@ -487,8 +487,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 6333172, "1.3.0"),
     ],
     EthereumNetwork.SEPOLIA: [
-        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 3921532, "1.4.1+L2"),
-        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 3921533, "1.4.1"),
+        ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 3921532, "1.4.1+L2"),
+        ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 3921533, "1.4.1"),
         (
             "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
             2086878,
@@ -641,7 +641,7 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
 
 PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     EthereumNetwork.MAINNET: [
-        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 17440707),  # v1.4.1
+        ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 17440707),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             14981216,
@@ -661,7 +661,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x12302fE9c02ff50939BaAaaf415fc226C078613C", 4110083),
     ],
     EthereumNetwork.GOERLI: [
-        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 8681525),  # v1.4.1
+        ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 8681525),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             6900531,
@@ -681,7 +681,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x12302fE9c02ff50939BaAaaf415fc226C078613C", 10629898),
     ],
     EthereumNetwork.GNOSIS: [
-        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 27419153),  # v1.4.1
+        ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 27419153),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             27679953,
@@ -702,7 +702,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B", 6876681),
     ],
     EthereumNetwork.POLYGON: [
-        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 40683009),  # v1.4.1
+        ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 40683009),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             34504003,
@@ -748,7 +748,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 147),  # v1.3.0
     ],
     EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET: [
-        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 28092030),  # v1.4.1
+        ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 28092030),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             28059981,
@@ -902,7 +902,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 595181),  # v1.3.0
     ],
     EthereumNetwork.BASE_GOERLI_TESTNET: [
-        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 7330598),  # v1.4.1
+        ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 7330598),  # v1.4.1
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 938696),  # v1.3.0
     ],
     EthereumNetwork.KAVA_EVM: [
@@ -952,7 +952,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 6333172),  # v1.3.0
     ],
     EthereumNetwork.SEPOLIA: [
-        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 3312223),  # v1.4.1
+        ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 3312223),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             2087031,

--- a/gnosis/safe/addresses.py
+++ b/gnosis/safe/addresses.py
@@ -15,6 +15,8 @@ SAFE_SIMULATE_TX_ACCESSOR_ADDRESS: ChecksumAddress = (
 
 MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
     EthereumNetwork.MAINNET: [
+        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 17486982, "1.4.1+L2"),
+        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 17487000, "1.4.1"),
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
             14981217,
@@ -53,6 +55,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x2727D69C0BD14B1dDd28371B8D97e808aDc1C2f7", 3055781, "0.0.2"),
     ],
     EthereumNetwork.GOERLI: [
+        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 9134479, "1.4.1+L2"),
+        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 9134480, "1.4.1"),
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
             6900544,
@@ -89,6 +93,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x8942595A2dC5181Df0465AF0D7be08c8f23C93af", 9465686, "0.1.0"),
     ],
     EthereumNetwork.GNOSIS: [
+        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 28204126, "1.4.1+L2"),
+        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 28204128, "1.4.1"),
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
             27679972,
@@ -127,6 +133,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F", 6876642, "1.1.1"),
     ],
     EthereumNetwork.POLYGON: [
+        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 44367857, "1.4.1+L2"),
+        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 44367925, "1.4.1"),
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
             34516629,
@@ -186,6 +194,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 155, "1.3.0"),
     ],
     EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET: [
+        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 31484712, "1.4.1+L2"),
+        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 31484715, "1.4.1"),
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
             28092011,
@@ -410,6 +420,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 595211, "1.3.0"),
     ],
     EthereumNetwork.BASE_GOERLI_TESTNET: [
+        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 7330635, "1.4.1+L2"),
+        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 7330643, "1.4.1"),
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 938848, "1.3.0+L2"),
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 939064, "1.3.0"),
     ],
@@ -475,6 +487,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 6333172, "1.3.0"),
     ],
     EthereumNetwork.SEPOLIA: [
+        ("0x29fcb43b46531bca003ddc8fcb67ffe91900c762", 3921532, "1.4.1+L2"),
+        ("0x41675c099f32341bf84bfc5382af534df5c7461a", 3921533, "1.4.1"),
         (
             "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
             2086878,
@@ -627,6 +641,7 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
 
 PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     EthereumNetwork.MAINNET: [
+        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 17440707),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             14981216,
@@ -646,6 +661,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x12302fE9c02ff50939BaAaaf415fc226C078613C", 4110083),
     ],
     EthereumNetwork.GOERLI: [
+        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 8681525),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             6900531,
@@ -665,6 +681,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x12302fE9c02ff50939BaAaaf415fc226C078613C", 10629898),
     ],
     EthereumNetwork.GNOSIS: [
+        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 27419153),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             27679953,
@@ -685,6 +702,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x76E2cFc1F5Fa8F6a5b3fC4c8F4788F0116861F9B", 6876681),
     ],
     EthereumNetwork.POLYGON: [
+        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 40683009),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             34504003,
@@ -730,6 +748,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 147),  # v1.3.0
     ],
     EthereumNetwork.BINANCE_SMART_CHAIN_MAINNET: [
+        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 28092030),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             28059981,
@@ -883,6 +902,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 595181),  # v1.3.0
     ],
     EthereumNetwork.BASE_GOERLI_TESTNET: [
+        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 7330598),  # v1.4.1
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 938696),  # v1.3.0
     ],
     EthereumNetwork.KAVA_EVM: [
@@ -932,6 +952,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 6333172),  # v1.3.0
     ],
     EthereumNetwork.SEPOLIA: [
+        ("0x4e1dcf7ad4e460cfd30791ccc4f9c8a4f820ec67", 3312223),  # v1.4.1
         (
             "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
             2087031,


### PR DESCRIPTION
Closes #684 
- Add Mainnet addresses 
- Add Goerli addresses 
- Add BNB addresses
- Add Gnosis chain addresses
- Add Polygon addresses
- Add Sepolia addresses
- Add Base Goerli addresses

Related issues:
- https://github.com/safe-global/safe-deployments/issues/327
- https://github.com/safe-global/safe-deployments/issues/325