### PR TITLE
Add addresses 1.3.0 for Redstone and Redstone Garnet

### DIFF
--- a/gnosis/safe/addresses.py
+++ b/gnosis/safe/addresses.py
@@ -1082,10 +1082,14 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
     EthereumNetwork.REDSTONE: [
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 930078, "1.3.0"),  # v1.3.0
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 930071, "1.3.0+L2"),  # v1.3.0+L2
+        ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 0, "1.3.0"),  # v1.3.0
+        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 0, "1.3.0+L2"),  # v1.3.0+L2
     ],
     EthereumNetwork.GARNET_HOLESKY: [
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 937241, "1.3.0"),  # v1.3.0
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 937238, "1.3.0+L2"),  # v1.3.0+L2
+        ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 0, "1.3.0"),  # v1.3.0
+        ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 0, "1.3.0+L2"),  # v1.3.0+L2
     ],
     EthereumNetwork.ENDURANCE_SMART_CHAIN_MAINNET: [
         ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 462220, "1.3.0"),  # v1.3.0
@@ -1776,9 +1780,11 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     ],
     EthereumNetwork.REDSTONE: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 930025),  # v1.3.0
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 929904),  # v1.3.0
     ],
     EthereumNetwork.GARNET_HOLESKY: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 937080),  # v1.3.0
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 936805),  # v1.3.0
     ],
     EthereumNetwork.ENDURANCE_SMART_CHAIN_MAINNET: [
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 462212),  # v1.3.0


### PR DESCRIPTION
[As suggested in this comment](https://github.com/safe-global/safe-eth-py/issues/993#issuecomment-2139413149), I am creating this pull request instead of an issue because the Redstone Network team has deployed the Master Copy contracts at the Genesis block.

**Redstone Mainnet:**
- https://chainlist.org/chain/690
- https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-690.json
- block explorer - https://explorer.redstone.xyz
- rpc node endpoint - https://rpc.redstonechain.com

**Redstone Garnet Testnet:**
- https://chainlist.org/chain/17069
- https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-17069.json
- block explorer - https://explorer.garnetchain.com
- rpc node endpoint - https://rpc.garnetchain.com

Thanks in advance!