### PR TITLE
Improve typing using `mypy`

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -29,7 +29,7 @@ jobs:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
       - name: Install dependencies
-        run: pip install -U pre-commit
+        run: pip install -U pre-commit -r requirements-test.txt
       - name: Run pre-commit
         run: pre-commit run --all-files
 
@@ -67,8 +67,6 @@ jobs:
         pip install -r requirements-test.txt coveralls
       env:
         PIP_USE_MIRRORS: true
-    - name: Run mypy
-      run: mypy .
     - name: Run tests and coverage
       run: coverage run --source=$SOURCE_FOLDER -m pytest -W ignore::DeprecationWarning -rxXs --reruns 3
       env:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -67,6 +67,8 @@ jobs:
         pip install -r requirements-test.txt coveralls
       env:
         PIP_USE_MIRRORS: true
+    - name: Run mypy
+      run: mypy .
     - name: Run tests and coverage
       run: coverage run --source=$SOURCE_FOLDER -m pytest -W ignore::DeprecationWarning -rxXs --reruns 3
       env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,11 +19,7 @@ repos:
       - id: mypy
         exclude: env|docs|config|.github
         args: [--ignore-missing-imports, --warn-unused-ignores, --warn-redundant-casts, --warn-unused-configs]
-        additional_dependencies:
-          - types-requests==2.32.0.20240712
-          - hexbytes==0.3.1
-          - web3==6.20.2
-          - pytest==8.3.2
+        language: system
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,17 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
+        exclude: env|docs|config|.github
+        args: [--ignore-missing-imports, --warn-unused-ignores, --warn-redundant-casts, --warn-unused-configs]
+        additional_dependencies:
+          - types-requests==2.32.0.20240712
+          - hexbytes==0.3.1
+          - web3==6.20.2
+          - pytest==8.3.2
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
     hooks:

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,23 +1,8 @@
 [mypy]
-
-
-[mypy-django_filters.*]
+exclude = env|docs|config
+python_version = 3.9
 ignore_missing_imports = True
-[mypy-faker.*]
-ignore_missing_imports = True
-[mypy-pytest.*]
-ignore_missing_imports = True
-[mypy-safe_eth.eth.contracts]
-ignore_missing_imports = True
-[mypy-py_eth_sig_utils.*]
-ignore_missing_imports = True
-[mypy-rlp.*]
-ignore_missing_imports = True
-[mypy-eth_account.*]
-ignore_missing_imports = True
-[mypy-ethereum.*]
-ignore_missing_imports = True
-[mypy-rest_framework.*]
-ignore_missing_imports = True
-[mypy-django.*]
-ignore_missing_imports = True
+# check_untyped_defs = True  # Type-checks the interior of functions without type annotations.
+warn_unused_ignores = True
+warn_redundant_casts = True
+warn_unused_configs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-exclude = env|docs|config
+exclude = env|docs|config|.github
 python_version = 3.9
 ignore_missing_imports = True
 # check_untyped_defs = True  # Type-checks the interior of functions without type annotations.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ hatch
 ipdb
 ipython
 isort
-mypy
 pre-commit
 sphinx
 sphinx-rtd-theme

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 coverage==7.6.1
 faker==27.4.0
+mypy==1.11.2
 pytest==8.3.2
 pytest-django==4.8.0
 pytest-env==1.1.3

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,6 +1,6 @@
 -r requirements.txt
 coverage==7.6.1
-faker==27.4.0
+faker==28.4.1
 mypy==1.11.2
 pytest==8.3.2
 pytest-django==4.8.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -7,3 +7,4 @@ pytest-django==4.8.0
 pytest-env==1.1.3
 pytest-rerunfailures==14.0
 pytest-sugar==1.0.0
+types-requests==2.32.0.20240712

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,4 @@ py-evm==0.10.1b1
 pysha3>=1.0.0,<2.0.0; python_version<"3.9"
 requests==2.32.3
 safe-pysha3>=1.0.0; python_version>="3.9"
-types-requests==2.32.0.20240712
 web3==6.20.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ py-evm==0.10.1b1
 pysha3>=1.0.0,<2.0.0; python_version<"3.9"
 requests==2.32.3
 safe-pysha3>=1.0.0; python_version>="3.9"
+types-requests==2.32.0.20240712
 web3==6.20.2

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,11 +1,7 @@
 #!/bin/sh
-
-# Execute mypy and stop script if it fails
-mypy . || exit 1
-
 # Postgresql and ganache-cli must be running for the tests
-docker-compose up -d db ganache
 
+docker-compose up -d db ganache
 sleep 3
 
 # python manage.py test --settings=config.settings.test

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Llama a mypy y detiene el script si falla
+# Execute mypy and stop script if it fails
 mypy . || exit 1
 
 # Postgresql and ganache-cli must be running for the tests

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
-# Postgresql and ganache-cli must be running for the tests
 
+# Llama a mypy y detiene el script si falla
+mypy . || exit 1
+
+# Postgresql and ganache-cli must be running for the tests
 docker-compose up -d db ganache
+
 sleep 3
 
 # python manage.py test --settings=config.settings.test

--- a/safe_eth/eth/account_abstraction/bundler_client.py
+++ b/safe_eth/eth/account_abstraction/bundler_client.py
@@ -182,16 +182,15 @@ class BundlerClient:
         if (
             results
             and isinstance(results, list)
-            and results[0] is not None
+            and len(results) >= 2
             and isinstance(results[0], dict)
-            and results[1] is not None
             and isinstance(results[1], dict)
         ):
             return UserOperation.from_bundler_response(
                 user_operation_hash, results[0]
             ), self._parse_user_operation_receipt(results[1])
-        else:
-            return None
+
+        return None
 
     @lru_cache(maxsize=None)
     def supported_entry_points(self) -> List[ChecksumAddress]:

--- a/safe_eth/eth/account_abstraction/bundler_client.py
+++ b/safe_eth/eth/account_abstraction/bundler_client.py
@@ -210,9 +210,9 @@ class BundlerClient:
         result = self._do_request(payload)
         if result and isinstance(result, list):
             return [
-                ChecksumAddress(HexAddress(HexStr(x)))
-                for x in result
-                if isinstance(x, str)
+                ChecksumAddress(HexAddress(HexStr(address)))
+                for address in result
+                if isinstance(address, str)
             ]
-        else:
-            return []
+
+        return []

--- a/safe_eth/eth/account_abstraction/bundler_client.py
+++ b/safe_eth/eth/account_abstraction/bundler_client.py
@@ -2,13 +2,13 @@ import logging
 from functools import cache, lru_cache
 from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
-from eth_typing import ChecksumAddress, HexStr
+from eth_typing import ChecksumAddress, HexAddress, HexStr
 from hexbytes import HexBytes
 
 from safe_eth.util.http import prepare_http_session
 
 from .exceptions import BundlerClientConnectionException, BundlerClientResponseException
-from .user_operation import UserOperation
+from .user_operation import UserOperation, UserOperationV07
 from .user_operation_receipt import UserOperationReceipt
 
 logger = logging.getLogger(__name__)
