### PR TITLE
Fix delegateAddress type

### DIFF
--- a/gnosis/safe/api/transaction_service_api/transaction_service_messages.py
+++ b/gnosis/safe/api/transaction_service_api/transaction_service_messages.py
@@ -34,7 +34,7 @@ def get_delegate_message(
                 {"name": "chainId", "type": "uint256"},
             ],
             "Delegate": [
-                {"name": "delegateAddress", "type": "bytes32"},
+                {"name": "delegateAddress", "type": "address"},
                 {"name": "totp", "type": "uint256"},
             ],
         },

--- a/gnosis/safe/tests/api/test_transaction_service_messages.py
+++ b/gnosis/safe/tests/api/test_transaction_service_messages.py
@@ -33,7 +33,7 @@ class TestTransactionServiceMessages(TestCase):
                     {"name": "chainId", "type": "uint256"},
                 ],
                 "Delegate": [
-                    {"name": "delegateAddress", "type": "bytes32"},
+                    {"name": "delegateAddress", "type": "address"},
                     {"name": "totp", "type": "uint256"},
                 ],
             },


### PR DESCRIPTION
The Delegate EIP712 payload was using bytes32 as the type for the delegate address (which is an Ethereum Address).

While this works, it represents the wrong input type and size constraints that we should accept for that field (an address is 20 bytes so any input bigger than that should not be valid).