### PR TITLE
4337: Add get_chain_id

### DIFF
--- a/gnosis/eth/account_abstraction/bundler_client.py
+++ b/gnosis/eth/account_abstraction/bundler_client.py
@@ -108,6 +108,16 @@ class BundlerClient:
             "id": request_id,
         }
 
+    def get_chain_id(self):
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "eth_chainId",
+            "params": [],
+            "id": 1,
+        }
+        result = self._do_request(payload)
+        return int(result, 16)
+
     @lru_cache(maxsize=1024)
     def get_user_operation_by_hash(
         self, user_operation_hash: HexStr

--- a/gnosis/eth/tests/account_abstraction/test_e2e_bundler_client.py
+++ b/gnosis/eth/tests/account_abstraction/test_e2e_bundler_client.py
@@ -21,6 +21,9 @@ class TestE2EBundlerClient(TestCase):
 
         self.bundler = BundlerClient(bundler_client_url)
 
+    def test_get_chain_id(self):
+        self.assertGreater(self.bundler.get_chain_id(), 0)
+
     def test_get_user_operation_by_hash(self):
         user_operation_hash = safe_4337_user_operation_hash_mock.hex()
 


### PR DESCRIPTION
- It's very useful to know the `chain_id` of the bundler so we can check the expected network was configured
