### PR TITLE
4337: Add method to get deployed account from receipt

### DIFF
--- a/gnosis/eth/account_abstraction/constants.py
+++ b/gnosis/eth/account_abstraction/constants.py
@@ -1,12 +1,19 @@
 from hexbytes import HexBytes
 
-# Entrypoint v0.6.0 and v0.7.0 deposited event
+# Entrypoint v0.6.0 and v0.7.0 events ----------------------------------------------------
+
+# AccountDeployed (index_topic_1 bytes32 userOpHash, index_topic_2 address sender, address factory, address paymaster)
+ACCOUNT_DEPLOYED_TOPIC = HexBytes(
+    "0xd51a9c61267aa6196961883ecf5ff2da6619c37dac0fa92122513fb32c032d2d"
+)
+
 # Deposited (index_topic_1 address account, uint256 totalDeposit)
 DEPOSIT_EVENT_TOPIC = HexBytes(
     "0x2da466a7b24304f47e87fa2e1e5a81b9831ce54fec19055ce277ca2f39ba42c4"
 )
 
-# Safe (L2 not required) >= 1.4.1 events
+# Safe (L2 not required) >= 1.4.1 events -------------------------------------------------
+
 # ExecutionFromModuleSuccess (index_topic_1 address module)
 EXECUTION_FROM_MODULE_SUCCESS_TOPIC = HexBytes(
     "0x6895c13664aa4f67288b25d7a21d7aaa34916e355fb9b6fae0a139a9085becb8"

--- a/gnosis/eth/account_abstraction/user_operation_receipt.py
+++ b/gnosis/eth/account_abstraction/user_operation_receipt.py
@@ -6,6 +6,7 @@ from hexbytes import HexBytes
 from web3.types import LogReceipt
 
 from gnosis.eth.account_abstraction.constants import (
+    ACCOUNT_DEPLOYED_TOPIC,
     DEPOSIT_EVENT_TOPIC,
     EXECUTION_FROM_MODULE_FAILURE_TOPIC,
     EXECUTION_FROM_MODULE_SUCCESS_TOPIC,
@@ -43,6 +44,19 @@ class UserOperationReceipt:
             user_operation_receipt_response["reason"],
             user_operation_receipt_response["logs"],
         )
+
+    def get_deployed_account(self) -> Optional[ChecksumAddress]:
+        """
+        :return: Deployed account in case a new account was deployed
+        """
+        for log in self.logs:
+            if (
+                len(log["topics"]) == 3
+                and HexBytes(log["topics"][0]) == ACCOUNT_DEPLOYED_TOPIC
+            ):
+                # Address is stored at the 40 last chars of the 3rd topic
+                return fast_to_checksum_address(log["topics"][2][-40:])
+        return None
 
     def get_deposit(self) -> int:
         """

--- a/gnosis/eth/tests/account_abstraction/test_user_operation_receipt.py
+++ b/gnosis/eth/tests/account_abstraction/test_user_operation_receipt.py
@@ -11,7 +11,13 @@ class TestUserOperation(TestCase):
             user_operation_receipt_mock["result"]
         )
 
-    def test_calculate_deposit(self):
+    def test_get_deployed_account(self):
+        self.assertEqual(
+            self.user_operation_receipt.get_deployed_account(),
+            self.user_operation_receipt.sender,
+        )
+
+    def test_get_deposit(self):
         expected_value = 759_940_285_250_436
         self.assertEqual(self.user_operation_receipt.get_deposit(), expected_value)
 


### PR DESCRIPTION
- Use `AccountDeployed` event to check if the account was indeed deployed