### PR TITLE
Add configuration object for the EnsClient

### DIFF
--- a/gnosis/eth/clients/ens_client.py
+++ b/gnosis/eth/clients/ens_client.py
@@ -1,5 +1,4 @@
 import os
-from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
 import requests
@@ -15,20 +14,29 @@ class EnsClient:
     Resolves Ethereum Name Service domains using ``thegraph`` API
     """
 
-    @dataclass
     class Config:
-        network: EthereumNetwork
-        base_url: str
+        def __init__(self, network: EthereumNetwork, base_url: str) -> None:
+            self.network = network
+            self.base_url = base_url
 
-        def get_url(self) -> str:
+        @property
+        def url(self) -> str:
             return self.base_url
 
-    @dataclass
     class SubgraphConfig(Config):
-        api_key: str
-        subgraph_id: str
+        def __init__(
+            self,
+            network: EthereumNetwork,
+            base_url: str,
+            api_key: str,
+            subgraph_id: str,
+        ) -> None:
+            super().__init__(network, base_url)
+            self.api_key = api_key
+            self.subgraph_id = subgraph_id
 
-        def get_url(self):
+        @property
+        def url(self):
             return f"{self.base_url}/api/subgraphs/id/{self.subgraph_id}"
 
     def __init__(self, config: Config):
@@ -44,7 +52,7 @@ class EnsClient:
         """
         try:
             return self.request_session.get(
-                self.config.get_url(), timeout=self.request_timeout
+                self.config.url, timeout=self.request_timeout
             ).ok
         except IOError:
             return False
@@ -72,7 +80,7 @@ class EnsClient:
         )
         try:
             response = self.request_session.post(
-                self.config.get_url(),
+                self.config.url,
                 json={"query": query},
                 timeout=self.request_timeout,
             )
@@ -154,7 +162,7 @@ class EnsClient:
         )
         try:
             response = self.request_session.post(
-                self.config.get_url(),
+                self.config.url,
                 json={"query": query},
                 timeout=self.request_timeout,
             )

--- a/gnosis/eth/clients/ens_client.py
+++ b/gnosis/eth/clients/ens_client.py
@@ -6,7 +6,6 @@ import requests
 from eth_typing import HexStr
 from hexbytes import HexBytes
 
-from gnosis.eth import EthereumNetwork
 from gnosis.util import cache
 
 
@@ -17,7 +16,6 @@ class EnsClient:
 
     @dataclass
     class Config:
-        network: EthereumNetwork
         base_url: str
 
         @property

--- a/gnosis/eth/clients/ens_client.py
+++ b/gnosis/eth/clients/ens_client.py
@@ -1,4 +1,5 @@
 import os
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
 import requests
@@ -14,26 +15,19 @@ class EnsClient:
     Resolves Ethereum Name Service domains using ``thegraph`` API
     """
 
+    @dataclass
     class Config:
-        def __init__(self, network: EthereumNetwork, base_url: str) -> None:
-            self.network = network
-            self.base_url = base_url
+        network: EthereumNetwork
+        base_url: str
 
         @property
         def url(self) -> str:
             return self.base_url
 
+    @dataclass
     class SubgraphConfig(Config):
-        def __init__(
-            self,
-            network: EthereumNetwork,
-            base_url: str,
-            api_key: str,
-            subgraph_id: str,
-        ) -> None:
-            super().__init__(network, base_url)
-            self.api_key = api_key
-            self.subgraph_id = subgraph_id
+        api_key: str
+        subgraph_id: str
 
         @property
         def url(self):

--- a/gnosis/eth/clients/ens_client.py
+++ b/gnosis/eth/clients/ens_client.py
@@ -37,7 +37,7 @@ class EnsClient:
 
         @property
         def url(self):
-            return f"{self.base_url}/api/subgraphs/id/{self.subgraph_id}"
+            return f"{self.base_url}/api/{self.api_key}/subgraphs/id/{self.subgraph_id}"
 
     def __init__(self, config: Config):
         self.config = config

--- a/gnosis/eth/clients/ens_client.py
+++ b/gnosis/eth/clients/ens_client.py
@@ -1,4 +1,5 @@
 import os
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
 import requests
@@ -14,15 +15,24 @@ class EnsClient:
     Resolves Ethereum Name Service domains using ``thegraph`` API
     """
 
-    def __init__(self, network_id: int):
-        self.ethereum_network = EthereumNetwork(network_id)
-        if network_id == self.ethereum_network.SEPOLIA:
-            url = (
-                "https://api.studio.thegraph.com/proxy/49574/enssepolia/version/latest/"
-            )
-        else:  # Fallback to mainnet
-            url = "https://api.thegraph.com/subgraphs/name/ensdomains/ens/"
-        self.url = url
+    @dataclass
+    class Config:
+        network: EthereumNetwork
+        base_url: str
+
+        def get_url(self) -> str:
+            return self.base_url
+
+    @dataclass
+    class SubgraphConfig(Config):
+        api_key: str
+        subgraph_id: str
+
+        def get_url(self):
+            return f"{self.base_url}/api/subgraphs/id/{self.subgraph_id}"
+
+    def __init__(self, config: Config):
+        self.config = config
         self.request_timeout = int(
             os.environ.get("ENS_CLIENT_REQUEST_TIMEOUT", 5)
         )  # Seconds
