### PR TITLE
  Create `EthereumAddressFastBinaryField`

### DIFF
--- a/gnosis/eth/django/tests/models.py
+++ b/gnosis/eth/django/tests/models.py
@@ -2,7 +2,7 @@ from django.db import models
 
 from ..models import (
     EthereumAddressBinaryField,
-    EthereumAddressCharField,
+    EthereumAddressFastBinaryField,
     Keccak256Field,
     Uint32Field,
     Uint96Field,
@@ -10,12 +10,12 @@ from ..models import (
 )
 
 
-class EthereumAddress(models.Model):
-    value = EthereumAddressCharField(null=True)
-
-
-class EthereumAddressV2(models.Model):
+class EthereumAddressBinary(models.Model):
     value = EthereumAddressBinaryField(null=True)
+
+
+class EthereumAddressFastBinary(models.Model):
+    value = EthereumAddressFastBinaryField(null=True)
 
 
 class Uint256(models.Model):

--- a/gnosis/eth/django/validators.py
+++ b/gnosis/eth/django/validators.py
@@ -1,9 +1,23 @@
 from django.core.exceptions import ValidationError
 
+from hexbytes import HexBytes
+
 from ..utils import fast_is_checksum_address
 
 
-def validate_checksumed_address(address):
+def validate_address(address: str):
+    try:
+        address_bytes = HexBytes(address)
+        if len(address_bytes) != 20:
+            raise ValueError
+    except ValueError:
+        raise ValidationError(
+            "%(address)s is not a valid EthereumAddress",
+            params={"address": address},
+        )
+
+
+def validate_checksumed_address(address: str):
     if not fast_is_checksum_address(address):
         raise ValidationError(
             "%(address)s has an invalid checksum",


### PR DESCRIPTION
- Faster than `EthereumAddressBinaryField` as it does not involve EIP55 checksums
- Depends on #835 to be merged first