### PR TITLE
Fix CI run docker for v26

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -51,8 +51,10 @@ jobs:
         ports:
           - 5432:5432
     steps:
+    - name: Create Ganache network
+      run: docker network create ganache
     - name: Setup and run ganache
-      run: docker run --detach --publish 8545:8545 --network-alias ganache -e DOCKER=true trufflesuite/ganache:latest --defaultBalanceEther 10000 --gasLimit 10000000 -a 30 --chain.chainId 1337 --chain.networkId 1337 -d
+      run: docker run --detach --publish 8545:8545 --network ganache -e DOCKER=true trufflesuite/ganache:latest --defaultBalanceEther 10000 --gasLimit 10000000 -a 30 --chain.chainId 1337 --chain.networkId 1337 -d
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5


### PR DESCRIPTION
Docker [v26](https://github.com/docker/cli/blob/v26.1.3/docs/deprecated.md) needs to create first the network before define it in network-aliases