### PR TITLE
Add get_safes from owner address

### DIFF
--- a/gnosis/safe/api/transaction_service_api.py
+++ b/gnosis/safe/api/transaction_service_api.py
@@ -165,6 +165,17 @@ class TransactionServiceApi(SafeBaseAPI):
             raise SafeAPIException(f"Cannot get delegates: {response.content}")
         return response.json().get("results", [])
 
+    def get_safes(self, owner_address: ChecksumAddress) -> List[ChecksumAddress]:
+        """
+
+        :param owner_address:
+        :return: return a List of Safe addresses which the owner_address is an owner
+        """
+        response = self._get_request(f"/api/v1/owners/{owner_address}/safes/")
+        if not response.ok:
+            raise SafeAPIException(f"Cannot get delegates: {response.content}")
+        return response.json().get("safes", [])
+
     def post_signatures(self, safe_tx_hash: bytes, signatures: bytes) -> bool:
         safe_tx_hash = HexBytes(safe_tx_hash).hex()
         response = self._post_request(

--- a/gnosis/safe/api/transaction_service_api.py
+++ b/gnosis/safe/api/transaction_service_api.py
@@ -103,6 +103,11 @@ class TransactionServiceApi(SafeBaseAPI):
             )
 
     def get_balances(self, safe_address: str) -> List[Dict[str, Any]]:
+        """
+
+        :param safe_address:
+        :return: a list of balances for provided Safe
+        """
         response = self._get_request(f"/api/v1/safes/{safe_address}/balances/")
         if not response.ok:
             raise SafeAPIException(f"Cannot get balances: {response.content}")
@@ -152,6 +157,11 @@ class TransactionServiceApi(SafeBaseAPI):
         return safe_tx, tx_hash
 
     def get_transactions(self, safe_address: ChecksumAddress) -> List[Dict[str, Any]]:
+        """
+
+        :param safe_address:
+        :return: a list of transactions for provided Safe
+        """
         response = self._get_request(
             f"/api/v1/safes/{safe_address}/multisig-transactions/"
         )
@@ -160,6 +170,11 @@ class TransactionServiceApi(SafeBaseAPI):
         return response.json().get("results", [])
 
     def get_delegates(self, safe_address: ChecksumAddress) -> List[Dict[str, Any]]:
+        """
+
+        :param safe_address:
+        :return: a list of delegates for provided Safe
+        """
         response = self._get_request(f"/api/v1/delegates/?safe={safe_address}")
         if not response.ok:
             raise SafeAPIException(f"Cannot get delegates: {response.content}")
@@ -169,7 +184,7 @@ class TransactionServiceApi(SafeBaseAPI):
         """
 
         :param owner_address:
-        :return: return a List of Safe addresses which the owner_address is an owner
+        :return: a List of Safe addresses which the owner_address is an owner
         """
         response = self._get_request(f"/api/v1/owners/{owner_address}/safes/")
         if not response.ok:
@@ -177,6 +192,12 @@ class TransactionServiceApi(SafeBaseAPI):
         return response.json().get("safes", [])
 
     def post_signatures(self, safe_tx_hash: bytes, signatures: bytes) -> bool:
+        """
+        Create a new confirmation with provided signature for the given safe_tx_hash
+        :param safe_tx_hash:
+        :param signatures:
+        :return: True if new confirmation was created
+        """
         safe_tx_hash = HexBytes(safe_tx_hash).hex()
         response = self._post_request(
             f"/api/v1/multisig-transactions/{safe_tx_hash}/confirmations/",

--- a/gnosis/safe/api/transaction_service_api.py
+++ b/gnosis/safe/api/transaction_service_api.py
@@ -180,7 +180,9 @@ class TransactionServiceApi(SafeBaseAPI):
             raise SafeAPIException(f"Cannot get delegates: {response.content}")
         return response.json().get("results", [])
 
-    def get_safes(self, owner_address: ChecksumAddress) -> List[ChecksumAddress]:
+    def get_safes_for_owner(
+        self, owner_address: ChecksumAddress
+    ) -> List[ChecksumAddress]:
         """
 
         :param owner_address:

--- a/gnosis/safe/tests/api/test_transaction_service_api.py
+++ b/gnosis/safe/tests/api/test_transaction_service_api.py
@@ -103,7 +103,7 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
         transactions = self.transaction_service_api.get_transactions(self.safe_address)
         self.assertIsInstance(transactions, list)
 
-    def test_get_safe(self):
+    def test_get_safes_for_owner(self):
         owner_address = "0x5aC255889882aCd3da2aA939679E3f3d4cea221e"
-        safes = self.transaction_service_api.get_safes(owner_address)
+        safes = self.transaction_service_api.get_safes_for_owner(owner_address)
         self.assertIn(self.safe_address, safes)

--- a/gnosis/safe/tests/api/test_transaction_service_api.py
+++ b/gnosis/safe/tests/api/test_transaction_service_api.py
@@ -102,3 +102,8 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
     def test_get_transactions(self):
         transactions = self.transaction_service_api.get_transactions(self.safe_address)
         self.assertIsInstance(transactions, list)
+
+    def test_get_safe(self):
+        owner_address = "0x5aC255889882aCd3da2aA939679E3f3d4cea221e"
+        safes = self.transaction_service_api.get_safes(owner_address)
+        self.assertIn(self.safe_address, safes)


### PR DESCRIPTION
# Description
Get Safes from an owner was missing on transaction_api client.
This PR add the missing function. 
 
