### PR TITLE
Add label to new chain addresses in Release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,10 @@ changelog:
         labels:
           - dependencies
           - breaking_change
+          - add-new-address
+    - title: 🆕 New Chain Addresses
+      labels:
+        - add-new-address
     - title: 🛠 Breaking Changes
       labels:
         - breaking_change

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -8,12 +8,12 @@ changelog:
           - dependencies
           - breaking_change
           - add-new-address
-    - title: 🆕 New Chain Addresses
-      labels:
-        - add-new-address
     - title: 🛠 Breaking Changes
       labels:
         - breaking_change
     - title: 👒 Dependencies
       labels:
         - dependencies
+    - title: 🆕 New Chain Addresses
+      labels:
+        - add-new-address

--- a/.github/scripts/github_adding_addresses/create_pr_with_new_address.py
+++ b/.github/scripts/github_adding_addresses/create_pr_with_new_address.py
@@ -73,12 +73,13 @@ def create_pr(
     issue_number: int,
 ) -> None:
     try:
-        repo.create_pull(
+        created_pull_request = repo.create_pull(
             title=f"Add addresses {version} for chain {chain_enum_name}",
             body=f"Automatic PR to add new address {version} to {chain_enum_name} chain\n Closes #{issue_number}",
             head=branch_name,
             base="main",
         )
+        created_pull_request.add_to_labels("add-new-address")
     except GithubException as e:
         print(f"Unable to create pull request: {e}")
 


### PR DESCRIPTION
To facilitate the reading of the Release notes, a section for automatic PRs of new chain addresses is added.