### PR TITLE
Add web3 forced version in addresses workflows

### DIFF
--- a/.github/workflows/create_pr_with_new_address.yml
+++ b/.github/workflows/create_pr_with_new_address.yml
@@ -112,7 +112,7 @@ jobs:
     - name: Install dependencies
       if: steps.check-comment.outputs.result == 'true'
       run: |
-        pip install PyGithub safe-eth-py pre-commit
+        grep -E "web3" requirements.txt | xargs pip install PyGithub safe-eth-py pre-commit
         pre-commit install
 
     - name: Process Issue and Create PR

--- a/.github/workflows/validate_new_address_issue_input_data.yml
+++ b/.github/workflows/validate_new_address_issue_input_data.yml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        pip install safe-eth-py validators tldextract
+        grep -E "web3" requirements.txt | xargs pip install safe-eth-py validators tldextract
 
     - name: Validate input data
       id: validate-input-data


### PR DESCRIPTION
 - A new major version of web3 is available but (for the moment) is not compatible with safe-eth-py (https://pypi.org/project/web3/7.0.0/)