### PR TITLE
Rename Gnosis Protocol libraries to Cowswap

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -184,21 +184,21 @@ To work with Multisig Transactions:
   safe_tx.call()  # Check it works
   safe_tx.execute(tx_sender_private_key)
 
-Protocol
+CowSwap
 ~~~~~~~~
-On ``gnosis.protocol`` there're classes to work with `Gnosis Protocol v2 <https://docs.cowswap.app>`_
+On ``gnosis.cowswap`` there're classes to work with `CowSwap v2 <https://docs.cowswap.app>`_
 
 .. code-block:: python
 
   import time
   from gnosis.eth import EthereumNetwork
-  from gnosis.protocol import Order, OrderKind, GnosisProtocolAPI
+  from gnosis.cowswap import Order, OrderKind, CowSwapAPI
 
-  account_address = ''  # Fill with checksummed version of a Gnosis Protocol user address
+  account_address = ''  # Fill with checksummed version of a CowSwap user address
   account_private_key = ''  # Fill with private key of a user address
-  gnosis_protocol_api = GnosisProtocolAPI(EthereumNetwork.RINKEBY)
-  print(gnosis_protocol_api.get_trades(owner=account_address))
-  buy_amount = gnosis_protocol_api.get_estimated_amount(base_token, quote_token, OrderKind.SELL, sell_amount)
+  cow_swap_api = CowSwapAPI(EthereumNetwork.RINKEBY)
+  print(cow_swap_api.get_trades(owner=account_address))
+  buy_amount = cow_swap_api.get_estimated_amount(base_token, quote_token, OrderKind.SELL, sell_amount)
   valid_to = int(time.time() + (24 * 60 * 60))  # Order valid for 1 day
   order = Order(
         sellToken=base_token,
@@ -207,11 +207,11 @@ On ``gnosis.protocol`` there're classes to work with `Gnosis Protocol v2 <https:
         sellAmount=sell_amount,
         buyAmount=buy_amount,
         validTo=valid_to,  # timestamp
-        appData=ipfs_hash,  # IPFS hash for metadata
+        appData={},  # Dict with CowSwap AppData schema definition (https://github.com/cowprotocol/app-data)
         fee_amount=0,  # If set to `0` it will be autodetected
         kind='sell',  # `sell` or `buy`
         partiallyFillable=True,  # `True` or `False`
         sellTokenBalance='erc20',  # `erc20`, `external` or `internal`
         buyTokenBalance='erc20',  # `erc20` or `internal`
     )
-  gnosis_protocol_api.place_order(order, account_private_key)
+  cow_swap_api.place_order(order, account_private_key)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -186,7 +186,7 @@ To work with Multisig Transactions:
 
 CowSwap
 ~~~~~~~~
-On ``gnosis.cowswap`` there're classes to work with `CowSwap v2 <https://docs.cowswap.app>`_
+On ``gnosis.cowswap`` there're classes to work with `CowSwap <https://docs.cowswap.app>`_
 
 .. code-block:: python
 
@@ -196,7 +196,7 @@ On ``gnosis.cowswap`` there're classes to work with `CowSwap v2 <https://docs.co
 
   account_address = ''  # Fill with checksummed version of a CowSwap user address
   account_private_key = ''  # Fill with private key of a user address
-  cow_swap_api = CowSwapAPI(EthereumNetwork.RINKEBY)
+  cow_swap_api = CowSwapAPI(EthereumNetwork.SEPOLIA)
   print(cow_swap_api.get_trades(owner=account_address))
   buy_amount = cow_swap_api.get_estimated_amount(base_token, quote_token, OrderKind.SELL, sell_amount)
   valid_to = int(time.time() + (24 * 60 * 60))  # Order valid for 1 day

--- a/gnosis/cowsap/__init__.py
+++ b/gnosis/cowsap/__init__.py
@@ -1,9 +1,9 @@
 # flake8: noqa F401
-from .gnosis_protocol_api import GnosisProtocolAPI
+from .cow_swap_api import CowSwapAPI
 from .order import Order, OrderKind
 
 __all__ = [
-    "GnosisProtocolAPI",
+    "CowSwapAPI",
     "Order",
     "OrderKind",
 ]

--- a/gnosis/cowsap/cow_swap_api.py
+++ b/gnosis/cowsap/cow_swap_api.py
@@ -1,3 +1,4 @@
+import json
 from functools import cached_property
 from typing import Any, Dict, List, Optional, TypedDict, Union, cast
 
@@ -5,7 +6,6 @@ import requests
 from eth_account import Account
 from eth_account.messages import encode_defunct
 from eth_typing import AnyAddress, ChecksumAddress, HexStr
-from hexbytes import HexBytes
 
 from gnosis.eth import EthereumNetwork, EthereumNetworkNotSupported
 from gnosis.eth.eip712 import eip712_encode_hash
@@ -37,21 +37,19 @@ class ErrorResponse(TypedDict):
     description: str
 
 
