### PR TITLE
Allow query params to get_transactions api method

### DIFF
--- a/gnosis/safe/api/transaction_service_api/transaction_service_api.py
+++ b/gnosis/safe/api/transaction_service_api/transaction_service_api.py
@@ -1,6 +1,7 @@
 import logging
 import os
 from typing import Any, Dict, List, Optional, Tuple, Union
+from urllib.parse import urlencode
 
 from eth_account.signers.local import LocalAccount
 from eth_typing import ChecksumAddress, HexStr
@@ -168,15 +169,23 @@ class TransactionServiceApi(SafeBaseAPI):
             safe_tx.tx_hash = tx_hash
         return safe_tx, tx_hash
 
-    def get_transactions(self, safe_address: ChecksumAddress) -> List[Dict[str, Any]]:
+    def get_transactions(
+        self, safe_address: ChecksumAddress, **kwargs: Union[str, int, bool]
+    ) -> List[Dict[str, Any]]:
         """
 
         :param safe_address:
         :return: a list of transactions for provided Safe
         """
-        response = self._get_request(
-            f"/api/v1/safes/{safe_address}/multisig-transactions/"
-        )
+        url = f"/api/v1/safes/{safe_address}/multisig-transactions/"
+
+        if kwargs:
+            query_string = urlencode(
+                {key: f"{value}" for key, value in kwargs.items() if value is not None}
+            )
+            url += "?" + query_string
+
+        response = self._get_request(url)
         if not response.ok:
             raise SafeAPIException(f"Cannot get transactions: {response.content}")
         return response.json().get("results", [])

--- a/gnosis/safe/api/transaction_service_api/transaction_service_api.py
+++ b/gnosis/safe/api/transaction_service_api/transaction_service_api.py
@@ -181,7 +181,7 @@ class TransactionServiceApi(SafeBaseAPI):
 
         if kwargs:
             query_string = urlencode(
-                {key: f"{value}" for key, value in kwargs.items() if value is not None}
+                {key: str(value) for key, value in kwargs.items() if value is not None}
             )
             url += "?" + query_string
 

--- a/gnosis/safe/api/transaction_service_api/transaction_service_api.py
+++ b/gnosis/safe/api/transaction_service_api/transaction_service_api.py
@@ -170,7 +170,7 @@ class TransactionServiceApi(SafeBaseAPI):
         return safe_tx, tx_hash
 
     def get_transactions(
-        self, safe_address: ChecksumAddress, **kwargs: Union[str, int, bool]
+        self, safe_address: ChecksumAddress, **kwargs: Dict[str, Union[str, int, bool]]
     ) -> List[Dict[str, Any]]:
         """
 

--- a/gnosis/safe/tests/api/test_transaction_service_api.py
+++ b/gnosis/safe/tests/api/test_transaction_service_api.py
@@ -1,4 +1,5 @@
 from unittest import mock
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -103,6 +104,14 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
         transactions = self.transaction_service_api.get_transactions(self.safe_address)
         self.assertIsInstance(transactions, list)
         self.assertEqual(len(transactions), 6)
+
+        with patch.object(TransactionServiceApi, "_get_request") as mock_get_request:
+            self.transaction_service_api.get_transactions(
+                self.safe_address, limit=2, nonce__lt=30, failed=False
+            )
+
+        expected_url = f"/api/v1/safes/{self.safe_address}/multisig-transactions/?limit=2&nonce__lt=30&failed=False"
+        mock_get_request.assert_called_once_with(expected_url)
 
     def test_get_safes_for_owner(self):
         owner_address = "0x3066786706Ff0B6e71044e55074dBAE7D01573cB"


### PR DESCRIPTION
Closes https://github.com/safe-global/safe-eth-py/issues/890