@@ -33,7 +33,11 @@ class BundlerClient:
 
     def _do_request(
         self, payload: Union[Dict[Any, Any], Sequence[Dict[Any, Any]]]
-    ) -> Union[Optional[Union[Dict[str, Any]]], Optional[List[Dict[str, Any]]]]:
+    ) -> Union[
+        Optional[Union[Dict[str, Any]]],
+        Optional[List[Dict[str, Any]]],
+        Optional[List[str]],
+    ]:
         """
         :param payload: Allows simple request or a batch request
         :return: Result of the request
@@ -49,7 +53,7 @@ class BundlerClient:
 
         if not response.ok:
             raise BundlerClientConnectionException(
-                f"Error connecting to bundler {self.url} : {response.status_code} {response.content}"
+                f"Error connecting to bundler {self.url} : {response.status_code} {response.content!r}"
             )
 
         bundler_responses = response.json()
@@ -122,7 +126,7 @@ class BundlerClient:
     @lru_cache(maxsize=1024)
     def get_user_operation_by_hash(
         self, user_operation_hash: HexStr
-    ) -> Optional[UserOperation]:
+    ) -> Optional[Union[UserOperation, UserOperationV07]]:
         """
         https://docs.alchemy.com/reference/eth-getuseroperationbyhash
 
@@ -133,11 +137,10 @@ class BundlerClient:
         """
         payload = self._get_user_operation_by_hash_payload(user_operation_hash)
         result = self._do_request(payload)
-        return (
-            UserOperation.from_bundler_response(user_operation_hash, result)
-            if result
-            else None
-        )
+        if result and isinstance(result, dict):
+            return UserOperation.from_bundler_response(user_operation_hash, result)
+        else:
+            return None
 
     @lru_cache(maxsize=1024)
     def get_user_operation_receipt(
@@ -153,12 +156,15 @@ class BundlerClient:
         """
         payload = self._get_user_operation_receipt_payload(user_operation_hash)
         result = self._do_request(payload)
-        return UserOperationReceipt.from_bundler_response(result) if result else None
+        if result and isinstance(result, dict):
+            return UserOperationReceipt.from_bundler_response(result)
+        else:
+            return None
 
     @lru_cache(maxsize=1024)
     def get_user_operation_and_receipt(
         self, user_operation_hash: HexStr
-    ) -> Optional[Tuple[UserOperation, UserOperationReceipt]]:
+    ) -> Optional[Tuple[Union[UserOperation, UserOperationV07], UserOperationReceipt]]:
         """
         Get UserOperation and UserOperationReceipt in the same request using a batch query.
         NOTE: Batch requests are not supported by Pimlico
@@ -172,13 +178,20 @@ class BundlerClient:
             self._get_user_operation_by_hash_payload(user_operation_hash, request_id=1),
             self._get_user_operation_receipt_payload(user_operation_hash, request_id=2),
         ]
-        result = self._do_request(payload)
-        if not (result and result[0]):
+        results = self._do_request(payload)
+        if (
+            results
+            and isinstance(results, list)
+            and results[0] is not None
+            and isinstance(results[0], dict)
+            and results[1] is not None
+            and isinstance(results[1], dict)
+        ):
+            return UserOperation.from_bundler_response(
+                user_operation_hash, results[0]
+            ), self._parse_user_operation_receipt(results[1])
+        else:
             return None
-
-        return UserOperation.from_bundler_response(
-            user_operation_hash, result[0]
-        ), self._parse_user_operation_receipt(result[1])
 
     @lru_cache(maxsize=None)
     def supported_entry_points(self) -> List[ChecksumAddress]:
@@ -195,4 +208,12 @@ class BundlerClient:
             "params": [],
             "id": 1,
         }
-        return self._do_request(payload)
+        result = self._do_request(payload)
+        if result and isinstance(result, list):
+            return [
+                ChecksumAddress(HexAddress(HexStr(x)))
+                for x in result
+                if isinstance(x, str)
+            ]
+        else:
+            return []

--- a/safe_eth/eth/account_abstraction/user_operation.py
+++ b/safe_eth/eth/account_abstraction/user_operation.py
@@ -204,7 +204,12 @@ class UserOperationV07:
 
     @property
     def paymaster_and_data(self) -> bytes:
-        if not self.paymaster:
+        if (
+            not self.paymaster
+            or not self.paymaster_verification_gas_limit
+            or not self.paymaster_post_op_gas_limit
+            or not self.paymaster_data
+        ):
             return b""
         return (
             HexBytes(self.paymaster).rjust(20, b"\x00")

--- a/safe_eth/eth/clients/blockscout_client.py
+++ b/safe_eth/eth/clients/blockscout_client.py
@@ -135,7 +135,7 @@ class BlockscoutClient:
 
     def __init__(self, network: EthereumNetwork):
         self.network = network
-        self.grahpql_url = self.NETWORK_WITH_URL.get(network) or ""
+        self.grahpql_url = self.NETWORK_WITH_URL.get(network, "")
         if not self.grahpql_url:
             raise BlockScoutConfigurationProblem(
                 f"Network {network.name} - {network.value} not supported"

--- a/safe_eth/eth/clients/blockscout_client.py
+++ b/safe_eth/eth/clients/blockscout_client.py
@@ -135,8 +135,8 @@ class BlockscoutClient:
 
     def __init__(self, network: EthereumNetwork):
         self.network = network
-        self.grahpql_url = self.NETWORK_WITH_URL.get(network)
-        if self.grahpql_url is None:
+        self.grahpql_url = self.NETWORK_WITH_URL.get(network) or ""
+        if not self.grahpql_url:
             raise BlockScoutConfigurationProblem(
                 f"Network {network.name} - {network.value} not supported"
             )
@@ -167,3 +167,4 @@ class BlockscoutClient:
             return ContractMetadata(
                 smart_contract["name"], json.loads(smart_contract["abi"]), False
             )
+        return None

--- a/safe_eth/eth/clients/etherscan_client.py
+++ b/safe_eth/eth/clients/etherscan_client.py
@@ -130,8 +130,8 @@ class EtherscanClient:
     ):
         self.network = network
         self.api_key = api_key
-        self.base_url = self.NETWORK_WITH_URL.get(network) or ""
-        self.base_api_url = self.NETWORK_WITH_API_URL.get(network) or ""
+        self.base_url = self.NETWORK_WITH_URL.get(network, "")
+        self.base_api_url = self.NETWORK_WITH_API_URL.get(network, "")
         if not self.base_api_url:
             raise EtherscanClientConfigurationProblem(
                 f"Network {network.name} - {network.value} not supported"

--- a/safe_eth/eth/clients/etherscan_client.py
+++ b/safe_eth/eth/clients/etherscan_client.py
@@ -1,7 +1,7 @@
 import json
 import os
 import time
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, MutableMapping, Optional, Union
 from urllib.parse import urljoin
 
 from ...util.http import prepare_http_session
@@ -116,7 +116,7 @@ class EtherscanClient:
         EthereumNetwork.HOLESKY: "https://api-holesky.etherscan.io",
         EthereumNetwork.LINEA_SEPOLIA: "https://api-sepolia.lineascan.build",
     }
-    HTTP_HEADERS = {
+    HTTP_HEADERS: MutableMapping[str, Union[str, bytes]] = {
         "User-Agent": "curl/7.77.0",
     }
 
@@ -130,9 +130,9 @@ class EtherscanClient:
     ):
         self.network = network
         self.api_key = api_key
-        self.base_url = self.NETWORK_WITH_URL.get(network)
-        self.base_api_url = self.NETWORK_WITH_API_URL.get(network)
-        if self.base_api_url is None:
+        self.base_url = self.NETWORK_WITH_URL.get(network) or ""
+        self.base_api_url = self.NETWORK_WITH_API_URL.get(network) or ""
+        if not self.base_api_url:
             raise EtherscanClientConfigurationProblem(
                 f"Network {network.name} - {network.value} not supported"
             )
@@ -146,7 +146,7 @@ class EtherscanClient:
             url += f"&apikey={self.api_key}"
         return url
 
-    def _do_request(self, url: str) -> Optional[Dict[str, Any]]:
+    def _do_request(self, url: str) -> Optional[Union[Dict[str, Any], List[Any], str]]:
         response = self.http_session.get(url, timeout=self.request_timeout)
 
         if response.ok:
@@ -157,8 +157,11 @@ class EtherscanClient:
                 raise EtherscanRateLimitError
             if response_json["status"] == "1":
                 return result
+        return None
 
-    def _retry_request(self, url: str, retry: bool = True) -> Optional[Dict[str, Any]]:
+    def _retry_request(
+        self, url: str, retry: bool = True
+    ) -> Optional[Union[Dict[str, Any], List[Any], str]]:
         for _ in range(3):
             try:
                 return self._do_request(url)
@@ -167,6 +170,7 @@ class EtherscanClient:
                     raise exc
                 else:
                     time.sleep(5)
+        return None
 
     def get_contract_metadata(
         self, contract_address: str, retry: bool = True
@@ -179,6 +183,7 @@ class EtherscanClient:
             contract_abi = contract_source_code["ABI"]
             if contract_abi:
                 return ContractMetadata(contract_name, contract_abi, False)
+        return None
 
     def get_contract_source_code(self, contract_address: str, retry: bool = True):
         """
