### PR TITLE
Add validation for safe_tx_hash in tx service response

### DIFF
--- a/gnosis/safe/api/transaction_service_api/__init__.py
+++ b/gnosis/safe/api/transaction_service_api/__init__.py
@@ -1,5 +1,6 @@
-from .transaction_service_api import TransactionServiceApi
+from .transaction_service_api import (
+    ApiSafeTxHashNotMatchingException,
+    TransactionServiceApi,
+)
 
-__all__ = [
-    "TransactionServiceApi",
-]
+__all__ = ["TransactionServiceApi", "ApiSafeTxHashNotMatchingException"]

--- a/gnosis/safe/api/transaction_service_api/transaction_service_api.py
+++ b/gnosis/safe/api/transaction_service_api/transaction_service_api.py
@@ -167,6 +167,12 @@ class TransactionServiceApi(SafeBaseAPI):
         )
         if tx_hash:
             safe_tx.tx_hash = tx_hash
+
+        if safe_tx.safe_tx_hash != HexBytes(safe_tx_hash):
+            raise SafeAPIException(
+                f"The provided safe_tx_hash: {safe_tx_hash} doesn't match the safe_tx_hash: {safe_tx.safe_tx_hash.hex()} of the response transaction."
+            )
+
         return safe_tx, tx_hash
 
     def get_transactions(

--- a/gnosis/safe/api/transaction_service_api/transaction_service_api.py
+++ b/gnosis/safe/api/transaction_service_api/transaction_service_api.py
@@ -135,11 +135,9 @@ class TransactionServiceApi(SafeBaseAPI):
             safe_nonce=int(tx_raw["nonce"]),
             chain_id=self.network.value,
         )
