### PR TITLE
Set version 6.0.0b27

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = safe-eth-py
-version = 6.0.0b26
+version = 6.0.0b27
 description = Safe Ecosystem Foundation utilities for Ethereum projects
 long_description = file: README.rst
 long_description_content_type = text/x-rst; charset=UTF-8


### PR DESCRIPTION
Set new version of safe-eth-py to includes: 

### 🏕 Features
* Add addresses 1.3.0 for chain RSS3_VSL_SEPOLIA_TESTNET by @github-actions in https://github.com/safe-global/safe-eth-py/pull/936
* Fix test get contract metadata by @moisses89 in https://github.com/safe-global/safe-eth-py/pull/938
* Add addresses 1.3.0 for chain RSS3_VSL_MAINNET by @github-actions in https://github.com/safe-global/safe-eth-py/pull/939
* Add addresses 1.3.0 for chain CROSSFI_TESTNET by @github-actions in https://github.com/safe-global/safe-eth-py/pull/940
* Fix linting addresses file by @falvaradorodriguez in https://github.com/safe-global/safe-eth-py/pull/941
* feat: add Blast Mainnet by @ElvisKrop in https://github.com/safe-global/safe-eth-py/pull/830
* feat: add Astar zKyoto support by @ElvisKrop in https://github.com/safe-global/safe-eth-py/pull/861
* Bump safe-deployments to v1.35.0 by @moisses89 in https://github.com/safe-global/safe-eth-py/pull/945
### 👒 Dependencies
* Bump pytest from 8.1.1 to 8.2.0 by @dependabot in https://github.com/safe-global/safe-eth-py/pull/944
* Bump coverage from 7.4.4 to 7.5.0 by @dependabot in https://github.com/safe-global/safe-eth-py/pull/942
* Bump faker from 24.11.0 to 24.14.1 by @dependabot in https://github.com/safe-global/safe-eth-py/pull/943