### PR TITLE
Skip test if fail due liquidity changes

### DIFF
--- a/gnosis/eth/tests/oracles/test_uniswap_v3.py
+++ b/gnosis/eth/tests/oracles/test_uniswap_v3.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+import pytest
 from eth_account import Account
 
 from ... import EthereumClient
@@ -15,6 +16,7 @@ from ..utils import just_test_if_mainnet_node
 
 
 class TestUniswapV3Oracle(EthereumTestCaseMixin, TestCase):
+    @pytest.mark.xfail(reason="Could fail due to liquidity changes")
     def test_get_price(self):
         mainnet_node = just_test_if_mainnet_node()
         ethereum_client = EthereumClient(mainnet_node)


### PR DESCRIPTION
We expect that one of the tokens have not liquidity but this is something that can change like currently happens. 