### PR TITLE
Check batch requests return same number of results

### DIFF
--- a/safe_eth/eth/ethereum_client.py
+++ b/safe_eth/eth/ethereum_client.py
@@ -1284,7 +1284,6 @@ class EthereumClient:
 
         batch_size = batch_size or self.batch_request_max_size
 
-        all_results = []
         for payload_chunk in chunks(payload, batch_size):
             response = self.http_session.post(
                 self.ethereum_node_url, json=payload_chunk, timeout=self.slow_timeout
@@ -1301,8 +1300,12 @@ class EthereumClient:
 
             results = response.json()
 
-            # If there's an error some nodes return a json instead of a list
-            if isinstance(results, dict) and "error" in results:
+            # If there's an error some nodes return a json instead of a list, and other return a list of one element
+            if (isinstance(results, dict) and "error" in results) or (
+                isinstance(results, list)
+                and len(results) == 1
+                and "error" in results[0]
+            ):
                 logger.error(
                     "Batch request problem with payload=%s, result=%s)",
                     payload_chunk,
@@ -1318,19 +1321,19 @@ class EthereumClient:
                     response.content,
                 )
                 raise ValueError(
-                    "Different number of results than payload requests were returned"
+                    "Batch request error: Different number of results than payload requests were returned"
                 )
 
-            all_results.extend(results)
+            # Sorted due to Nodes like Erigon send back results out of order
+            for query, result in zip(payload, sorted(results, key=lambda x: x["id"])):
+                if "result" not in result:
+                    message = (
+                        f"Batch request problem with payload=`{query}` result={result}"
+                    )
+                    logger.error(message)
+                    raise ValueError(f"Batch request error: {message}")
 
-        # Nodes like Erigon send back results out of order
-        for query, result in zip(payload, sorted(all_results, key=lambda x: x["id"])):
-            if "result" not in result:
-                message = f"Problem with payload=`{query}` result={result}"
-                logger.error(message)
-                raise ValueError(message)
-
-            yield result["result"]
+                yield result["result"]
 
     @property
     def current_block_number(self):


### PR DESCRIPTION
- It could be possible that a batch request returns less results than the number of payloads
- We should catch and log those if that's the case