@@ -203,11 +208,19 @@ class EtherscanClient:
         url = self.build_url(
             f"api?module=contract&action=getsourcecode&address={contract_address}"
         )
-        result = self._retry_request(url, retry=retry)  # Returns a list
-        if result:
-            result = result[0]
-            abi_str = result["ABI"]
-            result["ABI"] = json.loads(abi_str) if abi_str.startswith("[") else None
+        response = self._retry_request(url, retry=retry)  # Returns a list
+        if response and isinstance(response, list):
+            result = response[0]
+            abi_str = result.get("ABI")
+
+            if isinstance(abi_str, str) and abi_str.startswith("["):
+                try:
+                    result["ABI"] = json.loads(abi_str)
+                except json.JSONDecodeError:
+                    result["ABI"] = None  # Handle the case where JSON decoding fails
+            else:
+                result["ABI"] = None
+
             return result
 
     def get_contract_abi(self, contract_address: str, retry: bool = True):
@@ -215,5 +228,11 @@ class EtherscanClient:
             f"api?module=contract&action=getabi&address={contract_address}"
         )
         result = self._retry_request(url, retry=retry)
-        if result:
-            return json.loads(result)
+        if isinstance(result, dict):
+            return result
+        elif isinstance(result, str):
+            try:
+                return json.loads(result)
+            except json.JSONDecodeError:
+                pass
+        return None

--- a/safe_eth/eth/contracts/__init__.py
+++ b/safe_eth/eth/contracts/__init__.py
@@ -31,7 +31,7 @@ import json
 import os
 import sys
 from functools import cache
-from typing import Any, Callable, Dict, Optional
+from typing import Any, Callable, Dict, Optional, Type, Union
 
 from eth_typing import ChecksumAddress
 from hexbytes import HexBytes
@@ -101,7 +101,7 @@ def _load_json_file(path) -> Dict[str, Any]:
 
 def generate_contract_fn(
     contract: Dict[str, Any]
-) -> Callable[[Web3, Optional[ChecksumAddress]], Contract]:
+) -> Callable[[Web3, Optional[ChecksumAddress]], Union[Type[Contract], Contract]]:
     """
     Dynamically generate a function to build a Web3 Contract for the provided contract ABI
 
@@ -109,10 +109,13 @@ def generate_contract_fn(
     :return: function that will return a Web3 Contract from an ABI
     """
 
