### PR TITLE
Skip ens tests

### DIFF
--- a/safe_eth/eth/tests/clients/test_ens_client.py
+++ b/safe_eth/eth/tests/clients/test_ens_client.py
@@ -2,6 +2,7 @@ from unittest import mock
 
 from django.test import TestCase
 
+import pytest
 from eth_utils import keccak
 from requests import Session
 
@@ -25,6 +26,7 @@ class TestEnsClient(TestCase):
         self.assertEqual(len(EnsClient.domain_hash_to_hex_str(None)), 66)
         self.assertEqual(len(EnsClient.domain_hash_to_hex_str(2)), 66)
 
+    @pytest.mark.skip(reason="Test will fail due api changes")
     def test_query_by_account(self):
         ens_client = EnsClient(config=self.config)
         if not ens_client.is_available():
@@ -118,6 +120,7 @@ class TestEnsClient(TestCase):
             },
         )
 
+    @pytest.mark.skip(reason="Test will fail due api changes")
     def test_query_by_domain_hash(self):
         ens_client = EnsClient(config=self.config)
         if not ens_client.is_available():


### PR DESCRIPTION
# Description 
Skip ens tests due API changes, it´s the second time and we should check if we want to keep the ENS support or refactor this part to fix the issues finally. 