### PR TITLE
Fix typying proposer can be None

### DIFF
--- a/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
+++ b/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
@@ -130,7 +130,7 @@ class TransactionServiceApi(SafeBaseAPI):
     ) -> TransactionServiceTx:
         signatures = self.parse_signatures(tx_raw)
         safe_tx = TransactionServiceTx(
-            to_checksum_address(tx_raw["proposer"]),
+            to_checksum_address(tx_raw["proposer"]) if tx_raw["proposer"] else None,
             self.ethereum_client,
             tx_raw["safe"],
             tx_raw["to"],

--- a/safe_eth/safe/api/transaction_service_api/transaction_service_tx.py
+++ b/safe_eth/safe/api/transaction_service_api/transaction_service_tx.py
@@ -1,9 +1,11 @@
+from typing import Optional
+
 from eth_typing import ChecksumAddress
 
 from safe_eth.safe import SafeTx
 
 
 class TransactionServiceTx(SafeTx):
-    def __init__(self, proposer: ChecksumAddress, *args, **kwargs):
+    def __init__(self, proposer: Optional[ChecksumAddress], *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.proposer = proposer


### PR DESCRIPTION
# Description
Safe transaction service lets create transactions without any signature, which means the proposer can be null.