-    def fn(w3: Web3, address: Optional[ChecksumAddress] = None) -> Contract:
-        return w3.eth.contract(
+    def fn(
+        w3: Web3, address: Optional[ChecksumAddress] = None
+    ) -> Union[Type[Contract], Contract]:
+        eth_contract = w3.eth.contract(
             address=address, abi=contract["abi"], bytecode=contract.get("bytecode")
         )
+        return eth_contract
 
     return fn
 
@@ -130,27 +133,27 @@ def get_safe_contract(w3: Web3, address: Optional[ChecksumAddress] = None) -> Co
 def get_safe_V0_0_1_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_safe_V1_0_0_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_safe_V1_1_1_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_safe_V1_3_0_contract(w3: Web3, address: Optional[str] = None) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_safe_V1_4_1_contract(w3: Web3, address: Optional[str] = None) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_compatibility_fallback_handler_contract(
@@ -167,59 +170,59 @@ def get_compatibility_fallback_handler_contract(
 def get_compatibility_fallback_handler_V1_3_0_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_compatibility_fallback_handler_V1_4_1_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_sign_message_lib_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_erc20_contract(w3: Web3, address: Optional[ChecksumAddress] = None) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_erc721_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_erc1155_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_example_erc20_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_delegate_constructor_proxy_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_multi_send_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_paying_proxy_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_proxy_factory_contract(w3: Web3, address: Optional[str] = None) -> Contract:
@@ -234,77 +237,77 @@ def get_proxy_factory_contract(w3: Web3, address: Optional[str] = None) -> Contr
 def get_proxy_factory_V1_0_0_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_proxy_factory_V1_1_1_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_proxy_factory_V1_3_0_contract(
     w3: Web3, address: Optional[str] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_proxy_factory_V1_4_1_contract(
     w3: Web3, address: Optional[str] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_proxy_contract(w3: Web3, address: Optional[ChecksumAddress] = None) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_simulate_tx_accessor_V1_4_1_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_uniswap_exchange_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_uniswap_factory_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_uniswap_v2_factory_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_uniswap_v2_pair_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_uniswap_v2_router_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_kyber_network_proxy_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_cpk_factory_contract(
     w3: Web3, address: Optional[ChecksumAddress] = None
 ) -> Contract:
-    pass
+    raise NotImplementedError
 
 
 def get_multicall_v3_contract(w3: Web3, address: Optional[ChecksumAddress] = None):

--- a/safe_eth/eth/contracts/contract_base.py
+++ b/safe_eth/eth/contracts/contract_base.py
@@ -14,7 +14,7 @@ class ContractBase(metaclass=ABCMeta):
     def __init__(
         self,
         address: ChecksumAddress,
-        ethereum_client: "EthereumClient",  # noqa F821
+        ethereum_client: "EthereumClient",  # type: ignore # noqa F821
         *args,
         **kwargs,
     ):

--- a/safe_eth/eth/django/models.py
+++ b/safe_eth/eth/django/models.py
@@ -45,6 +45,7 @@ class EthereumAddressBinaryField(models.Field):
     ) -> Optional[ChecksumAddress]:
         if value:
             return fast_bytes_to_checksum_address(value)
+        return None
 
     def get_prep_value(self, value: ChecksumAddress) -> Optional[bytes]:
         if value:
@@ -56,6 +57,7 @@ class EthereumAddressBinaryField(models.Field):
                     code="invalid",
                     params={"value": value},
                 )
+        return None
 
     def to_python(self, value) -> Optional[ChecksumAddress]:
         if value is not None:
@@ -67,6 +69,7 @@ class EthereumAddressBinaryField(models.Field):
                     code="invalid",
                     params={"value": value},
                 )
+        return None
 
     def formfield(self, **kwargs):
         defaults = {
@@ -91,9 +94,11 @@ class EthereumAddressFastBinaryField(EthereumAddressBinaryField):
 
     def from_db_value(
         self, value: memoryview, expression, connection
-    ) -> Optional[HexAddress]:
+    ) -> Optional[ChecksumAddress]:
         if value:
-            return HexAddress(HexStr("0x" + bytes(value).hex()))
+            return ChecksumAddress(HexAddress(HexStr("0x" + bytes(value).hex())))
+
+        return None
 
     def to_python(self, value) -> Optional[ChecksumAddress]:
         if value is not None:
@@ -103,13 +108,16 @@ class EthereumAddressFastBinaryField(EthereumAddressBinaryField):
                         raise ValueError(
                             "Cannot convert %s to a checksum address, 20 bytes were expected"
                         )
-                return HexAddress(HexStr(to_normalized_address(value)[2:]))
+                return ChecksumAddress(
+                    HexAddress(HexStr(to_normalized_address(value)[2:]))
+                )
             except ValueError:
                 raise exceptions.ValidationError(
                     self.error_messages["invalid"],
                     code="invalid",
                     params={"value": value},
                 )
+        return None
 
 
 class UnsignedDecimal(models.DecimalField):
@@ -218,10 +226,12 @@ class Keccak256Field(models.BinaryField):
     def from_db_value(self, value: memoryview, expression, connection) -> Optional[str]:
         if value:
             return HexBytes(value.tobytes()).hex()
+        return None
 
     def get_prep_value(self, value: Union[bytes, str]) -> Optional[bytes]:
         if value:
             return self._to_bytes(value)
+        return None
 
     def value_to_string(self, obj):
         return str(self.value_from_object(obj))
@@ -236,6 +246,7 @@ class Keccak256Field(models.BinaryField):
                     code="invalid",
                     params={"value": value},
                 )
+        return None
 
     def formfield(self, **kwargs):
         defaults = {

--- a/safe_eth/eth/ethereum_client.py
+++ b/safe_eth/eth/ethereum_client.py
@@ -112,23 +112,33 @@ def tx_with_exception_handling(func):
     error_with_exception: Dict[str, Exception] = {
         "EIP-155": ChainIdIsRequired,
         "Transaction with the same hash was already imported": TransactionAlreadyImported,
-        "replacement transaction underpriced": ReplacementTransactionUnderpriced,  # https://github.com/ethereum/go-ethereum/blob/eaccdba4ab310e3fb98edbc4b340b5e7c4d767fd/core/tx_pool.go#L72
-        "There is another transaction with same nonce in the queue": ReplacementTransactionUnderpriced,  # https://github.com/openethereum/openethereum/blob/f1dc6821689c7f47d8fd07dfc0a2c5ad557b98ec/crates/rpc/src/v1/helpers/errors.rs#L374
+        "replacement transaction underpriced": ReplacementTransactionUnderpriced,
+        # https://github.com/ethereum/go-ethereum/blob/eaccdba4ab310e3fb98edbc4b340b5e7c4d767fd/core/tx_pool.go#L72
+        "There is another transaction with same nonce in the queue": ReplacementTransactionUnderpriced,
+        # https://github.com/openethereum/openethereum/blob/f1dc6821689c7f47d8fd07dfc0a2c5ad557b98ec/crates/rpc/src/v1/helpers/errors.rs#L374
         "There are too many transactions in the queue. Your transaction was dropped due to limit. Try increasing "
-        "the fee": TransactionQueueLimitReached,  # https://github.com/openethereum/openethereum/blob/f1dc6821689c7f47d8fd07dfc0a2c5ad557b98ec/crates/rpc/src/v1/helpers/errors.rs#L380
-        "txpool is full": TransactionQueueLimitReached,  # https://github.com/ethereum/go-ethereum/blob/eaccdba4ab310e3fb98edbc4b340b5e7c4d767fd/core/tx_pool.go#L68
-        "transaction underpriced": TransactionGasPriceTooLow,  # https://github.com/ethereum/go-ethereum/blob/eaccdba4ab310e3fb98edbc4b340b5e7c4d767fd/core/tx_pool.go#L64
-        "Transaction gas price is too low": TransactionGasPriceTooLow,  # https://github.com/openethereum/openethereum/blob/f1dc6821689c7f47d8fd07dfc0a2c5ad557b98ec/crates/rpc/src/v1/helpers/errors.rs#L386
+        "the fee": TransactionQueueLimitReached,
+        # https://github.com/openethereum/openethereum/blob/f1dc6821689c7f47d8fd07dfc0a2c5ad557b98ec/crates/rpc/src/v1/helpers/errors.rs#L380
+        "txpool is full": TransactionQueueLimitReached,
+        # https://github.com/ethereum/go-ethereum/blob/eaccdba4ab310e3fb98edbc4b340b5e7c4d767fd/core/tx_pool.go#L68
+        "transaction underpriced": TransactionGasPriceTooLow,
+        # https://github.com/ethereum/go-ethereum/blob/eaccdba4ab310e3fb98edbc4b340b5e7c4d767fd/core/tx_pool.go#L64
+        "Transaction gas price is too low": TransactionGasPriceTooLow,
+        # https://github.com/openethereum/openethereum/blob/f1dc6821689c7f47d8fd07dfc0a2c5ad557b98ec/crates/rpc/src/v1/helpers/errors.rs#L386
         "from not found": FromAddressNotFound,
         "correct nonce": InvalidNonce,
-        "nonce too low": NonceTooLow,  # https://github.com/ethereum/go-ethereum/blob/bbfb1e4008a359a8b57ec654330c0e674623e52f/core/error.go#L46
-        "nonce too high": NonceTooHigh,  # https://github.com/ethereum/go-ethereum/blob/bbfb1e4008a359a8b57ec654330c0e674623e52f/core/error.go#L46
-        "insufficient funds": InsufficientFunds,  # https://github.com/openethereum/openethereum/blob/f1dc6821689c7f47d8fd07dfc0a2c5ad557b98ec/crates/rpc/src/v1/helpers/errors.rs#L389
+        "nonce too low": NonceTooLow,
+        # https://github.com/ethereum/go-ethereum/blob/bbfb1e4008a359a8b57ec654330c0e674623e52f/core/error.go#L46
+        "nonce too high": NonceTooHigh,
+        # https://github.com/ethereum/go-ethereum/blob/bbfb1e4008a359a8b57ec654330c0e674623e52f/core/error.go#L46
+        "insufficient funds": InsufficientFunds,
+        # https://github.com/openethereum/openethereum/blob/f1dc6821689c7f47d8fd07dfc0a2c5ad557b98ec/crates/rpc/src/v1/helpers/errors.rs#L389
         "doesn't have enough funds": InsufficientFunds,
         "sender account not recognized": SenderAccountNotFoundInNode,
         "unknown account": UnknownAccount,
         "exceeds block gas limit": GasLimitExceeded,  # Geth
-        "exceeds current gas limit": GasLimitExceeded,  # https://github.com/openethereum/openethereum/blob/f1dc6821689c7f47d8fd07dfc0a2c5ad557b98ec/crates/rpc/src/v1/helpers/errors.rs#L392
+        "exceeds current gas limit": GasLimitExceeded,
+        # https://github.com/openethereum/openethereum/blob/f1dc6821689c7f47d8fd07dfc0a2c5ad557b98ec/crates/rpc/src/v1/helpers/errors.rs#L392
     }
 
     @wraps(func)
@@ -538,12 +548,10 @@ class Erc20Manager(EthereumClientManager):
         )
 
         return_balances = [
-            {
-                "token_address": token_address,
-                "balance": balance
-                if isinstance(balance, int)
-                else 0,  # A `revert` with bytes can be returned
-            }
+            BalanceDict(
+                balance=balance if isinstance(balance, int) else 0,
+                token_address=token_address,
+            )
             for token_address, balance in zip(token_addresses, balances)
         ]
 
@@ -552,10 +560,9 @@ class Erc20Manager(EthereumClientManager):
 
         # Add ether balance response
         return [
-            {
-                "token_address": None,
-                "balance": self.ethereum_client.get_balance(address),
-            }
+            BalanceDict(
+                balance=self.ethereum_client.get_balance(address), token_address=None
+            )
         ] + return_balances
 
     def get_name(self, erc20_address: ChecksumAddress) -> str:
@@ -710,7 +717,7 @@ class Erc20Manager(EthereumClientManager):
                 for address in addresses
             ]
             # Topics for transfer `to` and `from` an address
