### PR TITLE
Fix: `run_tests.sh` script

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,3 +7,12 @@ services:
       - "5432:5432"
     environment:
       POSTGRES_PASSWORD: postgres
+  ganache:
+    image: trufflesuite/ganache:latest
+    ports:
+      - "8545:8545"
+    command: --defaultBalanceEther 10000 --gasLimit 10000000 -a 30 --chain.chainId 1337 --chain.networkId 1337 -d
+    networks:
+      default:
+        aliases:
+          - ganache

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,14 +1,6 @@
 #!/bin/sh
 # Postgresql and ganache-cli must be running for the tests
 
-ps aux | grep ganache-cli | grep -v grep > /dev/null
-if [ $? -eq 1 ]; then
-    echo 'Running Ganache-Cli'
-    ganache-cli --defaultBalanceEther 10000 --gasLimit 10000000 -a 30 --chain.chainId 1337 --chain.networkId 1337 -d > /dev/null &
-    GANACHE_PID=$!
-    sleep 3
-fi
-
 docker ps | grep '\->5432' > /dev/null
 if [ $? -eq 1 ]; then
     docker-compose up -d db
@@ -18,15 +10,19 @@ else
     DATABASE_UP=0
 fi
 
+docker ps | grep '\->8545' > /dev/null
+if [ $? -eq 1 ]; then
+    docker-compose up -d ganache
+    sleep 3
+    GANACHE_UP=1
+else
+    GANACHE_UP=0
+fi
+
 
 # python manage.py test --settings=config.settings.test
 DJANGO_SETTINGS_MODULE=config.settings.test pytest
 
-if [ ${GANACHE_PID:-0} -gt 1 ]; then
-    echo 'Killing opened Ganache-Cli'
-    kill $GANACHE_PID
-fi
-
-if [ $DATABASE_UP -eq 1 ]; then
+if [ $DATABASE_UP -eq 1 ] || [ $GANACHE_UP -eq 1 ]; then
     docker-compose down
 fi


### PR DESCRIPTION
This PR:
- Do not rely on the globally installed `ganache-cli` package, use docker service
- Fixes #696 