-        tx_hash = (
+        safe_tx.tx_hash = (
             HexBytes(tx_raw["transactionHash"]) if tx_raw["transactionHash"] else None
         )
-        if tx_hash:
-            safe_tx.tx_hash = tx_hash
         return safe_tx
 
     def get_balances(self, safe_address: str) -> List[Dict[str, Any]]:

--- a/gnosis/safe/api/transaction_service_api/transaction_service_api.py
+++ b/gnosis/safe/api/transaction_service_api/transaction_service_api.py
@@ -145,7 +145,7 @@ class TransactionServiceApi(SafeBaseAPI):
 
         if safe_tx.safe_tx_hash != safe_tx_hash:
             raise ApiSafeTxHashNotMatchingException(
-                f"The provided safe_tx_hash: {safe_tx_hash.hex()} doesn't match the safe_tx_hash: {safe_tx.safe_tx_hash.hex()} of the response transaction."
+                f"API safe-tx-hash: {safe_tx_hash.hex()} doesn't match the calculated safe-tx-hash: {safe_tx.safe_tx_hash.hex()}"
             )
 
         return safe_tx
@@ -210,6 +210,7 @@ class TransactionServiceApi(SafeBaseAPI):
         transactions = response.json().get("results", [])
 
         if safe_tx_hash_arg := kwargs.get("safe_tx_hash", None):
+            # Validation that the calculated safe_tx_hash is the same as the safe_tx_hash provided for filter.
             safe_tx_hash = HexBytes(safe_tx_hash_arg)
             [
                 self._build_transaction_service_tx(safe_tx_hash, tx)

--- a/gnosis/safe/tests/api/test_transaction_service_api.py
+++ b/gnosis/safe/tests/api/test_transaction_service_api.py
@@ -9,7 +9,10 @@ from hexbytes import HexBytes
 from gnosis.eth import EthereumClient, EthereumNetwork, EthereumNetworkNotSupported
 from gnosis.eth.tests.ethereum_test_case import EthereumTestCaseMixin
 from gnosis.safe import SafeTx
-from gnosis.safe.api.transaction_service_api import TransactionServiceApi
+from gnosis.safe.api.transaction_service_api import (
+    ApiSafeTxHashNotMatchingException,
+    TransactionServiceApi,
+)
 
 from ...api import SafeAPIException
 from ..mocks.mock_transactions import transaction_data_mock, transaction_mock
@@ -109,13 +112,13 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             safe_tx_invalid_hash = (
                 "0x06c88df42a8ab64b2b2c5e2b5c8c4df384c267b39929a8416d1518db23f90000"
             )
-            with self.assertRaises(SafeAPIException) as context:
+            with self.assertRaises(ApiSafeTxHashNotMatchingException) as context:
                 self.transaction_service_api.get_transactions(
                     self.safe_address, safe_tx_hash=safe_tx_invalid_hash
                 )
-
+            safe_tx_hash_expected = transaction_mock.get("safeTxHash")
             self.assertIn(
-                f"The provided safe_tx_hash: {safe_tx_invalid_hash} doesn't match the safe_tx_hash of one or more response transactions.",
+                f"The provided safe_tx_hash: {safe_tx_invalid_hash} doesn't match the safe_tx_hash: {safe_tx_hash_expected} of the response transaction.",
                 str(context.exception),
             )
 
@@ -163,7 +166,7 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             safe_tx_invalid_hash = HexBytes(
                 "0x06c88df42a8ab64b2b2c5e2b5c8c4df384c267b39929a8416d1518db23f90000"
             )
-            with self.assertRaises(SafeAPIException) as context:
+            with self.assertRaises(ApiSafeTxHashNotMatchingException) as context:
                 self.transaction_service_api.get_safe_transaction(safe_tx_invalid_hash)
 
             safe_tx_hash_expected = transaction_mock.get("safeTxHash")

--- a/gnosis/safe/tests/api/test_transaction_service_api.py
+++ b/gnosis/safe/tests/api/test_transaction_service_api.py
@@ -118,7 +118,7 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
                 )
             safe_tx_hash_expected = transaction_mock.get("safeTxHash")
             self.assertIn(
-                f"The provided safe_tx_hash: {safe_tx_invalid_hash} doesn't match the safe_tx_hash: {safe_tx_hash_expected} of the response transaction.",
+                f"API safe-tx-hash: {safe_tx_invalid_hash} doesn't match the calculated safe-tx-hash: {safe_tx_hash_expected}",
                 str(context.exception),
             )
 
@@ -171,7 +171,7 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
 
             safe_tx_hash_expected = transaction_mock.get("safeTxHash")
             self.assertIn(
-                f"The provided safe_tx_hash: {safe_tx_invalid_hash.hex()} doesn't match the safe_tx_hash: {safe_tx_hash_expected} of the response transaction.",
+                f"API safe-tx-hash: {safe_tx_invalid_hash.hex()} doesn't match the calculated safe-tx-hash: {safe_tx_hash_expected}",
                 str(context.exception),
             )
 

--- a/gnosis/safe/tests/api/test_transaction_service_api.py
+++ b/gnosis/safe/tests/api/test_transaction_service_api.py
@@ -1,11 +1,17 @@
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import MagicMock, PropertyMock, patch
 
 from django.test import TestCase
 
+from hexbytes import HexBytes
+
 from gnosis.eth import EthereumClient, EthereumNetwork, EthereumNetworkNotSupported
 from gnosis.eth.tests.ethereum_test_case import EthereumTestCaseMixin
+from gnosis.safe import SafeTx
 from gnosis.safe.api.transaction_service_api import TransactionServiceApi
+
+from ...api import SafeAPIException
+from ..mocks.mock_transactions import transaction_data_mock, transaction_mock
 
 
 class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
@@ -41,51 +47,9 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             self.assertEqual(transaction_service_api.network, EthereumNetwork.GOERLI)
 
     def test_data_decoded_to_text(self):
-        test_data = {
-            "method": "multiSend",
-            "parameters": [
-                {
-                    "name": "transactions",
-                    "type": "bytes",
-                    "value": "0x00c68877b75c3f9b950a798f9c9df4cde121c432ed000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000247de7edef00000000000000000000000034cfac646f301356faa8b21e94227e3583fe3f5f00c68877b75c3f9b950a798f9c9df4cde121c432ed00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024f08a0323000000000000000000000000d5d82b6addc9027b22dca772aa68d5d74cdbdf44",
-                    "decodedValue": [
-                        {
-                            "operation": "CALL",
-                            "to": "0xc68877B75c3f9b950a798f9C9dF4cDE121C432eD",
-                            "value": 0,
-                            "data": "0x7de7edef00000000000000000000000034cfac646f301356faa8b21e94227e3583fe3f5f",
-                            "decodedData": {
-                                "method": "changeMasterCopy",
-                                "parameters": [
-                                    {
-                                        "name": "_masterCopy",
-                                        "type": "address",
-                                        "value": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
-                                    }
-                                ],
-                            },
-                        },
-                        {
-                            "operation": "CALL",
-                            "to": "0xc68877B75c3f9b950a798f9C9dF4cDE121C432eD",
-                            "value": 0,
-                            "data": "0xf08a0323000000000000000000000000d5d82b6addc9027b22dca772aa68d5d74cdbdf44",
-                            "decodedData": {
-                                "method": "setFallbackHandler",
-                                "parameters": [
-                                    {
-                                        "name": "handler",
-                                        "type": "address",
-                                        "value": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
-                                    }
-                                ],
-                            },
-                        },
-                    ],
-                }
-            ],
-        }
-        decoded_data_text = self.transaction_service_api.data_decoded_to_text(test_data)
+        decoded_data_text = self.transaction_service_api.data_decoded_to_text(
+            transaction_data_mock
+        )
         self.assertIn(
             "- changeMasterCopy: 0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
             decoded_data_text,
@@ -117,3 +81,47 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
         owner_address = "0x3066786706Ff0B6e71044e55074dBAE7D01573cB"
         safes = self.transaction_service_api.get_safes_for_owner(owner_address)
         self.assertListEqual(safes, [self.safe_address])
+
+    def test_get_safe_transaction(self):
+        safe_tx_hash = HexBytes(
+            "0x06c88df42a8ab64b2b2c5e2b5c8c4df384c267b39929a8416d1518db23f91783"
+        )
+        with patch.object(
+            TransactionServiceApi, "_get_request"
+        ) as mock_get_request, patch.object(
+            SafeTx, "safe_version", new_callable=PropertyMock
+        ) as mock_safe_version:
+            mock_safe_version.return_value = "1.4.1"
+            mock_get_request.return_value.ok = True
+            mock_get_request.return_value.json = MagicMock(
+                return_value=transaction_mock
+            )
+
+            safe_tx, tx_hash = self.transaction_service_api.get_safe_transaction(
+                safe_tx_hash
+            )
+            self.assertEqual(safe_tx.tx_hash, tx_hash)
+            self.assertEqual(safe_tx.safe_version, "1.4.1")
+            self.assertEqual(safe_tx.safe_tx_hash, safe_tx_hash)
+
+            # Test invalid hash
+            safe_tx_invalid_hash = HexBytes(
+                "0x06c88df42a8ab64b2b2c5e2b5c8c4df384c267b39929a8416d1518db23f90000"
+            )
+            with self.assertRaises(SafeAPIException) as context:
+                self.transaction_service_api.get_safe_transaction(safe_tx_invalid_hash)
+
+            safe_tx_hash_expected = transaction_mock.get("safeTxHash")
+            self.assertIn(
+                f"The provided safe_tx_hash: {safe_tx_invalid_hash.hex()} doesn't match the safe_tx_hash: {safe_tx_hash_expected} of the response transaction.",
+                str(context.exception),
+            )
+
+            # Test response not ok
+            mock_get_request.return_value.ok = False
+            with self.assertRaises(SafeAPIException) as context:
+                self.transaction_service_api.get_safe_transaction(safe_tx_hash)
+            self.assertIn(
+                f"Cannot get transaction with safe-tx-hash={safe_tx_hash.hex()}:",
+                str(context.exception),
+            )

--- a/gnosis/safe/tests/mocks/mock_transactions.py
+++ b/gnosis/safe/tests/mocks/mock_transactions.py
@@ -1,0 +1,106 @@
+transaction_data_mock = {
+    "method": "multiSend",
+    "parameters": [
+        {
+            "name": "transactions",
+            "type": "bytes",
+            "value": "0x00c68877b75c3f9b950a798f9c9df4cde121c432ed000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000247de7edef00000000000000000000000034cfac646f301356faa8b21e94227e3583fe3f5f00c68877b75c3f9b950a798f9c9df4cde121c432ed00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024f08a0323000000000000000000000000d5d82b6addc9027b22dca772aa68d5d74cdbdf44",
+            "decodedValue": [
+                {
+                    "operation": "CALL",
+                    "to": "0xc68877B75c3f9b950a798f9C9dF4cDE121C432eD",
+                    "value": 0,
+                    "data": "0x7de7edef00000000000000000000000034cfac646f301356faa8b21e94227e3583fe3f5f",
+                    "decodedData": {
+                        "method": "changeMasterCopy",
+                        "parameters": [
+                            {
+                                "name": "_masterCopy",
+                                "type": "address",
+                                "value": "0x34CfAC646f301356fAa8B21e94227e3583Fe3F5F",
+                            }
+                        ],
+                    },
+                },
+                {
+                    "operation": "CALL",
+                    "to": "0xc68877B75c3f9b950a798f9C9dF4cDE121C432eD",
+                    "value": 0,
+                    "data": "0xf08a0323000000000000000000000000d5d82b6addc9027b22dca772aa68d5d74cdbdf44",
+                    "decodedData": {
+                        "method": "setFallbackHandler",
+                        "parameters": [
+                            {
+                                "name": "handler",
+                                "type": "address",
+                                "value": "0xd5D82B6aDDc9027B22dCA772Aa68D5d74cdBdF44",
+                            }
+                        ],
+                    },
+                },
+            ],
+        }
+    ],
+}
+
+transaction_mock = {
+    "safe": "0xAedF684C1c41B51CbD228116e11484425d2FACB9",
+    "to": "0xAedF684C1c41B51CbD228116e11484425d2FACB9",
+    "value": "0",
+    "data": "0xe318b52b0000000000000000000000000000000000000000000000000000000000000001000000000000000000000000c6b82ba149cfa113f8f48d5e3b1f78e933e16dfd0000000000000000000000003066786706ff0b6e71044e55074dbae7d01573cb",
+    "operation": 0,
+    "gasToken": "0x0000000000000000000000000000000000000000",
+    "safeTxGas": 0,
+    "baseGas": 0,
+    "gasPrice": "0",
+    "refundReceiver": "0x0000000000000000000000000000000000000000",
+    "nonce": 5,
+    "executionDate": "2024-01-24T15:22:55Z",
+    "submissionDate": "2024-01-24T15:22:07.408155Z",
+    "modified": "2024-01-24T15:22:55Z",
+    "blockNumber": 32106343,
+    "transactionHash": "0x27ac6f19a73da17d632259563aafb5092ace7e44c932ca1ed2336b2da83b30ca",
+    "safeTxHash": "0x06c88df42a8ab64b2b2c5e2b5c8c4df384c267b39929a8416d1518db23f91783",
+    "proposer": "0xc6b82bA149CFA113f8f48d5E3b1F78e933e16DfD",
+    "executor": "0xc6b82bA149CFA113f8f48d5E3b1F78e933e16DfD",
+    "isExecuted": True,
+    "isSuccessful": True,
+    "ethGasPrice": "3219910388",
+    "maxFeePerGas": "3219910389",
+    "maxPriorityFeePerGas": "3219910378",
+    "gasUsed": 84977,
+    "fee": "273618325041076",
+    "origin": "{}",
+    "dataDecoded": {
+        "method": "swapOwner",
+        "parameters": [
+            {
+                "name": "prevOwner",
+                "type": "address",
+                "value": "0x0000000000000000000000000000000000000001",
+            },
+            {
+                "name": "oldOwner",
+                "type": "address",
+                "value": "0xc6b82bA149CFA113f8f48d5E3b1F78e933e16DfD",
+            },
+            {
+                "name": "newOwner",
+                "type": "address",
+                "value": "0x3066786706Ff0B6e71044e55074dBAE7D01573cB",
+            },
+        ],
+    },
+    "confirmationsRequired": 1,
+    "confirmations": [
+        {
+            "owner": "0xc6b82bA149CFA113f8f48d5E3b1F78e933e16DfD",
+            "submissionDate": "2024-01-24T15:22:55Z",
+            "transactionHash": None,
+            "signature": "0x000000000000000000000000c6b82ba149cfa113f8f48d5e3b1f78e933e16dfd000000000000000000000000000000000000000000000000000000000000000001",
+            "signatureType": "APPROVED_HASH",
+        }
+    ],
+    "trusted": True,
+    "signatures": "0x000000000000000000000000c6b82ba149cfa113f8f48d5e3b1f78e933e16dfd000000000000000000000000000000000000000000000000000000000000000001",
+}


### PR DESCRIPTION
Closes: https://github.com/safe-global/safe-cli/issues/382

All requests originating from `safe-cli` where a check can be made between the given safe-tx-hash and the one obtained from the result are routed through the `get_safe_transaction` method of `transaction_service_api`. 

I have added a new check and test for the method.