### PR TITLE
Use Decimal for min_value

### DIFF
--- a/gnosis/eth/django/serializers.py
+++ b/gnosis/eth/django/serializers.py
@@ -1,4 +1,5 @@
 import logging
+from decimal import Decimal
 
 from django.utils.translation import gettext_lazy as _
 
@@ -129,7 +130,7 @@ class Sha3HashField(HexadecimalField):
 
 class Uint96Field(serializers.DecimalField):
     def __init__(self, **kwargs):
-        kwargs["min_value"] = 0
+        kwargs["min_value"] = Decimal(0)
         kwargs["max_digits"] = 29
         kwargs["decimal_places"] = 0
         super().__init__(**kwargs)
@@ -137,7 +138,7 @@ class Uint96Field(serializers.DecimalField):
 
 class Uint32Field(serializers.DecimalField):
     def __init__(self, **kwargs):
-        kwargs["min_value"] = 0
+        kwargs["min_value"] = Decimal(0)
         kwargs["max_digits"] = 10
         kwargs["decimal_places"] = 0
         super().__init__(**kwargs)


### PR DESCRIPTION
The `DecimalField` from Django REST Framework recommends using a Decimal value when setting the `min_value`. It logs a warning otherwise.

Reference: https://github.com/encode/django-rest-framework/blob/fe92f0dd0d4c587eed000c7de611ddbff241bd6a/rest_framework/fields.py#L991-L992