### PR TITLE
Dont respect retry_after_header

### DIFF
--- a/gnosis/util/http.py
+++ b/gnosis/util/http.py
@@ -15,8 +15,7 @@ def prepare_http_session(
     session = requests.Session()
     retry_conf = (
         requests.adapters.Retry(
-            total=retry_count,
-            backoff_factor=0.3,
+            total=retry_count, backoff_factor=0.3, respect_retry_after_header=False
         )
         if retry_count
         else 0


### PR DESCRIPTION
- Previously, if a `RetryAfter` header is set it will overwrite our retry policy
- We should be the ones deciding on the retry policy
- More info on https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Retry-After
