### PR TITLE
Rename enum SafeOperation to SafeOperationEnum

### DIFF
--- a/gnosis/safe/__init__.py
+++ b/gnosis/safe/__init__.py
@@ -1,4 +1,5 @@
 # flake8: noqa F401
+from .enums import SafeOperationEnum
 from .exceptions import (
     CannotEstimateGas,
     CouldNotPayGasWithEther,
@@ -11,7 +12,7 @@ from .exceptions import (
     SignatureNotProvidedByOwner,
 )
 from .proxy_factory import ProxyFactory
-from .safe import Safe, SafeOperation, SafeTx
+from .safe import Safe, SafeTx
 
 __all__ = [
     "CannotEstimateGas",
@@ -25,6 +26,6 @@ __all__ = [
     "SignatureNotProvidedByOwner",
     "ProxyFactory",
     "Safe",
-    "SafeOperation",
+    "SafeOperationEnum",
     "SafeTx",
 ]

--- a/gnosis/safe/enums.py
+++ b/gnosis/safe/enums.py
@@ -1,0 +1,7 @@
+from enum import Enum
+
+
+class SafeOperationEnum(Enum):
+    CALL = 0
+    DELEGATE_CALL = 1
+    CREATE = 2

--- a/gnosis/safe/safe.py
+++ b/gnosis/safe/safe.py
@@ -2,7 +2,6 @@ import dataclasses
 import math
 import os
 from abc import ABCMeta, abstractmethod
-from enum import Enum
 from functools import cached_property
 from logging import getLogger
 from typing import Callable, Dict, List, Optional, Union
@@ -41,17 +40,12 @@ from gnosis.eth.utils import (
 
 from ..eth.typing import EthereumData
 from .addresses import SAFE_SIMULATE_TX_ACCESSOR_ADDRESS
+from .enums import SafeOperationEnum
 from .exceptions import CannotEstimateGas, CannotRetrieveSafeInfoException
 from .safe_creator import SafeCreator
 from .safe_tx import SafeTx
 
 logger = getLogger(__name__)
-
-
-class SafeOperation(Enum):
-    CALL = 0
-    DELEGATE_CALL = 1
-    CREATE = 2
 
 
 @dataclasses.dataclass
@@ -760,7 +754,7 @@ class Safe(SafeCreator, ContractBase, metaclass=ABCMeta):
         to: ChecksumAddress,
         value: int,
         data: bytes,
-        operation: int = SafeOperation.CALL.value,
+        operation: int = SafeOperationEnum.CALL.value,
         safe_tx_gas: int = 0,
         base_gas: int = 0,
         gas_price: int = 0,

--- a/gnosis/safe/serializers.py
+++ b/gnosis/safe/serializers.py
@@ -11,7 +11,7 @@ from gnosis.eth.constants import (
 )
 from gnosis.eth.django.serializers import EthereumAddressField, HexadecimalField
 
-from .safe import SafeOperation
+from .enums import SafeOperationEnum
 
 
 class SafeSignatureSerializer(serializers.Serializer):
@@ -74,7 +74,7 @@ class SafeMultisigEstimateTxSerializer(serializers.Serializer):
 
     def validate_operation(self, value):
         try:
-            return SafeOperation(value).value
+            return SafeOperationEnum(value).value
         except ValueError:
             raise ValidationError("Unknown operation")
 
@@ -87,7 +87,7 @@ class SafeMultisigEstimateTxSerializer(serializers.Serializer):
         if not data["to"] and not data["data"]:
             raise ValidationError("`data` and `to` cannot both be null")
 
-        if data["operation"] == SafeOperation.CREATE.value:
+        if data["operation"] == SafeOperationEnum.CREATE.value:
             raise ValidationError(
                 "Operation CREATE not supported. Please use Gnosis Safe CreateLib"
             )

--- a/gnosis/safe/tests/test_safe.py
+++ b/gnosis/safe/tests/test_safe.py
@@ -10,13 +10,14 @@ from gnosis.eth.constants import GAS_CALL_DATA_BYTE, NULL_ADDRESS
 from gnosis.eth.contracts import get_safe_contract, get_sign_message_lib_contract
 from gnosis.eth.utils import get_empty_tx_params
 
+from ..enums import SafeOperationEnum
 from ..exceptions import (
     CannotEstimateGas,
     CannotRetrieveSafeInfoException,
     CouldNotPayGasWithToken,
     InvalidInternalTx,
 )
-from ..safe import Safe, SafeOperation, SafeV100, SafeV111, SafeV130, SafeV141
+from ..safe import Safe, SafeV100, SafeV111, SafeV130, SafeV141
 from ..signatures import signature_to_bytes, signatures_to_bytes
 from .safe_test_case import SafeTestCaseMixin
 
@@ -485,10 +486,10 @@ class TestSafe(SafeTestCaseMixin, TestCase):
         nester_data = nester_tx["data"]
 
         safe_tx_gas_no_call = safe.estimate_tx_gas_with_safe(
-            nester.address, 0, nester_data, SafeOperation.CALL.value
+            nester.address, 0, nester_data, SafeOperationEnum.CALL.value
         )
         safe_tx_gas = safe.estimate_tx_gas_by_trying(
-            nester.address, 0, nester_data, SafeOperation.CALL.value
+            nester.address, 0, nester_data, SafeOperationEnum.CALL.value
         )
         self.assertGreater(safe_tx_gas, safe_tx_gas_no_call)
 
@@ -496,7 +497,7 @@ class TestSafe(SafeTestCaseMixin, TestCase):
             nester.address,
             0,
             nester_data,
-            SafeOperation.CALL.value,
+            SafeOperationEnum.CALL.value,
             NULL_ADDRESS,
             safe_tx_gas,
         )
@@ -722,7 +723,7 @@ class TestSafe(SafeTestCaseMixin, TestCase):
             sign_message_lib_address,
             0,
             sign_message_data,
-            SafeOperation.DELEGATE_CALL.value,
+            SafeOperationEnum.DELEGATE_CALL.value,
         )
         safe_tx.sign(self.ethereum_test_account.key)
         safe_tx.execute(tx_sender_private_key=self.ethereum_test_account.key)

--- a/gnosis/safe/tests/test_safe_tx.py
+++ b/gnosis/safe/tests/test_safe_tx.py
@@ -6,9 +6,9 @@ from eth_account import Account
 from hexbytes import HexBytes
 
 from ...eth.utils import get_empty_tx_params
+from ..enums import SafeOperationEnum
 from ..exceptions import NotEnoughSafeTransactionGas, SignaturesDataTooShort
 from ..multi_send import MultiSendOperation, MultiSendTx
-from ..safe import SafeOperation
 from ..safe_tx import SafeTx
 from .safe_test_case import SafeTestCaseMixin
 
@@ -59,7 +59,7 @@ class TestSafeTx(SafeTestCaseMixin, TestCase):
             to,
             0,
             safe_multisend_data,
-            SafeOperation.DELEGATE_CALL.value,
+            SafeOperationEnum.DELEGATE_CALL.value,
             safe_tx_gas,
             base_gas,
             self.gas_price,


### PR DESCRIPTION
- Remove confusion between 4337 SafeOperation and the enum for SafeTx
