### PR TITLE
Add async methods to source contracts clients

### DIFF
--- a/safe_eth/eth/clients/__init__.py
+++ b/safe_eth/eth/clients/__init__.py
@@ -1,5 +1,6 @@
 # flake8: noqa F401
 from .blockscout_client import (
+    AsyncBlockscoutClient,
     BlockscoutClient,
     BlockscoutClientException,
     BlockScoutConfigurationProblem,
@@ -12,14 +13,18 @@ from .etherscan_client import (
     EtherscanClientException,
     EtherscanRateLimitError,
 )
-from .etherscan_client_v2 import EtherscanClientV2
+from .etherscan_client_v2 import AsyncEtherscanClientV2, EtherscanClientV2
 from .sourcify_client import (
+    AsyncSourcifyClient,
     SourcifyClient,
     SourcifyClientConfigurationProblem,
     SourcifyClientException,
 )
 
 __all__ = [
+    "AsyncBlockscoutClient",
+    "AsyncEtherscanClientV2",
+    "AsyncSourcifyClient",
     "BlockScoutConfigurationProblem",
     "BlockscoutClient",
     "BlockscoutClientException",

--- a/safe_eth/eth/clients/blockscout_client.py
+++ b/safe_eth/eth/clients/blockscout_client.py
@@ -178,8 +178,9 @@ class BlockscoutClient:
 
         return response.json()
 
+    @staticmethod
     def _process_contract_metadata(
-        self, contract_data: dict[str, Any]
+        contract_data: dict[str, Any]
     ) -> Optional[ContractMetadata]:
         """
         Return a ContractMetadata from BlockScout response

--- a/safe_eth/eth/clients/etherscan_client.py
+++ b/safe_eth/eth/clients/etherscan_client.py
@@ -353,6 +353,16 @@ class EtherscanClient:
                     time.sleep(5)
         return None
 
+    @staticmethod
+    def _process_contract_metadata(
+        contract_data: Dict[str, Any]
+    ) -> Optional[ContractMetadata]:
+        contract_name = contract_data["ContractName"]
+        contract_abi = contract_data["ABI"]
+        if contract_abi:
+            return ContractMetadata(contract_name, contract_abi, False)
+        return None
+
     def get_contract_metadata(
         self, contract_address: str, retry: bool = True
     ) -> Optional[ContractMetadata]:
@@ -360,10 +370,7 @@ class EtherscanClient:
             contract_address, retry=retry
         )
         if contract_source_code:
-            contract_name = contract_source_code["ContractName"]
-            contract_abi = contract_source_code["ABI"]
-            if contract_abi:
-                return ContractMetadata(contract_name, contract_abi, False)
+            return self._process_contract_metadata(contract_source_code)
         return None
 
     @staticmethod

--- a/safe_eth/eth/clients/etherscan_client.py
+++ b/safe_eth/eth/clients/etherscan_client.py
@@ -366,7 +366,8 @@ class EtherscanClient:
                 return ContractMetadata(contract_name, contract_abi, False)
         return None
 
-    def process_response(self, response):
+    @staticmethod
+    def _process_response(response):
         if response and isinstance(response, list):
             result = response[0]
             abi_str = result.get("ABI")
@@ -405,7 +406,7 @@ class EtherscanClient:
             f"module=contract&action=getsourcecode&address={contract_address}"
         )
         response = self._retry_request(url, retry=retry)  # Returns a list
-        return self.process_response(response)
+        return self._process_response(response)
 
     def get_contract_abi(self, contract_address: str, retry: bool = True):
         url = self.build_url(

--- a/safe_eth/eth/clients/etherscan_client.py
+++ b/safe_eth/eth/clients/etherscan_client.py
@@ -367,7 +367,7 @@ class EtherscanClient:
         return None
 
     @staticmethod
-    def _process_response(response):
+    def _process_get_contract_source_code_response(response):
         if response and isinstance(response, list):
             result = response[0]
             abi_str = result.get("ABI")
@@ -406,7 +406,7 @@ class EtherscanClient:
             f"module=contract&action=getsourcecode&address={contract_address}"
         )
         response = self._retry_request(url, retry=retry)  # Returns a list
-        return self._process_response(response)
+        return self._process_get_contract_source_code_response(response)
 
     def get_contract_abi(self, contract_address: str, retry: bool = True):
         url = self.build_url(

--- a/safe_eth/eth/clients/etherscan_client_v2.py
+++ b/safe_eth/eth/clients/etherscan_client_v2.py
@@ -143,10 +143,7 @@ class AsyncEtherscanClientV2(EtherscanClientV2):
             contract_address
         )
         if contract_source_code:
-            contract_name = contract_source_code["ContractName"]
-            contract_abi = contract_source_code["ABI"]
-            if contract_abi:
-                return ContractMetadata(contract_name, contract_abi, False)
+            return self._process_contract_metadata(contract_source_code)
         return None
 
     async def async_get_contract_abi(self, contract_address: str):

--- a/safe_eth/eth/clients/etherscan_client_v2.py
+++ b/safe_eth/eth/clients/etherscan_client_v2.py
@@ -134,7 +134,7 @@ class AsyncEtherscanClientV2(EtherscanClientV2):
             f"module=contract&action=getsourcecode&address={contract_address}"
         )
         response = await self._async_do_request(url)  # Returns a list
-        return self.process_response(response)
+        return self._process_response(response)
 
     async def async_get_contract_metadata(
         self, contract_address: str

--- a/safe_eth/eth/clients/etherscan_client_v2.py
+++ b/safe_eth/eth/clients/etherscan_client_v2.py
@@ -134,7 +134,7 @@ class AsyncEtherscanClientV2(EtherscanClientV2):
             f"module=contract&action=getsourcecode&address={contract_address}"
         )
         response = await self._async_do_request(url)  # Returns a list
-        return self._process_response(response)
+        return self._process_get_contract_source_code_response(response)
 
     async def async_get_contract_metadata(
         self, contract_address: str

--- a/safe_eth/eth/clients/sourcify_client.py
+++ b/safe_eth/eth/clients/sourcify_client.py
@@ -91,6 +91,20 @@ class SourcifyClient:
         result = self._do_request(url)
         return result or {}
 
+    def _process_contract_metadata(
+        self, contract_data: dict[str, Any], match_type: str
+    ) -> ContractMetadata:
+        """
+        Return a ContractMetadata from Sourcify response
+
+        :param contract_data:
+        :param match_type:
+        :return:
+        """
+        abi = self._get_abi_from_metadata(contract_data)
+        name = self._get_name_from_metadata(contract_data)
+        return ContractMetadata(name, abi, match_type == "partial_match")
+
     def get_contract_metadata(
         self, contract_address: str
     ) -> Optional[ContractMetadata]:
@@ -103,11 +117,9 @@ class SourcifyClient:
                 self.base_url_repo,
                 f"/contracts/{match_type}/{self.network.value}/{contract_address}/metadata.json",
             )
-            metadata = self._do_request(url)
-            if metadata:
-                abi = self._get_abi_from_metadata(metadata)
-                name = self._get_name_from_metadata(metadata)
-                return ContractMetadata(name, abi, match_type == "partial_match")
+            contract_data = self._do_request(url)
+            if contract_data:
+                return self._process_contract_metadata(contract_data, match_type)
         return None
 
 
@@ -155,9 +167,7 @@ class AsyncSourcifyClient(SourcifyClient):
                 self.base_url_repo,
                 f"/contracts/{match_type}/{self.network.value}/{contract_address}/metadata.json",
             )
-            metadata = await self._async_do_request(url)
-            if metadata:
-                abi = self._get_abi_from_metadata(metadata)
-                name = self._get_name_from_metadata(metadata)
-                return ContractMetadata(name, abi, match_type == "partial_match")
+            contract_data = await self._async_do_request(url)
+            if contract_data:
+                return self._process_contract_metadata(contract_data, match_type)
         return None

--- a/safe_eth/eth/clients/sourcify_client.py
+++ b/safe_eth/eth/clients/sourcify_client.py
@@ -3,6 +3,8 @@ from functools import cache
 from typing import Any, Dict, List, Optional
 from urllib.parse import urljoin
 
+import aiohttp
+
 from ...util.http import prepare_http_session
 from .. import EthereumNetwork
 from ..utils import fast_is_checksum_address
@@ -38,12 +40,17 @@ class SourcifyClient:
         request_timeout: int = int(
             os.environ.get("SOURCIFY_CLIENT_REQUEST_TIMEOUT", 10)
         ),
+        max_requests: int = int(os.environ.get("SOURCIFY_CLIENT_MAX_REQUESTS", 100)),
     ):
         self.network = network
         self.base_url_api = base_url_api
         self.base_url_repo = base_url_repo
-        self.http_session = prepare_http_session(10, 100)
+        self.http_session = prepare_http_session(10, max_requests)
         self.request_timeout = request_timeout
+        # Limit simultaneous connections to the same host.
+        self.async_session = aiohttp.ClientSession(
+            connector=aiohttp.TCPConnector(limit_per_host=max_requests)
+        )
 
         if not self.is_chain_supported(network.value):
             raise SourcifyClientConfigurationProblem(
@@ -65,6 +72,18 @@ class SourcifyClient:
             return None
 
         return response.json()
+
+    async def _async_do_request(self, url: str) -> Optional[Dict[str, Any]]:
+        """
+        Asynchronous version of _do_request
+        """
+        async with self.async_session.get(
+            url, timeout=self.request_timeout
+        ) as response:
+            if not response.ok:
+                return None
+
+            return await response.json()
 
     def is_chain_supported(self, chain_id: int) -> bool:
         chains = self.get_chains()
@@ -102,6 +121,28 @@ class SourcifyClient:
                 f"/contracts/{match_type}/{self.network.value}/{contract_address}/metadata.json",
             )
             metadata = self._do_request(url)
+            if metadata:
+                abi = self._get_abi_from_metadata(metadata)
+                name = self._get_name_from_metadata(metadata)
+                return ContractMetadata(name, abi, match_type == "partial_match")
+        return None
+
+    async def async_get_contract_metadata(
+        self, contract_address: str
+    ) -> Optional[ContractMetadata]:
+        """
+        Asynchronous version of get_contract_metadata
+        """
+        assert fast_is_checksum_address(
+            contract_address
+        ), "Expecting a checksummed address"
+
+        for match_type in ("full_match", "partial_match"):
+            url = urljoin(
+                self.base_url_repo,
+                f"/contracts/{match_type}/{self.network.value}/{contract_address}/metadata.json",
+            )
+            metadata = await self._async_do_request(url)
             if metadata:
                 abi = self._get_abi_from_metadata(metadata)
                 name = self._get_name_from_metadata(metadata)

--- a/safe_eth/eth/tests/clients/test_blockscout_client.py
+++ b/safe_eth/eth/tests/clients/test_blockscout_client.py
@@ -1,9 +1,12 @@
+import unittest
+
 from django.test import TestCase
 
 import pytest
 
 from ... import EthereumNetwork
 from ...clients import BlockscoutClient, BlockScoutConfigurationProblem
+from ...clients.blockscout_client import AsyncBlockscoutClient
 from .mocks import sourcify_safe_metadata
 
 
@@ -23,3 +26,19 @@ class TestBlockscoutClient(TestCase):
         self.assertEqual(contract_metadata.abi, safe_master_copy_abi)
         random_address = "0xaE32496491b53841efb51829d6f886387708F99a"
         self.assertIsNone(blockscout_client.get_contract_metadata(random_address))
+
+
+class TestAsyncBlockscoutClient(unittest.IsolatedAsyncioTestCase):
+    async def test_async_blockscout_client(self):
+        blockscout_client = AsyncBlockscoutClient(EthereumNetwork.GNOSIS)
+        safe_master_copy_abi = sourcify_safe_metadata["output"]["abi"]
+        safe_master_copy_address = "0x6851D6fDFAfD08c0295C392436245E5bc78B0185"
+        contract_metadata = await blockscout_client.async_get_contract_metadata(
+            safe_master_copy_address
+        )
+        self.assertEqual(contract_metadata.name, "GnosisSafe")
+        self.assertEqual(contract_metadata.abi, safe_master_copy_abi)
+        random_address = "0xaE32496491b53841efb51829d6f886387708F99a"
+        self.assertIsNone(
+            await blockscout_client.async_get_contract_metadata(random_address)
+        )

--- a/safe_eth/eth/tests/clients/test_etherscan_client_v2.py
+++ b/safe_eth/eth/tests/clients/test_etherscan_client_v2.py
@@ -1,4 +1,5 @@
 import os
+import unittest
 
 from django.test import TestCase
 
@@ -6,6 +7,7 @@ import pytest
 
 from ... import EthereumNetwork
 from ...clients import EtherscanClientV2, EtherscanRateLimitError
+from ...clients.etherscan_client_v2 import AsyncEtherscanClientV2
 from .mocks import sourcify_safe_metadata
 
 
@@ -48,6 +50,43 @@ class TestEtherscanClientV2(TestCase):
             )
             self.assertFalse(
                 EtherscanClientV2.is_supported_network(EthereumNetwork.UNKNOWN)
+            )
+        except EtherscanRateLimitError:
+            self.skipTest("Etherscan rate limit reached")
+
+
+class TestAsyncEtherscanClientV2(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def get_etherscan_api(cls, network: EthereumNetwork):
+        etherscan_api_key_variable_name = "ETHERSCAN_API_KEY"
+        etherscan_api_key = os.environ.get(etherscan_api_key_variable_name)
+        if not etherscan_api_key:
+            pytest.skip(f"{etherscan_api_key_variable_name} needs to be defined")
+
+        return AsyncEtherscanClientV2(network, api_key=etherscan_api_key)
+
+    async def test_async_etherscan_get_abi(self):
+        try:
+            etherscan_api = self.get_etherscan_api(EthereumNetwork.MAINNET)
+            safe_master_copy_abi = sourcify_safe_metadata["output"]["abi"]
+            safe_master_copy_address = "0x6851D6fDFAfD08c0295C392436245E5bc78B0185"
+            self.assertEqual(
+                await etherscan_api.async_get_contract_abi(safe_master_copy_address),
+                safe_master_copy_abi,
+            )
+
+            contract_metadata = await etherscan_api.async_get_contract_metadata(
+                safe_master_copy_address
+            )
+            self.assertEqual(contract_metadata.name, "GnosisSafe")
+            self.assertEqual(contract_metadata.abi, safe_master_copy_abi)
+
+            random_address = "0xaE32496491b53841efb51829d6f886387708F99a"
+            self.assertIsNone(
+                await etherscan_api.async_get_contract_abi(random_address)
+            )
+            self.assertIsNone(
+                await etherscan_api.async_get_contract_metadata(random_address)
             )
         except EtherscanRateLimitError:
             self.skipTest("Etherscan rate limit reached")


### PR DESCRIPTION
# Description
- Add asynchronous methods of SourcifyClient, EtherscanClientV2 and BlockScoutClient. 
- EtherscanClient V1 is not included.

# Considerations
It was necessary extend the class with different method names because `mypy` does not let override functions with async and not asynchronous applications could have troubles  generating `aiohttp` session. 
