### PR TITLE
Fix inheritance safe subclasses

### DIFF
--- a/gnosis/safe/safe.py
+++ b/gnosis/safe/safe.py
@@ -92,7 +92,7 @@ class Safe(SafeCreator, ContractBase, metaclass=ABCMeta):
         """
         assert fast_is_checksum_address(address), "%s is not a valid address" % address
         if cls is not Safe:
-            return super().__new__(cls, address, ethereum_client, *args, **kwargs)
+            return super().__new__(cls, *args, **kwargs)
 
         versions: Dict[str, Safe] = {
             "0.0.1": SafeV001,

--- a/gnosis/safe/tests/test_safe.py
+++ b/gnosis/safe/tests/test_safe.py
@@ -64,6 +64,13 @@ class TestSafe(SafeTestCaseMixin, TestCase):
         not_a_safe = Account.create().address
         self.assertIsNone(Safe(not_a_safe, self.ethereum_client).domain_separator)
 
+    def test_inherit_safe(self):
+        address = Account.create().address
+        safe = SafeV141(address, self.ethereum_client)
+        self.assertEqual(safe.address, address)
+        self.assertEqual(safe.get_version(), "1.4.1")
+        self.assertEqual(safe.chain_id, 1337)
+
     def test_check_funds_for_tx_gas(self):
         safe = self.deploy_test_safe()
         safe_tx_gas = 2


### PR DESCRIPTION
Closes https://github.com/safe-global/safe-eth-py/issues/972

There was a problem when passing parameters to the __new__ method of the superclass in the constructor of the Safe class. These parameters must be passed in the __init__ method but not in the __new__ method.

If you directly instantiated a class that inherits from Safe, such as SafeV141, instead of passing it through the __new__ constructor of the Safe class, the same problem occurred.

A test case is added to validate the explicit condition in the Safe constructor.