### PR TITLE
Add Uint96Field

### DIFF
--- a/gnosis/eth/django/models.py
+++ b/gnosis/eth/django/models.py
@@ -2,6 +2,7 @@ import binascii
 from typing import Optional, Union
 
 from django.core import exceptions
+from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -132,6 +133,18 @@ class Uint256Field(models.DecimalField):
             return value
         return int(value)
 
+    def pre_save(self, model_instance, add):
+        """
+        Override pre_save to ensure that field is unsigned before save it
+        :param model_instance:
+        :param add:
+        :return:
+        """
+        value = getattr(model_instance, self.attname)
+        if value is not None and value < 0:
+            raise ValidationError("Value must be an unsigned 256-bit integer")
+        return super().pre_save(model_instance, add)
+
 
 class Uint96Field(models.DecimalField):
     """
@@ -156,6 +169,18 @@ class Uint96Field(models.DecimalField):
         if value is None:
             return value
         return int(value)
+
+    def pre_save(self, model_instance, add):
+        """
+        Override pre_save to ensure that field is unsigned before save it
+        :param model_instance:
+        :param add:
+        :return:
+        """
+        value = getattr(model_instance, self.attname)
+        if value is not None and value < 0:
+            raise ValidationError("Value must be an unsigned 96-bit integer")
+        return super().pre_save(model_instance, add)
 
 
 class HexField(models.CharField):

--- a/gnosis/eth/django/models.py
+++ b/gnosis/eth/django/models.py
@@ -118,7 +118,7 @@ class Uint256Field(models.DecimalField):
     description = _("Ethereum uint256 number")
 
     def __init__(self, *args, **kwargs):
-        kwargs["max_digits"] = 79  # 2 ** 256 is 78 digits
+        kwargs["max_digits"] = 78  # 2 ** 256 is 78 digits
         kwargs["decimal_places"] = 0
         super().__init__(*args, **kwargs)
 

--- a/gnosis/eth/django/models.py
+++ b/gnosis/eth/django/models.py
@@ -133,6 +133,31 @@ class Uint256Field(models.DecimalField):
         return int(value)
 
 
+class Uint96Field(models.DecimalField):
+    """
+    Field to store ethereum uint96 values. Uses Decimal db type without decimals to store
+    in the database, but retrieve as `int` instead of `Decimal` (https://docs.python.org/3/library/decimal.html)
+    """
+
+    description = _("Ethereum uint96 number")
+
+    def __init__(self, *args, **kwargs):
+        kwargs["max_digits"] = 29  # 2 ** 96 is 29 digits
+        kwargs["decimal_places"] = 0
+        super().__init__(*args, **kwargs)
+
+    def deconstruct(self):
+        name, path, args, kwargs = super().deconstruct()
+        del kwargs["max_digits"]
+        del kwargs["decimal_places"]
+        return name, path, args, kwargs
+
+    def from_db_value(self, value, expression, connection):
+        if value is None:
+            return value
+        return int(value)
+
+
 class HexField(models.CharField):
     """
     Field to store hex values (without 0x). Returns hex with 0x prefix.

--- a/gnosis/eth/django/tests/models.py
+++ b/gnosis/eth/django/tests/models.py
@@ -5,6 +5,7 @@ from ..models import (
     EthereumAddressV2Field,
     Keccak256Field,
     Sha3HashField,
+    Uint96Field,
     Uint256Field,
 )
 
@@ -19,6 +20,10 @@ class EthereumAddressV2(models.Model):
 
 class Uint256(models.Model):
     value = Uint256Field(null=True)
+
+
+class Uint96(models.Model):
+    value = Uint96Field(null=True)
 
 
 class Sha3Hash(models.Model):

--- a/gnosis/eth/django/tests/test_models.py
+++ b/gnosis/eth/django/tests/test_models.py
@@ -60,7 +60,6 @@ class TestModels(TestCase):
         for value in [
             2,
             2**256,
-            2**260,
             25572735541615049941137326092682691158109824779649981270427004917341670006487,
             None,
         ]:
@@ -202,7 +201,7 @@ class TestModels(TestCase):
         self.assertIn(address, serialized)
 
     def test_serialize_uint256_field_to_json(self):
-        value = 2**260
+        value = 2**256
         Uint256.objects.create(value=value)
         serialized = serialize("json", Uint256.objects.all())
         # value should be in serialized data

--- a/gnosis/eth/django/tests/test_models.py
+++ b/gnosis/eth/django/tests/test_models.py
@@ -9,7 +9,14 @@ from web3 import Web3
 
 from ...constants import NULL_ADDRESS, SENTINEL_ADDRESS
 from ...utils import fast_is_checksum_address
-from .models import EthereumAddress, EthereumAddressV2, Keccak256Hash, Sha3Hash, Uint256
+from .models import (
+    EthereumAddress,
+    EthereumAddressV2,
+    Keccak256Hash,
+    Sha3Hash,
+    Uint96,
+    Uint256,
+)
 
 faker = Faker()
 
@@ -52,7 +59,6 @@ class TestModels(TestCase):
     def test_uint256_field(self):
         for value in [
             2,
-            -2,
             2**256,
             2**260,
             25572735541615049941137326092682691158109824779649981270427004917341670006487,
@@ -66,6 +72,30 @@ class TestModels(TestCase):
         with self.assertRaises(Exception):
             value = 2**263
             Uint256.objects.create(value=value)
+
+        # Signed
+        with self.assertRaises(ValidationError):
+            Uint256.objects.create(value=-2)
+
+    def test_uint96_field(self):
+        for value in [
+            2,
+            2**96,
+            79228162514264337593543950336,
+            None,
+        ]:
+            uint96 = Uint96.objects.create(value=value)
+            uint96.refresh_from_db()
+            self.assertEqual(uint96.value, value)
+
+        # Overflow
+        with self.assertRaises(Exception):
+            value = 2**97
+            uint96.objects.create(value=value)
+
+        # Signed
+        with self.assertRaises(ValidationError):
+            Uint96.objects.create(value=-2)
 
     def test_sha3_hash_field(self):
         value_hexbytes = Web3.keccak(text=faker.name())


### PR DESCRIPTION
- Provide a django database field to fit with uint96 values. 
- Fix Uint256 field accepted  signed values overriding `pre_save` to ensure the value is unsigned. https://docs.djangoproject.com/en/5.0/howto/custom-model-fields/#preprocessing-values-before-saving