### PR TITLE
feat: add default singleton on Base

### DIFF
--- a/gnosis/safe/addresses.py
+++ b/gnosis/safe/addresses.py
@@ -412,7 +412,16 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 42293315, "1.3.0"),
     ],
     EthereumNetwork.BASE: [
-        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 595207, "1.3.0+L2"),
+        (
+            "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
+            595207,
+            "1.3.0+L2",
+        ),  # safe singleton address
+        (
+            "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+            2704166,
+            "1.3.0+L2",
+        ),  # default singleton address
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 595211, "1.3.0"),
         (
             "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
@@ -1180,7 +1189,14 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 42293264),  # v1.3.0
     ],
     EthereumNetwork.BASE: [
-        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 595181),  # v1.3.0
+        (
+            "0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC",
+            595181,
+        ),  # v1.3.0 safe singleton address
+        (
+            "0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2",
+            2156359,
+        ),  # v1.3.0 default singleton address
         ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 3024579),  # v1.4.1
     ],
     EthereumNetwork.BASE_GOERLI_TESTNET: [


### PR DESCRIPTION
The default singleton address on Base was missing: 

GnosisSafeL2
https://basescan.org/address/0x3E5c63644E683549055b9Be8653de26E0B4CD36E#code

GnosisSafeProxyFactory:
https://basescan.org/address/0xa6b71e26c5e0845f74c812102ca7114b6a896ab2

With this, could you also indicate if any other steps/prs are required to remove the `This Safe Account was created with an unsupported base contract. The web interface might not work correctly. We recommend using the command line interface instead.` message ? Thank you!