### PR TITLE
Add INK addresses for 1.3.0

### DIFF
--- a/safe_eth/safe/addresses.py
+++ b/safe_eth/safe/addresses.py
@@ -2012,6 +2012,22 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
     EthereumNetwork.INK: [
         ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 455060, "1.4.1"),
         ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 455065, "1.4.1+L2"),
+        ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 454704, "1.3.0"),  # 1.3.0 eip155
+        (
+            "0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552",
+            454704,
+            "1.3.0",
+        ),  # 1.3.0 canonical
+        (
+            "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
+            454704,
+            "1.3.0+L2",
+        ),  # 1.3.0+L2 eip155
+        (
+            "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
+            454704,
+            "1.3.0+L2",
+        ),  # 1.3.0+L2 canonical
     ],
 }
 
@@ -3018,5 +3034,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     ],
     EthereumNetwork.INK: [
         ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 454711),  # v1.4.1
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 454704),  # v1.3.0 eip155
+        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 454704),  # v1.3.0 canonical
     ],
 }


### PR DESCRIPTION
Added canonical and eip155 addresses for 1.3.0 contracts. 
The block is the first block were the deployment started. 