@@ -33,7 +43,9 @@ class EnsClient:
         :return: True if service is available, False if it's down
         """
         try:
-            return self.request_session.get(self.url, timeout=self.request_timeout).ok
+            return self.request_session.get(
+                self.config.get_url(), timeout=self.request_timeout
+            ).ok
         except IOError:
             return False
 
@@ -60,7 +72,9 @@ class EnsClient:
         )
         try:
             response = self.request_session.post(
-                self.url, json={"query": query}, timeout=self.request_timeout
+                self.config.get_url(),
+                json={"query": query},
+                timeout=self.request_timeout,
             )
         except IOError:
             return None
@@ -140,7 +154,9 @@ class EnsClient:
         )
         try:
             response = self.request_session.post(
-                self.url, json={"query": query}, timeout=self.request_timeout
+                self.config.get_url(),
+                json={"query": query},
+                timeout=self.request_timeout,
             )
         except IOError:
             return None

--- a/gnosis/eth/tests/clients/test_ens_client.py
+++ b/gnosis/eth/tests/clients/test_ens_client.py
@@ -5,14 +5,11 @@ from django.test import TestCase
 from eth_utils import keccak
 from requests import Session
 
-from gnosis.eth.ethereum_client import EthereumNetwork
-
 from ...clients import EnsClient
 
 
 class TestEnsClient(TestCase):
     config = EnsClient.Config(
-        network=EthereumNetwork.MAINNET,
         base_url="https://api.thegraph.com/subgraphs/name/ensdomains/ens",
     )
 
@@ -138,15 +135,13 @@ class TestEnsClient(TestCase):
     def test_is_available(self):
         for config in (
             EnsClient.Config(
-                network=EthereumNetwork.SEPOLIA,
                 base_url="https://api.studio.thegraph.com/query/49574/enssepolia/version/latest",
             ),
             EnsClient.Config(
-                network=EthereumNetwork.MAINNET,
                 base_url="https://api.thegraph.com/subgraphs/name/ensdomains/ens/",
             ),
         ):
-            with self.subTest(ethereum_network=config.network):
+            with self.subTest(base_url=config.base_url):
                 ens_client = EnsClient(config=config)
                 self.assertTrue(ens_client.is_available())
                 with mock.patch.object(Session, "get", side_effect=IOError()):

--- a/gnosis/eth/tests/clients/test_ens_client.py
+++ b/gnosis/eth/tests/clients/test_ens_client.py
@@ -11,6 +11,11 @@ from ...clients import EnsClient
 
 
 class TestEnsClient(TestCase):
+    config = EnsClient.Config(
+        network=EthereumNetwork.MAINNET,
+        base_url="https://api.thegraph.com/subgraphs/name/ensdomains/ens",
+    )
+
     def test_domain_hash_to_hex_str(self):
         domain_hash_bytes = keccak(text="gnosis")
         domain_hash_int = int.from_bytes(domain_hash_bytes, byteorder="big")
@@ -24,7 +29,7 @@ class TestEnsClient(TestCase):
         self.assertEqual(len(EnsClient.domain_hash_to_hex_str(2)), 66)
 
     def test_query_by_account(self):
-        ens_client = EnsClient(EthereumNetwork.MAINNET.value)
+        ens_client = EnsClient(config=self.config)
         if not ens_client.is_available():
             self.skipTest("ENS Mainnet Client is not available")
 
@@ -117,7 +122,7 @@ class TestEnsClient(TestCase):
         )
 
     def test_query_by_domain_hash(self):
-        ens_client = EnsClient(EthereumNetwork.MAINNET.value)  # Mainnet
+        ens_client = EnsClient(config=self.config)
         if not ens_client.is_available():
             self.skipTest("ENS Mainnet Client is not available")
 
@@ -131,12 +136,18 @@ class TestEnsClient(TestCase):
         self.assertIsNone(ens_client.query_by_domain_hash(domain_hash_2))
 
     def test_is_available(self):
-        for ethereum_network in (
-            EthereumNetwork.ROPSTEN,
-            EthereumNetwork.MAINNET,
+        for config in (
+            EnsClient.Config(
+                network=EthereumNetwork.SEPOLIA,
+                base_url="https://api.studio.thegraph.com/query/49574/enssepolia/version/latest",
+            ),
+            EnsClient.Config(
+                network=EthereumNetwork.MAINNET,
+                base_url="https://api.thegraph.com/subgraphs/name/ensdomains/ens/",
+            ),
         ):
-            with self.subTest(ethereum_network=ethereum_network):
-                ens_client = EnsClient(ethereum_network)
+            with self.subTest(config.network):
+                ens_client = EnsClient(config=config)
                 self.assertTrue(ens_client.is_available())
                 with mock.patch.object(Session, "get", side_effect=IOError()):
                     self.assertFalse(ens_client.is_available())

--- a/gnosis/eth/tests/clients/test_ens_client.py
+++ b/gnosis/eth/tests/clients/test_ens_client.py
@@ -146,7 +146,7 @@ class TestEnsClient(TestCase):
                 base_url="https://api.thegraph.com/subgraphs/name/ensdomains/ens/",
             ),
         ):
-            with self.subTest(config.network):
+            with self.subTest(ethereum_network=config.network):
                 ens_client = EnsClient(config=config)
                 self.assertTrue(ens_client.is_available())
                 with mock.patch.object(Session, "get", side_effect=IOError()):


### PR DESCRIPTION
Closes #1061

- Adds a required configuration argument to the `EnsClient`.
- The new configuration is still based on what is required by The Graph (schemas, authentication, requests).
- This configuration abstracts away from where the information should be retrieved.
  * The base `Config` class provides a mapping between a Network (chain) and a URL.
  * The `SubgraphConfig` class provides a Subgraph configuration if the `EnsClient` should use a SubGraph instead. See https://docs.ens.domains/web/subgraph
- This change does not update the URLs that are required to access The Graph services. It delegates the respective configuration to the consumers of `safe-eth-py`. So in order to continue using the `EnsClient`, a valid configuration should be provided.