-class GnosisProtocolAPI:
+class CowSwapAPI:
     """
-    Client for GnosisProtocol API. More info: https://docs.cowswap.exchange/
+    Client for CowSwap API. More info: https://docs.cowswap.exchange/
     """
 
     SETTLEMENT_CONTRACT_ADDRESSES = {
         EthereumNetwork.MAINNET: "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
-        EthereumNetwork.GOERLI: "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
         EthereumNetwork.GNOSIS: "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
         EthereumNetwork.SEPOLIA: "0x9008D19f58AAbD9eD0D60971565AA8510560ab41",
     }
 
     API_BASE_URLS = {
         EthereumNetwork.MAINNET: "https://api.cow.fi/mainnet",
-        EthereumNetwork.GOERLI: "https://api.cow.fi/goerli",
         EthereumNetwork.GNOSIS: "https://api.cow.fi/xdai",
         EthereumNetwork.SEPOLIA: "https://api.cow.fi/sepolia",
     }
@@ -60,7 +58,7 @@ class GnosisProtocolAPI:
         self.network = ethereum_network
         if self.network not in self.API_BASE_URLS:
             raise EthereumNetworkNotSupported(
-                f"{self.network.name} network not supported by Gnosis Protocol"
+                f"{self.network.name} network not supported by CowSwap"
             )
         self.settlement_contract_address = self.SETTLEMENT_CONTRACT_ADDRESSES[
             self.network
@@ -93,8 +91,6 @@ class GnosisProtocolAPI:
         """
         if self.network == EthereumNetwork.GNOSIS:  # WXDAI
             return ChecksumAddress("0xe91D153E0b41518A2Ce8Dd3D7944Fa863463a97d")
-        if self.network == EthereumNetwork.GOERLI:  # Goerli WETH9
-            return ChecksumAddress("0xB4FBF271143F4FBf7B91A5ded31805e42b2208d6")
 
         # Mainnet WETH9
         return ChecksumAddress("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
@@ -108,9 +104,7 @@ class GnosisProtocolAPI:
             "buyToken": order.buyToken.lower(),
             "sellAmountAfterFee": str(order.sellAmount),
             # "validTo": order.validTo,
-            "appData": HexBytes(order.appData).hex()
-            if isinstance(order.appData, bytes)
-            else order.appData,
+            "appData": json.dumps(order.appData),
             "feeAmount": str(order.feeAmount),
             "kind": order.kind,
             "partiallyFillable": order.partiallyFillable,
@@ -169,9 +163,7 @@ class GnosisProtocolAPI:
             "sellAmount": str(order.sellAmount),
             "buyAmount": str(order.buyAmount),
             "validTo": order.validTo,
-            "appData": HexBytes(order.appData).hex()
-            if isinstance(order.appData, bytes)
-            else order.appData,
+            "appData": json.dumps(order.appData),
             "feeAmount": str(order.feeAmount),
             "kind": order.kind,
             "partiallyFillable": order.partiallyFillable,
@@ -245,7 +237,7 @@ class GnosisProtocolAPI:
             sellAmount=amount_wei * 10 if kind == OrderKind.SELL else 0,
             buyAmount=amount_wei * 10 if kind == OrderKind.BUY else 0,
             validTo=0,  # Valid for 1 hour
-            appData="0x0000000000000000000000000000000000000000000000000000000000000000",
+            appData={},
             feeAmount=0,
             kind=kind.name.lower(),  # `sell` or `buy`
             partiallyFillable=False,

--- a/gnosis/cowsap/order.py
+++ b/gnosis/cowsap/order.py
@@ -1,8 +1,9 @@
+import json
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Dict, Literal
 
-from eth_typing import ChecksumAddress, Hash32
+from eth_typing import ChecksumAddress
 
 
 @dataclass
@@ -13,7 +14,7 @@ class Order:
     sellAmount: int
     buyAmount: int
     validTo: int
-    appData: Hash32
+    appData: Dict
     feeAmount: int
     kind: Literal["sell", "buy"]
     partiallyFillable: bool
@@ -40,7 +41,7 @@ class Order:
                 {"name": "sellAmount", "type": "uint256"},
                 {"name": "buyAmount", "type": "uint256"},
                 {"name": "validTo", "type": "uint32"},
-                {"name": "appData", "type": "bytes32"},
+                {"name": "appData", "type": "string"},
                 {"name": "feeAmount", "type": "uint256"},
                 {"name": "kind", "type": "string"},
                 {"name": "partiallyFillable", "type": "bool"},
@@ -55,7 +56,7 @@ class Order:
             "sellAmount": self.sellAmount,
             "buyAmount": self.buyAmount,
             "validTo": self.validTo,
-            "appData": self.appData,
+            "appData": json.dumps(self.appData),
             "feeAmount": self.feeAmount,
             "kind": self.kind,
             "partiallyFillable": self.partiallyFillable,
@@ -67,7 +68,7 @@ class Order:
             "types": types,
             "primaryType": "Order",
             "domain": {
-                "name": "Gnosis Protocol",
+                "name": "CowSwap",
                 "version": "v2",
                 "chainId": chain_id,
                 "verifyingContract": verifying_contract,

--- a/gnosis/eth/oracles/cowswap.py
+++ b/gnosis/eth/oracles/cowswap.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Optional
 
-from gnosis.protocol import GnosisProtocolAPI, OrderKind
+from gnosis.cowsap import CowSwapAPI, OrderKind
 
 from .. import EthereumClient, EthereumNetworkNotSupported
 from .exceptions import CannotGetPriceFromOracle
@@ -27,7 +27,7 @@ class CowswapOracle(PriceOracle):
         """
         self.ethereum_client = ethereum_client
         self.w3 = ethereum_client.w3
-        self.api = GnosisProtocolAPI(ethereum_client.get_network())
+        self.api = CowSwapAPI(ethereum_client.get_network())
 
     @classmethod
     def is_available(
@@ -39,7 +39,7 @@ class CowswapOracle(PriceOracle):
         :return: `True` if CowSwap is available for the EthereumClient provided, `False` otherwise
         """
         try:
-            GnosisProtocolAPI(ethereum_client.get_network())
+            CowSwapAPI(ethereum_client.get_network())
             return True
         except EthereumNetworkNotSupported:
             return False

--- a/scripts/cowswap/cow_swap_cli.py
+++ b/scripts/cowswap/cow_swap_cli.py
@@ -20,7 +20,7 @@ if __name__ == "__main__":
         print("Set PRIVATE_KEY as an environment variable")
         sys.exit(1)
 
-    parser = argparse.ArgumentParser(description="Place orders on CowSwap V2")
+    parser = argparse.ArgumentParser(description="Place orders on CowSwap")
     parser.add_argument(
         "--network",
         default=EthereumNetwork.RINKEBY.name,

--- a/scripts/cowswap/cow_swap_cli.py
+++ b/scripts/cowswap/cow_swap_cli.py
@@ -1,6 +1,3 @@
-from gnosis.eth.utils import fast_keccak
-
-
 def confirm_prompt(question: str) -> bool:
     reply = None
     while reply not in ("y", "n"):
@@ -14,16 +11,16 @@ if __name__ == "__main__":
     import sys
     import time
 
+    from gnosis.cowsap import CowSwapAPI, Order, OrderKind
     from gnosis.eth import EthereumNetwork
     from gnosis.eth.constants import NULL_ADDRESS
-    from gnosis.protocol import GnosisProtocolAPI, Order, OrderKind
 
     PRIVATE_KEY = os.environ.get("PRIVATE_KEY")
     if not PRIVATE_KEY:
         print("Set PRIVATE_KEY as an environment variable")
         sys.exit(1)
 
-    parser = argparse.ArgumentParser(description="Place orders on Gnosis Protocol V2")
+    parser = argparse.ArgumentParser(description="Place orders on CowSwap V2")
     parser.add_argument(
         "--network",
         default=EthereumNetwork.RINKEBY.name,
@@ -38,8 +35,8 @@ if __name__ == "__main__":
     from_token = args.from_token
     to_token = args.to_token
     amount_wei = args.amount_wei
-    gnosis_protocol_api = GnosisProtocolAPI(EthereumNetwork[args.network.upper()])
-    buy_amount_response = gnosis_protocol_api.get_estimated_amount(
+    cow_swap_api = CowSwapAPI(EthereumNetwork[args.network.upper()])
+    buy_amount_response = cow_swap_api.get_estimated_amount(
         from_token, to_token, OrderKind.SELL, amount_wei
     )
 
@@ -55,7 +52,7 @@ if __name__ == "__main__":
         sellAmount=amount_wei,
         buyAmount=buy_amount,
         validTo=int(time.time()) + (60 * 60),  # Valid for 1 hour
-        appData=fast_keccak(text="gp-cli"),
+        appData={"version": "1.2.2", "appCode": "CowSwap CLI", "metadata": {}},
         feeAmount=0,
         kind="sell",  # `sell` or `buy`
         partiallyFillable=not args.require_full_fill,
@@ -63,12 +60,12 @@ if __name__ == "__main__":
         buyTokenBalance="erc20",  # `erc20` or `internal`
     )
 
-    order.feeAmount = gnosis_protocol_api.get_fee(order)
+    order.feeAmount = cow_swap_api.get_fee(order)
 
     if confirm_prompt(
         f"Exchanging {amount_wei} {from_token} to {buy_amount} {to_token}?"
     ):
-        result = gnosis_protocol_api.place_order(order, PRIVATE_KEY)
+        result = cow_swap_api.place_order(order, PRIVATE_KEY)
         if isinstance(result, dict):
             print(f"Cannot place order {result}")
         else:


### PR DESCRIPTION
closes https://github.com/safe-global/safe-eth-py/issues/777

Points of interest:

- Changes indicated in the task are made.

- The type of the "appData" parameter is changed to string. CowSwap API requires a [string](https://docs.cow.fi/cow-protocol/reference/apis/orderbook) in that parameter instead of the existing hash. A JSON string with the format defined [here](https://github.com/cowprotocol/app-data) should be specified in the parameter.

- The existing configuration for using Goerli Testnet is removed.

- The necessary modifications are made to the TestEtherscanClient based on the above and the test skip is removed.

- The CLI client is moved to the scripts folder.