-            all_topics = [
+            all_topics: List[Sequence[Any]] = [
                 [topic_0, addresses_encoded],  # Topics from
                 [topic_0, None, addresses_encoded],  # Topics to
             ]
@@ -729,11 +736,9 @@ class Erc20Manager(EthereumClientManager):
 
             # Decode events. Just pick valid ERC20 Transfer events (ERC721 `Transfer` has the same signature)
             for event in self.slow_w3.eth.get_logs(parameters):
-                event["args"] = self._decode_transfer_log(
-                    event["data"], event["topics"]
-                )
-                if event["args"]:
-                    erc20_events.append(LogReceiptDecoded(event))
+                event_args = self._decode_transfer_log(event["data"], event["topics"])
+                if event_args:
+                    erc20_events.append(LogReceiptDecoded(**event, args=event_args))
 
         erc20_events.sort(key=lambda x: x["blockNumber"])
         return erc20_events
@@ -788,7 +793,7 @@ class Erc20Manager(EthereumClientManager):
         if to_address:
             argument_filters["to"] = to_address
 
-        return erc20.events.Transfer.create_filter(
+        return erc20.events.Transfer.create_filter(  # type: ignore[attr-defined]
             fromBlock=from_block,
             toBlock=to_block,
             address=token_address,
@@ -1000,6 +1005,7 @@ class TracingManager(EthereumClientManager):
                     trace_address = trace_address[:-1]
                 else:
                     return trace
+        return None
 
     def get_next_traces(
         self,
@@ -1035,7 +1041,7 @@ class TracingManager(EthereumClientManager):
         return traces
 
     def trace_block(self, block_identifier: BlockIdentifier) -> List[BlockTrace]:
-        return self.slow_w3.tracing.trace_block(block_identifier)
+        return self.slow_w3.tracing.trace_block(block_identifier)  # type: ignore[attr-defined]
 
     def trace_blocks(
         self, block_identifiers: Sequence[BlockIdentifier]
@@ -1057,14 +1063,14 @@ class TracingManager(EthereumClientManager):
         ]
 
         results = self.ethereum_client.raw_batch_request(payload)
-        return [trace_list_result_formatter(block_traces) for block_traces in results]
+        return [trace_list_result_formatter(block_traces) for block_traces in results]  # type: ignore[arg-type]
 
     def trace_transaction(self, tx_hash: EthereumHash) -> List[FilterTrace]:
         """
         :param tx_hash:
         :return: List of internal txs for `tx_hash`
         """
-        return self.slow_w3.tracing.trace_transaction(tx_hash)
+        return self.slow_w3.tracing.trace_transaction(tx_hash)  # type: ignore[attr-defined]
 
     def trace_transactions(
         self, tx_hashes: Sequence[EthereumHash]
@@ -1085,7 +1091,7 @@ class TracingManager(EthereumClientManager):
             for i, tx_hash in enumerate(tx_hashes)
         ]
         results = self.ethereum_client.raw_batch_request(payload)
-        return [trace_list_result_formatter(tx_traces) for tx_traces in results]
+        return [trace_list_result_formatter(tx_traces) for tx_traces in results]  # type: ignore[arg-type]
 
     def trace_filter(
         self,
@@ -1186,7 +1192,7 @@ class TracingManager(EthereumClientManager):
         if to_address:
             parameters["toAddress"] = to_address
 
-        return self.slow_w3.tracing.trace_filter(parameters)
+        return self.slow_w3.tracing.trace_filter(parameters)  # type: ignore[attr-defined]
 
 
 class EthereumClient:
@@ -1238,7 +1244,7 @@ class EthereumClient:
             # Don't spend resources con converting dictionaries to attribute dictionaries
             w3.middleware_onion.remove("attrdict")
             # Disable web3 automatic retry, it's handled on our HTTP Session
-            w3.provider.middlewares = []
+            w3.provider.middlewares = ()
             if self.use_caching_middleware:
                 w3.middleware_onion.add(simple_cache_middleware)
 
@@ -1264,7 +1270,7 @@ class EthereumClient:
 
     def raw_batch_request(
         self, payload: Sequence[Dict[str, Any]], batch_size: Optional[int] = None
-    ) -> Iterable[Optional[Dict[str, Any]]]:
+    ) -> Iterable[Union[Optional[Dict[str, Any]], List[Dict[str, Any]]]]:
         """
         Perform a raw batch JSON RPC call
 
@@ -1290,7 +1296,7 @@ class EthereumClient:
                     response.status_code,
                     response.content,
                 )
-                raise ValueError(f"Batch request error: {response.content}")
+                raise ValueError(f"Batch request error: {response.content!r}")
 
             results = response.json()
 
@@ -1328,7 +1334,7 @@ class EthereumClient:
         """
         :return: RPC version information
         """
-        return self.w3.clientVersion
+        return self.w3.client_version
 
     def get_network(self) -> EthereumNetwork:
         """
@@ -1353,8 +1359,9 @@ class EthereumClient:
         address = os.environ.get(
             "SAFE_SINGLETON_FACTORY_ADDRESS", SAFE_SINGLETON_FACTORY_ADDRESS
         )
-        if self.is_contract(address):
-            return address
+        address_checksum = ChecksumAddress(HexAddress(HexStr(address)))
+        if self.is_contract(address_checksum):
+            return address_checksum
         return None
 
     @cache
@@ -1369,7 +1376,7 @@ class EthereumClient:
             return False
 
     @cached_property
-    def multicall(self) -> "Multicall":  # noqa F821
+    def multicall(self) -> "Multicall":  # type: ignore # noqa F821
         from .multicall import Multicall
 
         try:
@@ -1567,13 +1574,13 @@ class EthereumClient:
         if from_:
             tx["from"] = from_
         if value:
-            tx["value"] = value
+            tx["value"] = Wei(value)
         if data:
             tx["data"] = data
         if gas:
             tx["gas"] = gas
         if gas_price:
-            tx["gasPrice"] = gas_price
+            tx["gasPrice"] = Wei(gas_price)
         try:
             return self.w3.eth.estimate_gas(tx, block_identifier=block_identifier)
         except (Web3Exception, ValueError):
@@ -1641,15 +1648,15 @@ class EthereumClient:
         :raises: ValueError if EIP1559 not supported
         """
         base_fee_per_gas, max_priority_fee_per_gas = self.estimate_fee_eip1559(tx_speed)
-        tx = TxParams(tx)  # Don't modify provided tx
+        tx = TxParams(**tx)  # Don't modify provided tx
         if "gasPrice" in tx:
             del tx["gasPrice"]
 
         if "chainId" not in tx:
             tx["chainId"] = self.get_chain_id()
 
-        tx["maxPriorityFeePerGas"] = max_priority_fee_per_gas
-        tx["maxFeePerGas"] = base_fee_per_gas + max_priority_fee_per_gas
+        tx["maxPriorityFeePerGas"] = Wei(max_priority_fee_per_gas)
+        tx["maxFeePerGas"] = Wei(base_fee_per_gas + max_priority_fee_per_gas)
         return tx
 
     def get_balance(
@@ -1726,7 +1733,11 @@ class EthereumClient:
         receipts = []
         for tx_receipt in results:
             # Parity returns tx_receipt even is tx is still pending, so we check `blockNumber` is not None
-            if tx_receipt and tx_receipt["blockNumber"] is not None:
+            if (
+                tx_receipt
+                and isinstance(tx_receipt, dict)
+                and tx_receipt["blockNumber"] is not None
+            ):
                 receipts.append(receipt_formatter(tx_receipt))
             else:
                 receipts.append(None)
@@ -1774,7 +1785,7 @@ class EthereumClient:
         results = self.raw_batch_request(payload)
         blocks = []
         for raw_block in results:
-            if raw_block:
+            if raw_block and isinstance(raw_block, dict):
                 if "extraData" in raw_block:
                     del raw_block[
                         "extraData"
@@ -1813,30 +1824,30 @@ class EthereumClient:
         :return:
         """
 
-        tx_params: TxParams = tx_params or {}
+        new_tx_params: TxParams = tx_params if tx_params is not None else {}
 
         if from_address:
-            tx_params["from"] = from_address
+            new_tx_params["from"] = from_address
 
         if to_address:
-            tx_params["to"] = to_address
+            new_tx_params["to"] = to_address
 
         if value is not None:
-            tx_params["value"] = value
+            new_tx_params["value"] = Wei(value)
 
         if gas_price is not None:
-            tx_params["gasPrice"] = gas_price
+            new_tx_params["gasPrice"] = Wei(gas_price)
 
         if gas is not None:
-            tx_params["gas"] = gas
+            new_tx_params["gas"] = gas
 
         if nonce is not None:
-            tx_params["nonce"] = nonce
+            new_tx_params["nonce"] = Nonce(nonce)
 
         if chain_id is not None:
-            tx_params["chainId"] = chain_id
+            new_tx_params["chainId"] = chain_id
 
-        return tx_params
+        return new_tx_params
 
     @tx_with_exception_handling
     def send_transaction(self, transaction_dict: TxParams) -> HexBytes:
@@ -1844,7 +1855,13 @@ class EthereumClient:
 
     @tx_with_exception_handling
     def send_raw_transaction(self, raw_transaction: EthereumData) -> HexBytes:
-        return self.w3.eth.send_raw_transaction(bytes(raw_transaction))
+        if isinstance(raw_transaction, bytes):
+            value_bytes = raw_transaction
+        else:
+            value_bytes = bytes.fromhex(
+                raw_transaction.replace("0x", "")
+            )  # Remove '0x' and convert
+        return self.w3.eth.send_raw_transaction(value_bytes)
 
     def send_unsigned_transaction(
         self,
@@ -1936,6 +1953,7 @@ class EthereumClient:
                     address, block_identifier=block_identifier
                 )
                 number_errors -= 1
+        return HexBytes("")
 
     def send_eth_to(
         self,

--- a/safe_eth/eth/oracles/superfluid.py
+++ b/safe_eth/eth/oracles/superfluid.py
@@ -1,4 +1,5 @@
 from eth_abi.exceptions import DecodingError
+from eth_utils import to_checksum_address
 from web3.exceptions import Web3Exception
 
 from .. import EthereumClient, EthereumNetwork
@@ -35,8 +36,11 @@ class SuperfluidOracle(PriceOracle):
 
     def get_price(self, token_address: str) -> float:
         try:
+            token_address_checksum = to_checksum_address(token_address)
             underlying_token = (
-                self.w3.eth.contract(token_address, abi=super_token_abi)
+                self.w3.eth.contract(
+                    address=token_address_checksum, abi=super_token_abi
+                )
                 .functions.getUnderlyingToken()
                 .call()
             )

--- a/safe_eth/eth/tests/account_abstraction/test_bundler_client.py
+++ b/safe_eth/eth/tests/account_abstraction/test_bundler_client.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from django.test import TestCase
 
 import requests
+from eth_typing import HexStr
 
 from ...account_abstraction import (
     BundlerClient,
@@ -37,7 +38,7 @@ class TestBundlerClient(TestCase):
         mock_session.return_value.json = MagicMock(return_value=user_operation_mock)
         self.bundler.get_user_operation_by_hash.cache_clear()
         expected_user_operation = UserOperation.from_bundler_response(
-            user_operation_hash, user_operation_mock["result"]
+            HexStr(user_operation_hash), user_operation_mock["result"]
         )
         self.assertEqual(
             self.bundler.get_user_operation_by_hash(user_operation_hash),
@@ -127,7 +128,7 @@ class TestBundlerClient(TestCase):
         )
         self.bundler.get_user_operation_and_receipt.cache_clear()
         expected_user_operation = UserOperation.from_bundler_response(
-            user_operation_hash, user_operation_mock["result"]
+            HexStr(user_operation_hash), user_operation_mock["result"]
         )
         expected_user_operation_receipt = UserOperationReceipt.from_bundler_response(
             user_operation_receipt_mock["result"]

--- a/safe_eth/eth/tests/clients/test_sourcify_client.py
+++ b/safe_eth/eth/tests/clients/test_sourcify_client.py
@@ -40,6 +40,7 @@ class TestSourcifyClient(TestCase):
             )
         except IOError:
             self.skipTest("Cannot connect to Sourcify")
+        assert safe_contract_metadata_mainnet is not None
         self.assertEqual(safe_contract_metadata_mainnet.name, "Safe")
         self.assertIsInstance(safe_contract_metadata_mainnet.abi, List)
         self.assertTrue(safe_contract_metadata_mainnet.abi)
@@ -55,6 +56,7 @@ class TestSourcifyClient(TestCase):
         token_contract_metadata_mainnet = sourcify_client_mainnet.get_contract_metadata(
             partial_match_contract_address
         )
+        assert token_contract_metadata_mainnet is not None
         self.assertEqual(token_contract_metadata_mainnet.name, "LiquidGasToken")
         self.assertIsInstance(token_contract_metadata_mainnet.abi, List)
         self.assertTrue(token_contract_metadata_mainnet.abi)

--- a/safe_eth/eth/tests/ethereum_test_case.py
+++ b/safe_eth/eth/tests/ethereum_test_case.py
@@ -3,9 +3,10 @@ import os
 
 from eth_account import Account
 from eth_account.signers.local import LocalAccount
+from eth_typing import ChecksumAddress, HexAddress, HexStr
 from web3 import Web3
 from web3.contract import Contract
-from web3.types import TxParams
+from web3.types import TxParams, Wei
 
 from ..ethereum_client import EthereumClient, get_auto_ethereum_client
 from ..multicall import Multicall
@@ -66,7 +67,9 @@ class EthereumTestCaseMixin:
         return send_tx(self.w3, tx, account)
 
     def send_ether(self, to: str, value: int) -> bytes:
-        return send_tx(self.w3, {"to": to, "value": value}, self.ethereum_test_account)
+        return send_tx(
+            self.w3, {"to": to, "value": Wei(value)}, self.ethereum_test_account
+        )
 
     def create_and_fund_account(
         self, initial_ether: float = 0, initial_wei: int = 0
@@ -76,7 +79,9 @@ class EthereumTestCaseMixin:
             self.send_tx(
                 {
                     "to": account.address,
-                    "value": self.w3.to_wei(initial_ether, "ether") + initial_wei,
+                    "value": Wei(
+                        self.w3.to_wei(initial_ether, "ether") + Wei(initial_wei)
+                    ),
                 },
                 self.ethereum_test_account,
             )
@@ -95,12 +100,17 @@ class EthereumTestCaseMixin:
             self.ethereum_test_account,
             name,
             symbol,
-            owner,
+            ChecksumAddress(HexAddress(HexStr(owner))),
             amount,
             decimals=decimals,
         )
 
     def deploy_example_erc20(self, amount: int, owner: str) -> Contract:
         return deploy_erc20(
-            self.w3, self.ethereum_test_account, "Uxio", "UXI", owner, amount
+            self.w3,
+            self.ethereum_test_account,
+            "Uxio",
+            "UXI",
+            ChecksumAddress(HexAddress(HexStr(owner))),
+            amount,
         )

--- a/safe_eth/eth/tests/mocks/mock_bundler.py
+++ b/safe_eth/eth/tests/mocks/mock_bundler.py
@@ -1,9 +1,11 @@
+from typing import Any, Dict
+
 from eth_typing import ChecksumAddress, HexAddress, HexStr
 from hexbytes import HexBytes
 
 # Module address and chainId used for the following mocks
 safe_4337_address = ChecksumAddress(
-    HexStr(HexAddress("0xB0B5c0578Aa134b0496a6C0e51A7aae47C522861"))
+    HexAddress(HexStr("0xB0B5c0578Aa134b0496a6C0e51A7aae47C522861"))
 )
 safe_4337_user_operation_hash_mock = HexBytes(
     "0x39b3e2171c04539d9b3f848d04364dfaa42cc0b412ff65ce2a85c566cf8bf281"
@@ -17,7 +19,7 @@ safe_4337_safe_operation_hash_mock = HexBytes(
 )
 safe_4337_chain_id_mock = 11155111
 
-user_operation_mock = {
+user_operation_mock: Dict[str, Any] = {
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
@@ -41,7 +43,7 @@ user_operation_mock = {
     },
 }
 
-user_operation_receipt_mock = {
+user_operation_receipt_mock: Dict[str, Any] = {
     "jsonrpc": "2.0",
     "id": 1,
     "result": {
@@ -384,7 +386,7 @@ user_operation_receipt_mock = {
     },
 }
 
-supported_entrypoint_mock = {
+supported_entrypoint_mock: Dict[str, Any] = {
     "jsonrpc": "2.0",
     "id": 1,
     "result": [

--- a/safe_eth/eth/tests/oracles/test_cowswap.py
+++ b/safe_eth/eth/tests/oracles/test_cowswap.py
@@ -18,7 +18,7 @@ from ..test_oracles import (
 from ..utils import just_test_if_mainnet_node
 
 
-@pytest.skip("Having issues often", allow_module_level=True)
+@pytest.mark.skip("Having issues often")
 class TestCowswapOracle(EthereumTestCaseMixin, TestCase):
     def test_get_price(self):
         mainnet_node = just_test_if_mainnet_node()

--- a/safe_eth/eth/tests/test_multicall.py
+++ b/safe_eth/eth/tests/test_multicall.py
@@ -3,6 +3,8 @@ from unittest.mock import MagicMock
 
 from django.test import TestCase
 
+from eth_typing import URI, ChecksumAddress, HexAddress, HexStr
+
 from .. import EthereumClient, EthereumNetwork, EthereumNetworkNotSupported
 from ..constants import NULL_ADDRESS
 from ..contracts import get_erc20_contract
@@ -79,9 +81,12 @@ class TestMulticallNode(EthereumTestCaseMixin, TestCase):
     def setUpClass(cls) -> None:
         super().setUpClass()
         mainnet_node = just_test_if_mainnet_node()
-        cls.ethereum_client = EthereumClient(mainnet_node)
+        cls.ethereum_client = EthereumClient(URI(mainnet_node))
         cls.gno_contract = get_erc20_contract(
-            cls.ethereum_client.w3, "0x6810e776880C02933D47DB1b9fc05908e5386b96"
+            cls.ethereum_client.w3,
+            ChecksumAddress(
+                HexAddress(HexStr("0x6810e776880C02933D47DB1b9fc05908e5386b96"))
+            ),
         )
         cls.not_existing_contract = get_erc20_contract(
             cls.ethereum_client.w3, NULL_ADDRESS

--- a/safe_eth/eth/tests/utils.py
+++ b/safe_eth/eth/tests/utils.py
@@ -48,7 +48,7 @@ def just_test_if_node_available(node_url_variable_name: str) -> str:
             )
             if not response.ok:
                 pytest.fail(
-                    f"Problem connecting to node {node_url}: {response.status_code} - {response.content}"
+                    f"Problem connecting to node {node_url}: {response.status_code} - {response.content!r}"
                 )
         except IOError:
             pytest.fail(f"Problem connecting to {node_url}")
@@ -150,10 +150,12 @@ def bytes_to_str(o: Any) -> Any:
         o = dict(o)  # Remove AttributeDict
         for k in o.keys():
             o[k] = bytes_to_str(o[k])
-    elif isinstance(o, (list, tuple)):
+    elif isinstance(o, list):
         o = deepcopy(o)
         for i, v in enumerate(o):
             o[i] = bytes_to_str(o[i])
+    elif isinstance(o, tuple):
+        o = tuple(bytes_to_str(v) for v in o)
     elif isinstance(o, set):
         o = {bytes_to_str(element) for element in o}
     return o

--- a/safe_eth/safe/addresses.py
+++ b/safe_eth/safe/addresses.py
@@ -5,12 +5,12 @@ Every entry contains a tuple with address, deployment block number and version
 """
 from typing import Dict, List, Tuple
 
-from eth_typing import ChecksumAddress
+from eth_typing import ChecksumAddress, HexAddress, HexStr
 
 from safe_eth.eth import EthereumNetwork
 
-SAFE_SIMULATE_TX_ACCESSOR_ADDRESS: ChecksumAddress = (
-    "0x3d4BA2E0884aa488718476ca2FB8Efc291A46199"
+SAFE_SIMULATE_TX_ACCESSOR_ADDRESS: ChecksumAddress = ChecksumAddress(
+    HexAddress(HexStr("0x3d4BA2E0884aa488718476ca2FB8Efc291A46199"))
 )
 
 MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {

--- a/safe_eth/safe/api/base_api.py
+++ b/safe_eth/safe/api/base_api.py
@@ -34,7 +34,7 @@ class SafeBaseAPI(ABC):
         """
         self.network = network
         self.ethereum_client = ethereum_client
-        self.base_url = base_url or self.URL_BY_NETWORK.get(network)
+        self.base_url = base_url or self.URL_BY_NETWORK.get(network) or ""
         if not self.base_url:
             raise EthereumNetworkNotSupported(network)
         self.http_session = prepare_http_session(10, 100)

--- a/safe_eth/safe/api/base_api.py
+++ b/safe_eth/safe/api/base_api.py
@@ -34,7 +34,7 @@ class SafeBaseAPI(ABC):
         """
         self.network = network
         self.ethereum_client = ethereum_client
-        self.base_url = base_url or self.URL_BY_NETWORK.get(network) or ""
+        self.base_url = base_url or self.URL_BY_NETWORK.get(network, "")
         if not self.base_url:
             raise EthereumNetworkNotSupported(network)
         self.http_session = prepare_http_session(10, 100)

--- a/safe_eth/safe/api/transaction_service_api/entities.py
+++ b/safe_eth/safe/api/transaction_service_api/entities.py
@@ -1,6 +1,8 @@
-from typing import Any, List, Optional, TypedDict
+from typing import Any, List, Optional, TypedDict, Union
 
-from eth_typing import AnyAddress, HexStr
+from eth_typing import Address, ChecksumAddress, HexAddress, HexStr
+
+AnyAddressType = Union[Address, HexAddress, ChecksumAddress]
 
 
 class ParameterDecoded(TypedDict):
@@ -22,22 +24,22 @@ class Erc20Info(TypedDict):
 
 
 class Balance(TypedDict):
-    token_address: Optional[AnyAddress]
+    token_address: Optional[AnyAddressType]
     token: Optional[Erc20Info]
     balance: int
 
 
 class DelegateUser(TypedDict):
-    safe: Optional[AnyAddress]
-    delegate: AnyAddress
-    delegator: AnyAddress
+    safe: Optional[AnyAddressType]
+    delegate: AnyAddressType
+    delegator: AnyAddressType
     label: str
 
 
 class MessageConfirmation(TypedDict):
     created: str
     modified: str
-    owner: AnyAddress
+    owner: AnyAddressType
     signature: HexStr
     signatureType: str
 
@@ -45,17 +47,17 @@ class MessageConfirmation(TypedDict):
 class Message(TypedDict):
     created: str
     modified: str
-    safe: AnyAddress
+    safe: AnyAddressType
     messageHash: HexStr
     message: Any
-    proposedBy: AnyAddress
+    proposedBy: AnyAddressType
     safeAppId: int
     confirmations: Optional[List[MessageConfirmation]]
     preparedSignature: Optional[HexStr]
 
 
 class TransactionConfirmation(TypedDict):
-    owner: AnyAddress
+    owner: AnyAddressType
     submissionDate: str
     transactionHash: HexStr
     signature: HexStr
@@ -63,16 +65,16 @@ class TransactionConfirmation(TypedDict):
 
 
 class Transaction(TypedDict):
-    safe: AnyAddress
-    to: AnyAddress
+    safe: AnyAddressType
+    to: AnyAddressType
     value: str
     data: Optional[HexStr]
     operation: int
-    gasToken: Optional[AnyAddress]
+    gasToken: Optional[AnyAddressType]
     safeTxGas: int
     baseGas: int
     gasPrice: str
-    refundReceiver: Optional[AnyAddress]
+    refundReceiver: Optional[AnyAddressType]
     nonce: int
     execution_date: str
     submission_date: str
@@ -80,8 +82,8 @@ class Transaction(TypedDict):
     blockNumber: Optional[int]
     transactionHash: HexStr
     safeTxHash: HexStr
-    proposer: AnyAddress
-    executor: Optional[AnyAddress]
+    proposer: AnyAddressType
+    executor: Optional[AnyAddressType]
     isExecuted: bool
     isSuccessful: Optional[bool]
     ethGasPrice: Optional[str]

--- a/safe_eth/safe/safe_create2_tx.py
+++ b/safe_eth/safe/safe_create2_tx.py
@@ -127,13 +127,14 @@ class SafeCreate2TxBuilder:
         payment_token = payment_token or NULL_ADDRESS
         assert fast_is_checksum_address(payment_receiver)
         assert fast_is_checksum_address(payment_token)
+        owners_list = list(map(str, owners))
 
         # Get bytes for `setup(address[] calldata _owners, uint256 _threshold, address to, bytes calldata data,
         # address paymentToken, uint256 payment, address payable paymentReceiver)`
         # This initializer will be passed to the ProxyFactory to be called right after proxy is deployed
         # We use `payment=0` as safe has no ether yet and estimation will fail
         safe_setup_data: bytes = self._get_initial_setup_safe_data(
-            owners,
+            owners_list,
             threshold,
             fallback_handler=fallback_handler,
             payment_token=payment_token,
@@ -141,7 +142,7 @@ class SafeCreate2TxBuilder:
         )
 
         calculated_gas: int = self._calculate_gas(
-            owners, safe_setup_data, payment_token
+            owners_list, safe_setup_data, payment_token
         )
         estimated_gas: int = self._estimate_gas(
             safe_setup_data, salt_nonce, payment_token, payment_receiver
@@ -156,7 +157,7 @@ class SafeCreate2TxBuilder:
 
         # Now we have a estimate for `payment` so we get initialization data again
         final_safe_setup_data: bytes = self._get_initial_setup_safe_data(
-            owners,
+            owners_list,
             threshold,
             fallback_handler=fallback_handler,
             payment_token=payment_token,
@@ -171,7 +172,7 @@ class SafeCreate2TxBuilder:
 
         return SafeCreate2Tx(
             salt_nonce,
-            owners,
+            owners_list,
             threshold,
             fallback_handler,
             self.master_copy_address,

--- a/safe_eth/safe/safe_creator.py
+++ b/safe_eth/safe/safe_creator.py
@@ -90,7 +90,7 @@ class SafeCreator:
         )
 
         if proxy_factory_address:
-            proxy_factory = ProxyFactory(proxy_factory_address, ethereum_client)
+            proxy_factory = ProxyFactory(proxy_factory_address, ethereum_client)  # type: ignore[abstract]
             return proxy_factory.deploy_proxy_contract_with_nonce(
                 deployer_account, master_copy_address, initializer=HexBytes(initializer)
             )

--- a/safe_eth/safe/signatures.py
+++ b/safe_eth/safe/signatures.py
@@ -51,7 +51,7 @@ def signatures_to_bytes(signatures: List[Tuple[int, int, int]]) -> bytes:
     return b"".join([signature_to_bytes(v, r, s) for v, r, s in signatures])
 
 
-def get_signing_address(signed_hash: Union[bytes, str], v: int, r: int, s: int) -> str:
+def get_signing_address(signed_hash: bytes, v: int, r: int, s: int) -> str:
     """
     :return: checksummed ethereum address, for example `0x568c93675A8dEb121700A6FAdDdfE7DFAb66Ae4A`
     :rtype: str or `NULL_ADDRESS` if signature is not valid

--- a/safe_eth/util/http.py
+++ b/safe_eth/util/http.py
@@ -1,3 +1,5 @@
+from typing import Union
+
 import requests
 
 
@@ -13,7 +15,7 @@ def prepare_http_session(
     https://docs.python-requests.org/en/latest/api/#requests.adapters.HTTPAdapter
     """
     session = requests.Session()
-    retry_conf = (
+    retry_conf: Union[requests.adapters.Retry, int] = (
         requests.adapters.Retry(
             total=retry_count, backoff_factor=0.3, respect_retry_after_header=False
         )


### PR DESCRIPTION
Closes #1272 

Points of interest:

- The problems indicated by the mypy library are solved.
- mypy is configured in mypy.ini following the format of other Safe projects.
- Some exceptions need to be added:
  - Some `web3` lib related ignores and the abstract classes of the `safe` contracts. (`# type: ignore...` in specific lines)
  - Avoid checking `check_untyped_defs`. Checking it would involve rewriting a large part of the code. Right now only functions with type annotations are checked.
- Added `mypy` checking in CI and in the `run_tests.sh` script.