### PR TITLE
Fix missing paymaster

### DIFF
--- a/gnosis/eth/account_abstraction/user_operation_receipt.py
+++ b/gnosis/eth/account_abstraction/user_operation_receipt.py
@@ -20,7 +20,7 @@ class UserOperationReceipt:
     entry_point: ChecksumAddress
     sender: ChecksumAddress
     nonce: int
-    paymaster: ChecksumAddress
+    paymaster: Optional[ChecksumAddress]
     actual_gas_cost: int
     actual_gas_used: int
     success: bool
@@ -37,7 +37,7 @@ class UserOperationReceipt:
             user_operation_receipt_response["entryPoint"],
             user_operation_receipt_response["sender"],
             int(user_operation_receipt_response["nonce"], 16),
-            user_operation_receipt_response["paymaster"],
+            user_operation_receipt_response.get("paymaster"),
             int(user_operation_receipt_response["actualGasCost"], 16),
             int(user_operation_receipt_response["actualGasUsed"], 16),
             user_operation_receipt_response["success"],


### PR DESCRIPTION
Paymaster is not a required response field of `get_userOperationReceipt` 
https://github.com/eth-infinitism/bundler-spec/blob/d6f55418fb05a8f2ca761cbfe49b56ac9898f657/src/schemas/receipt.yaml#L105C1-L116C14
This PR add paymaster as optional field