### PR TITLE
Add pre-commit execution when creating automatic PRs

### DIFF
--- a/.github/scripts/github_adding_addresses/create_pr_with_new_address.py
+++ b/.github/scripts/github_adding_addresses/create_pr_with_new_address.py
@@ -231,7 +231,7 @@ def upsert_contract_address_master_copy(
             )
         else:
             new_entry = (
-                f'    ("{address}", {block_number}, "{version}"), # v{version}\n    '
+                f'    ("{address}", {block_number}, "{version}"),  # v{version}\n    '
             )
             updated_content = (
                 content[: match_network.start()]

--- a/.github/workflows/create_pr_with_new_address.yml
+++ b/.github/workflows/create_pr_with_new_address.yml
@@ -112,9 +112,7 @@ jobs:
     - name: Install dependencies
       if: steps.check-comment.outputs.result == 'true'
       run: |
-        pip install PyGithub
-        pip install safe-eth-py
-        pip install pre-commit
+        pip install PyGithub safe-eth-py pre-commit
         pre-commit install
 
     - name: Process Issue and Create PR

--- a/.github/workflows/create_pr_with_new_address.yml
+++ b/.github/workflows/create_pr_with_new_address.yml
@@ -114,6 +114,8 @@ jobs:
       run: |
         pip install PyGithub
         pip install safe-eth-py
+        pip install pre-commit
+        pre-commit install
 
     - name: Process Issue and Create PR
       if: steps.check-comment.outputs.result == 'true'
@@ -124,6 +126,29 @@ jobs:
         GITHUB_REPOSITORY_NAME: 'safe-global/safe-eth-py'
       run: |
         python .github/scripts/github_adding_addresses/create_pr_with_new_address.py
+
+    - uses: fregante/setup-git-user@v2
+
+    - name: Run pre-commit
+      if: steps.check-comment.outputs.result == 'true'
+      run: |
+        issue_inputs='${{ steps.get-issue-inputs.outputs.result }}'
+        chain_id=$(echo "$issue_inputs" | jq -r '.chainId')
+        version=$(echo "$issue_inputs" | jq -r '.version')
+        branch_name="add-new-chain-${chain_id}-${version}-addresses"
+        git pull origin main
+        git fetch
+        git checkout -b $branch_name origin/$branch_name
+
+        pre-commit run --all-files || true
+
+        if [[ $(git status --porcelain) ]]; then
+          git add .
+          git commit -m "Apply linter fixes"
+          git pull & git push
+        else
+          echo "No changes to commit."
+        fi
 
     - name: Add comment to issue
       if: steps.check-comment.outputs.result == 'true'

--- a/.github/workflows/validate_new_address_issue_input_data.yml
+++ b/.github/workflows/validate_new_address_issue_input_data.yml
@@ -64,9 +64,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install safe-eth-py
-        pip install validators
-        pip install tldextract
+        pip install safe-eth-py validators tldextract
 
     - name: Validate input data
       id: validate-input-data

--- a/.github/workflows/validate_new_address_issue_input_data.yml
+++ b/.github/workflows/validate_new_address_issue_input_data.yml
@@ -66,6 +66,7 @@ jobs:
       run: |
         pip install safe-eth-py
         pip install validators
+        pip install tldextract
 
     - name: Validate input data
       id: validate-input-data


### PR DESCRIPTION
Points of interest:

- Added pre-commit execution when creating automatic PRs of adding new addresses. In some times with very high block number the maximum line size of the linter is exceeded. This way we ensure that the CI process is not broken.

- Updated the way to check the urls of Blockscout and Etherscan clients. In some tests it has been detected that the netloc check was not sufficient.