### PR TITLE
Bump web3 to 7.7.0 version and Hexbytes to 1.3.0 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 django==5.1.5
 django-filter==24.3
 djangorestframework==3.15.2
-hexbytes==0.3.1
+hexbytes==1.3.0
 packaging
 psycopg[binary]==3.2.4
 py-evm==0.10.1b2
 requests==2.32.3
 safe-pysha3>=1.0.0
-web3==6.20.2
+web3==7.7.0

--- a/safe_eth/eth/clients/cowswap/cow_swap_api.py
+++ b/safe_eth/eth/clients/cowswap/cow_swap_api.py
@@ -10,6 +10,7 @@ from safe_eth.eth import EthereumNetwork, EthereumNetworkNotSupported
 from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.eth.eip712 import eip712_encode_hash
 from safe_eth.util.http import prepare_http_session
+from safe_eth.util.util import to_0x_hex_str
 
 from .order import Order, OrderKind
 
@@ -163,7 +164,7 @@ class CowSwapAPI:
             "feeAmount": str(order.feeAmount),
             "kind": order.kind,
             "partiallyFillable": order.partiallyFillable,
-            "signature": signed_message.signature.to_0x_hex(),
+            "signature": to_0x_hex_str(signed_message.signature),
             "signingScheme": "ethsign",
             "from": from_address,
         }

--- a/safe_eth/eth/clients/cowswap/cow_swap_api.py
+++ b/safe_eth/eth/clients/cowswap/cow_swap_api.py
@@ -163,7 +163,7 @@ class CowSwapAPI:
             "feeAmount": str(order.feeAmount),
             "kind": order.kind,
             "partiallyFillable": order.partiallyFillable,
-            "signature": signed_message.signature.hex(),
+            "signature": signed_message.signature.to_0x_hex(),
             "signingScheme": "ethsign",
             "from": from_address,
         }

--- a/safe_eth/eth/clients/ens_client.py
+++ b/safe_eth/eth/clients/ens_client.py
@@ -7,6 +7,8 @@ import requests
 from eth_typing import HexStr
 from hexbytes import HexBytes
 
+from safe_eth.util.util import to_0x_hex_str
+
 
 class EnsClient:
     """
@@ -58,7 +60,7 @@ class EnsClient:
         """
         if not domain_hash:
             domain_hash = b""
-        return HexStr("0x" + HexBytes(domain_hash).hex().rjust(64, "0"))
+        return HexStr(to_0x_hex_str(HexBytes(domain_hash)).rjust(66, "0"))
 
     @cache
     def _query_by_domain_hash(self, domain_hash_str: HexStr) -> Optional[str]:

--- a/safe_eth/eth/clients/ens_client.py
+++ b/safe_eth/eth/clients/ens_client.py
@@ -58,7 +58,7 @@ class EnsClient:
         """
         if not domain_hash:
             domain_hash = b""
-        return HexStr("0x" + HexBytes(domain_hash).hex()[2:].rjust(64, "0"))
+        return HexStr("0x" + HexBytes(domain_hash).hex().rjust(64, "0"))
 
     @cache
     def _query_by_domain_hash(self, domain_hash_str: HexStr) -> Optional[str]:

--- a/safe_eth/eth/django/forms.py
+++ b/safe_eth/eth/django/forms.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext as _
 from hexbytes import HexBytes
 
 from safe_eth.eth.utils import fast_is_checksum_address
+from safe_eth.util.util import to_0x_hex_str
 
 
 class EthereumAddressFieldForm(forms.CharField):
@@ -79,6 +80,6 @@ class Keccak256FieldForm(HexFieldForm):
             raise ValidationError(
                 self.error_messages["length"],
                 code="length",
-                params={"value": python_value.to_0x_hex()},
+                params={"value": to_0x_hex_str(python_value)},
             )
         return python_value

--- a/safe_eth/eth/django/forms.py
+++ b/safe_eth/eth/django/forms.py
@@ -79,6 +79,6 @@ class Keccak256FieldForm(HexFieldForm):
             raise ValidationError(
                 self.error_messages["length"],
                 code="length",
-                params={"value": python_value.hex()},
+                params={"value": python_value.to_0x_hex()},
             )
         return python_value

--- a/safe_eth/eth/django/forms.py
+++ b/safe_eth/eth/django/forms.py
@@ -40,7 +40,7 @@ class HexFieldForm(forms.CharField):
 
     def prepare_value(self, value: memoryview) -> str:
         if value:
-            return "0x" + bytes(value).hex()
+            return to_0x_hex_str(bytes(value))
         else:
             return ""
 

--- a/safe_eth/eth/django/models.py
+++ b/safe_eth/eth/django/models.py
@@ -97,7 +97,7 @@ class EthereumAddressFastBinaryField(EthereumAddressBinaryField):
         self, value: memoryview, expression, connection
     ) -> Optional[ChecksumAddress]:
         if value:
-            return ChecksumAddress(HexAddress(HexStr("0x" + bytes(value).hex())))
+            return ChecksumAddress(HexAddress(HexStr(to_0x_hex_str(bytes(value)))))
 
         return None
 

--- a/safe_eth/eth/django/models.py
+++ b/safe_eth/eth/django/models.py
@@ -225,7 +225,7 @@ class Keccak256Field(models.BinaryField):
 
     def from_db_value(self, value: memoryview, expression, connection) -> Optional[str]:
         if value:
-            return HexBytes(bytes(value)).hex()
+            return HexBytes(bytes(value)).to_0x_hex()
         return None
 
     def get_prep_value(self, value: Union[bytes, str]) -> Optional[bytes]:

--- a/safe_eth/eth/django/models.py
+++ b/safe_eth/eth/django/models.py
@@ -10,6 +10,7 @@ from eth_typing import ChecksumAddress, HexAddress, HexStr
 from eth_utils import to_normalized_address
 from hexbytes import HexBytes
 
+from ...util.util import to_0x_hex_str
 from ..utils import fast_bytes_to_checksum_address, fast_to_checksum_address
 from .forms import EthereumAddressFieldForm, HexFieldForm, Keccak256FieldForm
 from .validators import validate_address, validate_checksumed_address
@@ -225,7 +226,7 @@ class Keccak256Field(models.BinaryField):
 
     def from_db_value(self, value: memoryview, expression, connection) -> Optional[str]:
         if value:
-            return HexBytes(bytes(value)).to_0x_hex()
+            return to_0x_hex_str(bytes(value))
         return None
 
     def get_prep_value(self, value: Union[bytes, str]) -> Optional[bytes]:

--- a/safe_eth/eth/django/serializers.py
+++ b/safe_eth/eth/django/serializers.py
@@ -7,6 +7,7 @@ from hexbytes import HexBytes
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
+from ...util.util import to_0x_hex_str
 from ..constants import (
     SIGNATURE_R_MAX_VALUE,
     SIGNATURE_R_MIN_VALUE,
@@ -89,7 +90,7 @@ class HexadecimalField(serializers.Field):
             obj = HexBytes(obj.hex())
         elif not isinstance(obj, HexBytes):
             obj = HexBytes(obj)
-        return obj.to_0x_hex()
+        return to_0x_hex_str(obj)
 
     def to_internal_value(self, data):
         if isinstance(data, (bytes, memoryview)):

--- a/safe_eth/eth/django/serializers.py
+++ b/safe_eth/eth/django/serializers.py
@@ -89,7 +89,7 @@ class HexadecimalField(serializers.Field):
             obj = HexBytes(obj.hex())
         elif not isinstance(obj, HexBytes):
             obj = HexBytes(obj)
-        return obj.hex()
+        return obj.to_0x_hex()
 
     def to_internal_value(self, data):
         if isinstance(data, (bytes, memoryview)):

--- a/safe_eth/eth/django/tests/test_forms.py
+++ b/safe_eth/eth/django/tests/test_forms.py
@@ -3,6 +3,8 @@ from django.test import TestCase
 
 from hexbytes import HexBytes
 
+from safe_eth.util.util import to_0x_hex_str
+
 from ...utils import fast_keccak_text
 from ..forms import EthereumAddressFieldForm, HexFieldForm, Keccak256FieldForm
 
@@ -77,7 +79,7 @@ class TestForms(TestCase):
             form.errors["value"], ['"0x1234" keccak256 hash should be 32 bytes.']
         )
 
-        form = Keccak256Form(data={"value": fast_keccak_text("testing").to_0x_hex()})
+        form = Keccak256Form(data={"value": to_0x_hex_str(fast_keccak_text("testing"))})
         self.assertTrue(form.is_valid())
 
         form = Keccak256Form(data={"value": ""})

--- a/safe_eth/eth/django/tests/test_forms.py
+++ b/safe_eth/eth/django/tests/test_forms.py
@@ -77,7 +77,7 @@ class TestForms(TestCase):
             form.errors["value"], ['"0x1234" keccak256 hash should be 32 bytes.']
         )
 
-        form = Keccak256Form(data={"value": fast_keccak_text("testing").hex()})
+        form = Keccak256Form(data={"value": fast_keccak_text("testing").to_0x_hex()})
         self.assertTrue(form.is_valid())
 
         form = Keccak256Form(data={"value": ""})

--- a/safe_eth/eth/django/tests/test_models.py
+++ b/safe_eth/eth/django/tests/test_models.py
@@ -5,6 +5,7 @@ from django.test import TestCase
 
 from eth_account import Account
 from faker import Faker
+from hexbytes import HexBytes
 
 from ...constants import NULL_ADDRESS, SENTINEL_ADDRESS
 from ...utils import fast_is_checksum_address, fast_keccak_text
@@ -145,8 +146,8 @@ class TestModels(TestCase):
             Uint32.objects.create(value=-2)
 
     def test_keccak256_field(self):
-        value_hexbytes = fast_keccak_text(faker.name())
-        value_hex_with_0x: str = value_hexbytes.hex()
+        value_hexbytes = HexBytes(fast_keccak_text(faker.name()))
+        value_hex_with_0x: str = value_hexbytes.to_0x_hex()
         value_hex_without_0x: str = value_hex_with_0x[2:]
         value: bytes = bytes(value_hexbytes)
 

--- a/safe_eth/eth/django/tests/test_models.py
+++ b/safe_eth/eth/django/tests/test_models.py
@@ -7,6 +7,8 @@ from eth_account import Account
 from faker import Faker
 from hexbytes import HexBytes
 
+from safe_eth.util.util import to_0x_hex_str
+
 from ...constants import NULL_ADDRESS, SENTINEL_ADDRESS
 from ...utils import fast_is_checksum_address, fast_keccak_text
 from .models import (
@@ -147,7 +149,7 @@ class TestModels(TestCase):
 
     def test_keccak256_field(self):
         value_hexbytes = HexBytes(fast_keccak_text(faker.name()))
-        value_hex_with_0x: str = value_hexbytes.to_0x_hex()
+        value_hex_with_0x: str = to_0x_hex_str(value_hexbytes)
         value_hex_without_0x: str = value_hex_with_0x[2:]
         value: bytes = bytes(value_hexbytes)
 

--- a/safe_eth/eth/django/tests/test_serializers.py
+++ b/safe_eth/eth/django/tests/test_serializers.py
@@ -144,7 +144,7 @@ class TestSerializers(TestCase):
             hex_value = value if isinstance(value, str) else value.hex()
             a.value = value
             serializer = HexadecimalSerializerTest(a)
-            self.assertEqual(serializer.data["value"], HexBytes(hex_value).hex())
+            self.assertEqual(serializer.data["value"], HexBytes(hex_value).to_0x_hex())
 
     def test_hash_serializer_field(self):
         value = fast_keccak_text("test").hex()

--- a/safe_eth/eth/django/tests/test_serializers.py
+++ b/safe_eth/eth/django/tests/test_serializers.py
@@ -4,6 +4,8 @@ from eth_account import Account
 from hexbytes import HexBytes
 from rest_framework import serializers
 
+from safe_eth.util.util import to_0x_hex_str
+
 from ...constants import NULL_ADDRESS, SENTINEL_ADDRESS
 from ...utils import fast_keccak_text, get_eth_address_with_invalid_checksum
 from ..serializers import (
@@ -144,7 +146,9 @@ class TestSerializers(TestCase):
             hex_value = value if isinstance(value, str) else value.hex()
             a.value = value
             serializer = HexadecimalSerializerTest(a)
-            self.assertEqual(serializer.data["value"], HexBytes(hex_value).to_0x_hex())
+            self.assertEqual(
+                serializer.data["value"], to_0x_hex_str(HexBytes(hex_value))
+            )
 
     def test_hash_serializer_field(self):
         value = fast_keccak_text("test").hex()

--- a/safe_eth/eth/ethereum_client.py
+++ b/safe_eth/eth/ethereum_client.py
@@ -63,6 +63,7 @@ from safe_eth.eth.utils import (
 from safe_eth.util import chunks
 
 from ..util.http import prepare_http_session
+from ..util.util import to_0x_hex_str
 from .constants import (
     ERC20_721_TRANSFER_TOPIC,
     GAS_CALL_DATA_BYTE,
@@ -307,7 +308,9 @@ class BatchCallManager(EthereumClientManager):
             payloads, sorted(all_results, key=lambda x: x["id"])
         ):
             if "error" in result:
-                fn_name = payload.get("fn_name", HexBytes(payload["data"]).to_0x_hex())
+                fn_name = payload.get(
+                    "fn_name", to_0x_hex_str(HexBytes(payload["data"]))
+                )
                 errors.append(f'`{fn_name}`: {result["error"]}')
                 return_values.append(None)
             else:
@@ -325,7 +328,7 @@ class BatchCallManager(EthereumClientManager):
                         return_values.append(normalized_data)
                 except (DecodingError, OverflowError):
                     fn_name = payload.get(
-                        "fn_name", HexBytes(payload["data"]).to_0x_hex()
+                        "fn_name", to_0x_hex_str(HexBytes(payload["data"]))
                     )
                     errors.append(f"`{fn_name}`: DecodingError, cannot decode")
                     return_values.append(None)
@@ -475,7 +478,7 @@ class Erc20Manager(EthereumClientManager):
                 except DecodingError:
                     logger.warning(
                         "Cannot decode Transfer event `uint256 value` from data=%s",
-                        value_data.to_0x_hex(),
+                        to_0x_hex_str(value_data),
                     )
                     return None
                 from_to_data = b"".join(topics[1:])
@@ -490,7 +493,7 @@ class Erc20Manager(EthereumClientManager):
                 except DecodingError:
                     logger.warning(
                         "Cannot decode Transfer event `address from, address to` from topics=%s",
-                        HexBytes(from_to_data).to_0x_hex(),
+                        to_0x_hex_str(from_to_data),
                     )
                     return None
             elif topics_len == 4:
@@ -508,7 +511,7 @@ class Erc20Manager(EthereumClientManager):
                 except DecodingError:
                     logger.warning(
                         "Cannot decode Transfer event `address from, address to` from topics=%s",
-                        HexBytes(from_to_token_id_data).to_0x_hex(),
+                        to_0x_hex_str(from_to_token_id_data),
                     )
                     return None
         return None
@@ -713,10 +716,10 @@ class Erc20Manager(EthereumClientManager):
         :param token_address: Address of the token
         :return: List of events sorted by blockNumber
         """
-        topic_0 = self.TRANSFER_TOPIC.to_0x_hex()
+        topic_0 = to_0x_hex_str(self.TRANSFER_TOPIC)
         if addresses:
             addresses_encoded = [
-                HexBytes(eth_abi.encode(["address"], [address])).to_0x_hex()
+                to_0x_hex_str(eth_abi.encode(["address"], [address]))
                 for address in addresses
             ]
             # Topics for transfer `to` and `from` an address
@@ -1089,7 +1092,7 @@ class TracingManager(EthereumClientManager):
                 "id": i,
                 "jsonrpc": "2.0",
                 "method": "trace_transaction",
-                "params": [HexBytes(tx_hash).to_0x_hex()],
+                "params": [to_0x_hex_str(HexBytes(tx_hash))],
             }
             for i, tx_hash in enumerate(tx_hashes)
         ]
@@ -1542,7 +1545,7 @@ class EthereumClient:
 
                 tx["gas"] = self.w3.eth.estimate_gas(tx)
                 tx_hash = self.send_unsigned_transaction(
-                    tx, private_key=HexBytes(deployer_account.key).to_0x_hex()
+                    tx, private_key=to_0x_hex_str(deployer_account.key)
                 )
                 if check_receipt:
                     tx_receipt = self.get_transaction_receipt(
@@ -1709,7 +1712,7 @@ class EthereumClient:
                 "id": i,
                 "jsonrpc": "2.0",
                 "method": "eth_getTransactionByHash",
-                "params": [HexBytes(tx_hash).to_0x_hex()],
+                "params": [to_0x_hex_str(HexBytes(tx_hash))],
             }
             for i, tx_hash in enumerate(tx_hashes)
         ]
@@ -1752,7 +1755,7 @@ class EthereumClient:
                 "id": i,
                 "jsonrpc": "2.0",
                 "method": "eth_getTransactionReceipt",
-                "params": [HexBytes(tx_hash).to_0x_hex()],
+                "params": [to_0x_hex_str(HexBytes(tx_hash))],
             }
             for i, tx_hash in enumerate(tx_hashes)
         ]
@@ -1784,7 +1787,7 @@ class EthereumClient:
         if isinstance(block_identifier, int):
             return HexStr(hex(block_identifier))
         elif isinstance(block_identifier, bytes):
-            return HexStr(HexBytes(block_identifier).to_0x_hex())
+            return HexStr(to_0x_hex_str(HexBytes(block_identifier)))
         return str(block_identifier)
 
     def get_blocks(

--- a/safe_eth/eth/multicall.py
+++ b/safe_eth/eth/multicall.py
@@ -15,7 +15,7 @@ from web3 import Web3
 from web3._utils.abi import map_abi_data
 from web3._utils.normalizers import BASE_RETURN_NORMALIZERS
 from web3.contract.contract import Contract, ContractFunction
-from web3.exceptions import ContractLogicError
+from web3.exceptions import ContractLogicError, Web3RPCError, Web3ValueError
 
 from . import EthereumClient, EthereumNetwork, EthereumNetworkNotSupported
 from .contracts import ContractBase, get_multicall_v3_contract
@@ -430,7 +430,7 @@ class Multicall(ContractBase):
                 MulticallResult(success, data if data else None)
                 for success, data in result
             ]
-        except (ContractLogicError, OverflowError, ValueError):
+        except (ContractLogicError, OverflowError, Web3ValueError, Web3RPCError):
             raise BatchCallFunctionFailed
 
     def try_aggregate(

--- a/safe_eth/eth/tests/account_abstraction/test_bundler_client.py
+++ b/safe_eth/eth/tests/account_abstraction/test_bundler_client.py
@@ -32,7 +32,7 @@ class TestBundlerClient(TestCase):
         mock_session.return_value.json = MagicMock(
             return_value={"jsonrpc": "2.0", "id": 1, "result": None}
         )
-        user_operation_hash = safe_4337_user_operation_hash_mock.hex()
+        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
 
         self.assertIsNone(self.bundler.get_user_operation_by_hash(user_operation_hash))
         mock_session.return_value.json = MagicMock(return_value=user_operation_mock)
@@ -72,7 +72,7 @@ class TestBundlerClient(TestCase):
         mock_session.return_value.json = MagicMock(
             return_value={"jsonrpc": "2.0", "id": 1, "result": None}
         )
-        user_operation_hash = safe_4337_user_operation_hash_mock.hex()
+        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
         self.assertIsNone(self.bundler.get_user_operation_receipt(user_operation_hash))
         mock_session.return_value.json = MagicMock(
             return_value=copy.deepcopy(user_operation_receipt_mock)
@@ -116,7 +116,7 @@ class TestBundlerClient(TestCase):
                 {"jsonrpc": "2.0", "id": 2, "result": None},
             ]
         )
-        user_operation_hash = safe_4337_user_operation_hash_mock.hex()
+        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
         self.assertIsNone(
             self.bundler.get_user_operation_and_receipt(user_operation_hash)
         )

--- a/safe_eth/eth/tests/account_abstraction/test_bundler_client.py
+++ b/safe_eth/eth/tests/account_abstraction/test_bundler_client.py
@@ -7,6 +7,8 @@ from django.test import TestCase
 import requests
 from eth_typing import HexStr
 
+from safe_eth.util.util import to_0x_hex_str
+
 from ...account_abstraction import (
     BundlerClient,
     BundlerClientConnectionException,
@@ -32,7 +34,7 @@ class TestBundlerClient(TestCase):
         mock_session.return_value.json = MagicMock(
             return_value={"jsonrpc": "2.0", "id": 1, "result": None}
         )
-        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
+        user_operation_hash = to_0x_hex_str(safe_4337_user_operation_hash_mock)
 
         self.assertIsNone(self.bundler.get_user_operation_by_hash(user_operation_hash))
         mock_session.return_value.json = MagicMock(return_value=user_operation_mock)
@@ -72,7 +74,7 @@ class TestBundlerClient(TestCase):
         mock_session.return_value.json = MagicMock(
             return_value={"jsonrpc": "2.0", "id": 1, "result": None}
         )
-        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
+        user_operation_hash = to_0x_hex_str(safe_4337_user_operation_hash_mock)
         self.assertIsNone(self.bundler.get_user_operation_receipt(user_operation_hash))
         mock_session.return_value.json = MagicMock(
             return_value=copy.deepcopy(user_operation_receipt_mock)
@@ -116,7 +118,7 @@ class TestBundlerClient(TestCase):
                 {"jsonrpc": "2.0", "id": 2, "result": None},
             ]
         )
-        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
+        user_operation_hash = to_0x_hex_str(safe_4337_user_operation_hash_mock)
         self.assertIsNone(
             self.bundler.get_user_operation_and_receipt(user_operation_hash)
         )

--- a/safe_eth/eth/tests/account_abstraction/test_e2e_bundler_client.py
+++ b/safe_eth/eth/tests/account_abstraction/test_e2e_bundler_client.py
@@ -3,7 +3,8 @@ import os
 from django.test import TestCase
 
 import pytest
-from hexbytes import HexBytes
+
+from safe_eth.util.util import to_0x_hex_str
 
 from ...account_abstraction import BundlerClient, UserOperation, UserOperationReceipt
 from ...account_abstraction.user_operation import UserOperationV07
@@ -30,7 +31,7 @@ class TestE2EBundlerClient(TestCase):
         self.assertGreater(self.bundler.get_chain_id(), 0)
 
     def test_get_user_operation_by_hash(self):
-        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
+        user_operation_hash = to_0x_hex_str(safe_4337_user_operation_hash_mock)
 
         expected_user_operation = UserOperation.from_bundler_response(
             user_operation_hash, user_operation_mock["result"]
@@ -41,9 +42,9 @@ class TestE2EBundlerClient(TestCase):
             expected_user_operation,
         )
         self.assertEqual(
-            HexBytes(
+            to_0x_hex_str(
                 user_operation.calculate_user_operation_hash(safe_4337_chain_id_mock)
-            ).to_0x_hex(),
+            ),
             user_operation_hash,
         )
 
@@ -51,20 +52,20 @@ class TestE2EBundlerClient(TestCase):
         """
         Test UserOperation v0.7
         """
-        user_operation_hash = user_operation_v07_hash.to_0x_hex()
+        user_operation_hash = to_0x_hex_str(user_operation_v07_hash)
         user_operation = self.bundler.get_user_operation_by_hash(user_operation_hash)
         self.assertIsInstance(user_operation, UserOperationV07)
         self.assertEqual(
-            HexBytes(
+            to_0x_hex_str(
                 user_operation.calculate_user_operation_hash(
                     user_operation_v07_chain_id
                 )
-            ).to_0x_hex(),
+            ),
             user_operation_hash,
         )
 
     def test_get_user_operation_receipt(self):
-        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
+        user_operation_hash = to_0x_hex_str(safe_4337_user_operation_hash_mock)
         expected_user_operation_receipt = UserOperationReceipt.from_bundler_response(
             user_operation_receipt_mock["result"]
         )
@@ -76,7 +77,7 @@ class TestE2EBundlerClient(TestCase):
 
     @pytest.mark.xfail(reason="Some bundlers don't support batch requests")
     def test_get_user_operation_and_receipt(self):
-        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
+        user_operation_hash = to_0x_hex_str(safe_4337_user_operation_hash_mock)
 
         expected_user_operation = UserOperation.from_bundler_response(
             user_operation_hash, user_operation_mock["result"]

--- a/safe_eth/eth/tests/account_abstraction/test_e2e_bundler_client.py
+++ b/safe_eth/eth/tests/account_abstraction/test_e2e_bundler_client.py
@@ -3,6 +3,7 @@ import os
 from django.test import TestCase
 
 import pytest
+from hexbytes import HexBytes
 
 from ...account_abstraction import BundlerClient, UserOperation, UserOperationReceipt
 from ...account_abstraction.user_operation import UserOperationV07
@@ -29,7 +30,7 @@ class TestE2EBundlerClient(TestCase):
         self.assertGreater(self.bundler.get_chain_id(), 0)
 
     def test_get_user_operation_by_hash(self):
-        user_operation_hash = safe_4337_user_operation_hash_mock.hex()
+        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
 
         expected_user_operation = UserOperation.from_bundler_response(
             user_operation_hash, user_operation_mock["result"]
@@ -40,7 +41,9 @@ class TestE2EBundlerClient(TestCase):
             expected_user_operation,
         )
         self.assertEqual(
-            user_operation.calculate_user_operation_hash(safe_4337_chain_id_mock).hex(),
+            HexBytes(
+                user_operation.calculate_user_operation_hash(safe_4337_chain_id_mock)
+            ).to_0x_hex(),
             user_operation_hash,
         )
 
@@ -48,18 +51,20 @@ class TestE2EBundlerClient(TestCase):
         """
         Test UserOperation v0.7
         """
-        user_operation_hash = user_operation_v07_hash.hex()
+        user_operation_hash = user_operation_v07_hash.to_0x_hex()
         user_operation = self.bundler.get_user_operation_by_hash(user_operation_hash)
         self.assertIsInstance(user_operation, UserOperationV07)
         self.assertEqual(
-            user_operation.calculate_user_operation_hash(
-                user_operation_v07_chain_id
-            ).hex(),
+            HexBytes(
+                user_operation.calculate_user_operation_hash(
+                    user_operation_v07_chain_id
+                )
+            ).to_0x_hex(),
             user_operation_hash,
         )
 
     def test_get_user_operation_receipt(self):
-        user_operation_hash = safe_4337_user_operation_hash_mock.hex()
+        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
         expected_user_operation_receipt = UserOperationReceipt.from_bundler_response(
             user_operation_receipt_mock["result"]
         )
@@ -71,7 +76,7 @@ class TestE2EBundlerClient(TestCase):
 
     @pytest.mark.xfail(reason="Some bundlers don't support batch requests")
     def test_get_user_operation_and_receipt(self):
-        user_operation_hash = safe_4337_user_operation_hash_mock.hex()
+        user_operation_hash = safe_4337_user_operation_hash_mock.to_0x_hex()
 
         expected_user_operation = UserOperation.from_bundler_response(
             user_operation_hash, user_operation_mock["result"]

--- a/safe_eth/eth/tests/account_abstraction/test_user_operation.py
+++ b/safe_eth/eth/tests/account_abstraction/test_user_operation.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 
+from safe_eth.util.util import to_0x_hex_str
+
 from ...account_abstraction import UserOperation
 from ...account_abstraction.user_operation import UserOperationV07
 from ..mocks.mock_bundler import (
@@ -15,7 +17,7 @@ class TestUserOperation(TestCase):
     def test_calculate_user_operation_hash_V06(self):
         user_operation_hash = safe_4337_user_operation_hash_mock
         user_operation = UserOperation.from_bundler_response(
-            user_operation_hash.to_0x_hex(), user_operation_mock["result"]
+            to_0x_hex_str(user_operation_hash), user_operation_mock["result"]
         )
         self.assertIsInstance(user_operation, UserOperation)
         self.assertEqual(
@@ -26,7 +28,7 @@ class TestUserOperation(TestCase):
     def test_calculate_user_operation_hash_V07(self):
         user_operation_hash = user_operation_v07_hash
         user_operation = UserOperation.from_bundler_response(
-            user_operation_hash.to_0x_hex(), user_operation_v07_mock["result"]
+            to_0x_hex_str(user_operation_hash), user_operation_v07_mock["result"]
         )
         self.assertIsInstance(user_operation, UserOperationV07)
         self.assertEqual(

--- a/safe_eth/eth/tests/account_abstraction/test_user_operation.py
+++ b/safe_eth/eth/tests/account_abstraction/test_user_operation.py
@@ -15,7 +15,7 @@ class TestUserOperation(TestCase):
     def test_calculate_user_operation_hash_V06(self):
         user_operation_hash = safe_4337_user_operation_hash_mock
         user_operation = UserOperation.from_bundler_response(
-            user_operation_hash.hex(), user_operation_mock["result"]
+            user_operation_hash.to_0x_hex(), user_operation_mock["result"]
         )
         self.assertIsInstance(user_operation, UserOperation)
         self.assertEqual(
@@ -26,7 +26,7 @@ class TestUserOperation(TestCase):
     def test_calculate_user_operation_hash_V07(self):
         user_operation_hash = user_operation_v07_hash
         user_operation = UserOperation.from_bundler_response(
-            user_operation_hash.hex(), user_operation_v07_mock["result"]
+            user_operation_hash.to_0x_hex(), user_operation_v07_mock["result"]
         )
         self.assertIsInstance(user_operation, UserOperationV07)
         self.assertEqual(

--- a/safe_eth/eth/tests/eip712/test_eip712.py
+++ b/safe_eth/eth/tests/eip712/test_eip712.py
@@ -1,6 +1,7 @@
 from unittest import TestCase
 
 from safe_eth.eth.eip712 import eip712_encode_hash
+from safe_eth.util.util import to_0x_hex_str
 
 
 class TestEIP712(TestCase):
@@ -85,7 +86,7 @@ class TestEIP712(TestCase):
 
         payload["types"] = self.types
         self.assertEqual(
-            eip712_encode_hash(payload).to_0x_hex(),
+            to_0x_hex_str(eip712_encode_hash(payload)),
             "0x7c02fe79823722257b42ea95720e7dd31d51c3f6769dc0f56a271800dd030ef1",
         )
 
@@ -103,7 +104,7 @@ class TestEIP712(TestCase):
             "message": self.mailbox,
         }
         self.assertEqual(
-            eip712_encode_hash(payload).to_0x_hex(),
+            to_0x_hex_str(eip712_encode_hash(payload)),
             "0x7c02fe79823722257b42ea95720e7dd31d51c3f6769dc0f56a271800dd030ef1",
         )
 
@@ -130,7 +131,7 @@ class TestEIP712(TestCase):
         }
 
         self.assertEqual(
-            eip712_encode_hash(payload).to_0x_hex(),
+            to_0x_hex_str(eip712_encode_hash(payload)),
             "0x2950cf06416c6c20059f24a965e3baf51a24f4ef49a1e7b1a47ee13ee08cde1f",
         )
 
@@ -205,7 +206,7 @@ class TestEIP712(TestCase):
             },
         }
         self.assertEqual(
-            eip712_encode_hash(payload).to_0x_hex(),
+            to_0x_hex_str(eip712_encode_hash(payload)),
             "0x2f6856dbd51836973c1e61852b64949556aa2e7f253d9e20e682f9a02d436791",
         )
 
@@ -263,7 +264,7 @@ class TestEIP712(TestCase):
             },
         }
         self.assertEqual(
-            eip712_encode_hash(payload).to_0x_hex(),
+            to_0x_hex_str(eip712_encode_hash(payload)),
             "0x5dd3156111fb5e400606d4dd75ff097e36eb56614c84924b5eb6d1cf1b5038cf",
         )
 
@@ -320,6 +321,6 @@ class TestEIP712(TestCase):
         }
 
         self.assertEqual(
-            eip712_encode_hash(payload).to_0x_hex(),
+            to_0x_hex_str(eip712_encode_hash(payload)),
             "0x9a55335a1d86221594e96018fc3df611a1485d95b5b2afbef1540ac51f63d249",
         )

--- a/safe_eth/eth/tests/eip712/test_eip712.py
+++ b/safe_eth/eth/tests/eip712/test_eip712.py
@@ -85,7 +85,7 @@ class TestEIP712(TestCase):
 
         payload["types"] = self.types
         self.assertEqual(
-            eip712_encode_hash(payload).hex(),
+            eip712_encode_hash(payload).to_0x_hex(),
             "0x7c02fe79823722257b42ea95720e7dd31d51c3f6769dc0f56a271800dd030ef1",
         )
 
@@ -103,7 +103,7 @@ class TestEIP712(TestCase):
             "message": self.mailbox,
         }
         self.assertEqual(
-            eip712_encode_hash(payload).hex(),
+            eip712_encode_hash(payload).to_0x_hex(),
             "0x7c02fe79823722257b42ea95720e7dd31d51c3f6769dc0f56a271800dd030ef1",
         )
 
@@ -130,7 +130,7 @@ class TestEIP712(TestCase):
         }
 
         self.assertEqual(
-            eip712_encode_hash(payload).hex(),
+            eip712_encode_hash(payload).to_0x_hex(),
             "0x2950cf06416c6c20059f24a965e3baf51a24f4ef49a1e7b1a47ee13ee08cde1f",
         )
 
@@ -205,7 +205,7 @@ class TestEIP712(TestCase):
             },
         }
         self.assertEqual(
-            eip712_encode_hash(payload).hex(),
+            eip712_encode_hash(payload).to_0x_hex(),
             "0x2f6856dbd51836973c1e61852b64949556aa2e7f253d9e20e682f9a02d436791",
         )
 
@@ -263,7 +263,7 @@ class TestEIP712(TestCase):
             },
         }
         self.assertEqual(
-            eip712_encode_hash(payload).hex(),
+            eip712_encode_hash(payload).to_0x_hex(),
             "0x5dd3156111fb5e400606d4dd75ff097e36eb56614c84924b5eb6d1cf1b5038cf",
         )
 
@@ -320,6 +320,6 @@ class TestEIP712(TestCase):
         }
 
         self.assertEqual(
-            eip712_encode_hash(payload).hex(),
+            eip712_encode_hash(payload).to_0x_hex(),
             "0x9a55335a1d86221594e96018fc3df611a1485d95b5b2afbef1540ac51f63d249",
         )

--- a/safe_eth/eth/tests/test_ethereum_client.py
+++ b/safe_eth/eth/tests/test_ethereum_client.py
@@ -13,6 +13,7 @@ from web3.eth import Eth
 from web3.exceptions import Web3RPCError
 from web3.types import TxParams
 
+from ...util.util import to_0x_hex_str
 from ..constants import GAS_CALL_DATA_BYTE, NULL_ADDRESS
 from ..contracts import get_erc20_contract
 from ..ethereum_client import (
@@ -1189,7 +1190,7 @@ class TestEthereumClient(EthereumTestCaseMixin, TestCase):
         ]
         blocks = self.ethereum_client.get_blocks(block_numbers, full_transactions=True)
         block_hashes = [block["hash"] for block in blocks]
-        block_hashes_hex = [block_hash.to_0x_hex() for block_hash in block_hashes]
+        block_hashes_hex = [to_0x_hex_str(block_hash) for block_hash in block_hashes]
         for block_number, block in zip(block_numbers, blocks):
             self.assertEqual(block["number"], block_number)
             self.assertEqual(len(block["hash"]), 32)

--- a/safe_eth/eth/tests/test_ethereum_client.py
+++ b/safe_eth/eth/tests/test_ethereum_client.py
@@ -10,6 +10,7 @@ from eth_account import Account
 from eth_typing import URI, HexStr
 from hexbytes import HexBytes
 from web3.eth import Eth
+from web3.exceptions import Web3RPCError
 from web3.types import TxParams
 
 from ..constants import GAS_CALL_DATA_BYTE, NULL_ADDRESS
@@ -663,7 +664,7 @@ class TestTracingManager(EthereumTestCaseMixin, TestCase):
             self.ethereum_client.tracing.trace_filter()
 
         with self.assertRaisesMessage(
-            ValueError, "The method trace_filter does not exist/is not available"
+            Web3RPCError, "The method trace_filter does not exist/is not available"
         ):
             self.ethereum_client.tracing.trace_filter(
                 to_address=[Account.create().address]
@@ -1188,7 +1189,7 @@ class TestEthereumClient(EthereumTestCaseMixin, TestCase):
         ]
         blocks = self.ethereum_client.get_blocks(block_numbers, full_transactions=True)
         block_hashes = [block["hash"] for block in blocks]
-        block_hashes_hex = [block_hash.hex() for block_hash in block_hashes]
+        block_hashes_hex = [block_hash.to_0x_hex() for block_hash in block_hashes]
         for block_number, block in zip(block_numbers, blocks):
             self.assertEqual(block["number"], block_number)
             self.assertEqual(len(block["hash"]), 32)

--- a/safe_eth/eth/tests/test_utils.py
+++ b/safe_eth/eth/tests/test_utils.py
@@ -46,7 +46,7 @@ class TestUtils(EthereumTestCaseMixin, TestCase):
             {"nonce": nonce, "from": deployer_account.address}
         )
         signed_tx = deployer_account.sign_transaction(tx)
-        tx_hash = self.w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        tx_hash = self.w3.eth.send_raw_transaction(signed_tx.raw_transaction)
         tx_receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash)
         proxy_factory_contract = get_proxy_factory_contract(
             self.w3, address=tx_receipt["contractAddress"]
@@ -66,7 +66,7 @@ class TestUtils(EthereumTestCaseMixin, TestCase):
             }
         )
         signed_tx = deployer_account.sign_transaction(tx)
-        tx_hash = self.w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+        tx_hash = self.w3.eth.send_raw_transaction(signed_tx.raw_transaction)
         tx_receipt = self.w3.eth.wait_for_transaction_receipt(tx_hash)
         logs = proxy_factory_contract.events.ProxyCreation().process_receipt(tx_receipt)
         log = logs[0]

--- a/safe_eth/eth/tests/utils.py
+++ b/safe_eth/eth/tests/utils.py
@@ -100,11 +100,13 @@ def send_tx(w3: Web3, tx: TxParams, account: LocalAccount) -> bytes:
 
     if "gas" not in tx:
         tx["gas"] = w3.eth.estimate_gas(tx)
-
-    signed_tx = account.sign_transaction(tx)
-    tx_hash = w3.eth.send_raw_transaction(bytes(signed_tx.rawTransaction))
+    signed_tx = account.sign_transaction(tx)  # type: ignore
+    tx_hash = w3.eth.send_raw_transaction(bytes(signed_tx.raw_transaction))
     tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
-    assert tx_receipt["status"] == 1, "Error with tx %s - %s" % (tx_hash.hex(), tx)
+    assert tx_receipt["status"] == 1, "Error with tx %s - %s" % (
+        tx_hash.to_0x_hex(),
+        tx,
+    )
     return tx_hash
 
 
@@ -128,7 +130,7 @@ def deploy_erc20(
         }
     )
     signed_tx = account.sign_transaction(tx)
-    tx_hash = w3.eth.send_raw_transaction(signed_tx.rawTransaction)
+    tx_hash = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
 
     tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     erc20_address = tx_receipt["contractAddress"]
@@ -145,7 +147,7 @@ def bytes_to_str(o: Any) -> Any:
     :return:
     """
     if isinstance(o, bytes):
-        return HexBytes(o).hex()
+        return HexBytes(o).to_0x_hex()
     if isinstance(o, dict):
         o = dict(o)  # Remove AttributeDict
         for k in o.keys():

--- a/safe_eth/eth/tests/utils.py
+++ b/safe_eth/eth/tests/utils.py
@@ -8,11 +8,11 @@ import pytest
 import requests
 from eth_account.signers.local import LocalAccount
 from eth_typing import ChecksumAddress
-from hexbytes import HexBytes
 from web3 import Web3
 from web3.contract import Contract
 from web3.types import TxParams
 
+from ...util.util import to_0x_hex_str
 from ..contracts import get_example_erc20_contract
 
 
@@ -104,7 +104,7 @@ def send_tx(w3: Web3, tx: TxParams, account: LocalAccount) -> bytes:
     tx_hash = w3.eth.send_raw_transaction(bytes(signed_tx.raw_transaction))
     tx_receipt = w3.eth.wait_for_transaction_receipt(tx_hash)
     assert tx_receipt["status"] == 1, "Error with tx %s - %s" % (
-        tx_hash.to_0x_hex(),
+        to_0x_hex_str(tx_hash),
         tx,
     )
     return tx_hash
@@ -147,7 +147,7 @@ def bytes_to_str(o: Any) -> Any:
     :return:
     """
     if isinstance(o, bytes):
-        return HexBytes(o).to_0x_hex()
+        return to_0x_hex_str(o)
     if isinstance(o, dict):
         o = dict(o)  # Remove AttributeDict
         for k in o.keys():

--- a/safe_eth/eth/utils.py
+++ b/safe_eth/eth/utils.py
@@ -226,9 +226,11 @@ def mk_contract_address_2(
     salt = HexBytes(salt)
     init_code = HexBytes(init_code)
 
-    assert len(from_) == 20, f"Address {from_.hex()} is not valid. Must be 20 bytes"
-    assert len(salt) == 32, f"Salt {salt.hex()} is not valid. Must be 32 bytes"
-    assert len(init_code) > 0, f"Init code {init_code.hex()} is not valid"
+    assert (
+        len(from_) == 20
+    ), f"Address {from_.to_0x_hex()} is not valid. Must be 20 bytes"
+    assert len(salt) == 32, f"Salt {salt.to_0x_hex()} is not valid. Must be 32 bytes"
+    assert len(init_code) > 0, f"Init code {init_code.to_0x_hex()} is not valid"
 
     init_code_hash = fast_keccak(init_code)
     contract_address = fast_keccak(HexBytes("ff") + from_ + salt + init_code_hash)

--- a/safe_eth/eth/utils.py
+++ b/safe_eth/eth/utils.py
@@ -11,6 +11,8 @@ from hexbytes import HexBytes
 from sha3 import keccak_256
 from web3.types import TxParams, Wei
 
+from safe_eth.util.util import to_0x_hex_str
+
 
 def get_empty_tx_params() -> TxParams:
     """
@@ -228,9 +230,9 @@ def mk_contract_address_2(
 
     assert (
         len(from_) == 20
-    ), f"Address {from_.to_0x_hex()} is not valid. Must be 20 bytes"
-    assert len(salt) == 32, f"Salt {salt.to_0x_hex()} is not valid. Must be 32 bytes"
-    assert len(init_code) > 0, f"Init code {init_code.to_0x_hex()} is not valid"
+    ), f"Address {to_0x_hex_str(from_)} is not valid. Must be 20 bytes"
+    assert len(salt) == 32, f"Salt {to_0x_hex_str(salt)} is not valid. Must be 32 bytes"
+    assert len(init_code) > 0, f"Init code {to_0x_hex_str(init_code)} is not valid"
 
     init_code_hash = fast_keccak(init_code)
     contract_address = fast_keccak(HexBytes("ff") + from_ + salt + init_code_hash)

--- a/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
+++ b/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
@@ -10,6 +10,7 @@ from hexbytes import HexBytes
 from safe_eth.eth import EthereumClient, EthereumNetwork
 from safe_eth.eth.eip712 import eip712_encode_hash
 from safe_eth.safe import SafeTx
+from safe_eth.util.util import to_0x_hex_str
 
 from ..base_api import SafeAPIException, SafeBaseAPI
 from .entities import Balance, DataDecoded, DelegateUser, Message, Transaction
@@ -152,7 +153,7 @@ class TransactionServiceApi(SafeBaseAPI):
 
         if safe_tx.safe_tx_hash != safe_tx_hash:
             raise ApiSafeTxHashNotMatchingException(
-                f"API safe-tx-hash: {HexBytes(safe_tx_hash).to_0x_hex()} doesn't match the calculated safe-tx-hash: {HexBytes(safe_tx.safe_tx_hash).to_0x_hex()}"
+                f"API safe-tx-hash: {to_0x_hex_str(HexBytes(safe_tx_hash))} doesn't match the calculated safe-tx-hash: {to_0x_hex_str(HexBytes(safe_tx.safe_tx_hash))}"
             )
 
         return safe_tx
@@ -175,7 +176,7 @@ class TransactionServiceApi(SafeBaseAPI):
         :param safe_tx_hash:
         :return: SafeTx and `tx-hash` if transaction was executed
         """
-        safe_tx_hash_str = HexBytes(safe_tx_hash).to_0x_hex()
+        safe_tx_hash_str = to_0x_hex_str(HexBytes(safe_tx_hash))
         response = self._get_request(
             f"/api/v1/multisig-transactions/{safe_tx_hash_str}/"
         )
@@ -257,10 +258,10 @@ class TransactionServiceApi(SafeBaseAPI):
         :param signatures:
         :return: True if new confirmation was created
         """
-        safe_tx_hash_str = HexBytes(safe_tx_hash).to_0x_hex()
+        safe_tx_hash_str = to_0x_hex_str(safe_tx_hash)
         response = self._post_request(
-            f"/api/v1/multisig-transactions/{safe_tx_hash!r}/confirmations/",
-            payload={"signature": HexBytes(signatures).to_0x_hex()},
+            f"/api/v1/multisig-transactions/{safe_tx_hash_str}/confirmations/",
+            payload={"signature": to_0x_hex_str(signatures)},
         )
         if not response.ok:
             raise SafeAPIException(
@@ -279,7 +280,7 @@ class TransactionServiceApi(SafeBaseAPI):
         add_payload = {
             "delegate": delegate_address,
             "delegator": delegator_address,
-            "signature": HexBytes(signature).to_0x_hex(),
+            "signature": to_0x_hex_str(HexBytes(signature)),
             "label": label,
         }
         if safe_address:
@@ -308,7 +309,7 @@ class TransactionServiceApi(SafeBaseAPI):
         """
         remove_payload = {
             "delegator": delegator_address,
-            "signature": HexBytes(signature).to_0x_hex(),
+            "signature": to_0x_hex_str(HexBytes(signature)),
         }
         if safe_address:
             remove_payload["safe"] = safe_address
@@ -326,7 +327,7 @@ class TransactionServiceApi(SafeBaseAPI):
         data = {
             "to": safe_tx.to,
             "value": safe_tx.value,
-            "data": safe_tx.data.to_0x_hex() if safe_tx.data else None,
+            "data": to_0x_hex_str(safe_tx.data) if safe_tx.data else None,
             "operation": safe_tx.operation,
             "gasToken": safe_tx.gas_token,
             "safeTxGas": safe_tx.safe_tx_gas,
@@ -334,7 +335,7 @@ class TransactionServiceApi(SafeBaseAPI):
             "gasPrice": safe_tx.gas_price,
             "refundReceiver": safe_tx.refund_receiver,
             "nonce": safe_tx.safe_nonce,
-            "contractTransactionHash": safe_tx.safe_tx_hash.to_0x_hex(),
+            "contractTransactionHash": to_0x_hex_str(safe_tx.safe_tx_hash),
             "sender": sender,
             "signature": safe_tx.signatures.hex() if safe_tx.signatures else None,
             "origin": "Safe-CLI",
@@ -379,7 +380,7 @@ class TransactionServiceApi(SafeBaseAPI):
         payload = {
             "message": message,
             "safeAppId": safe_app_id,
-            "signature": HexBytes(signature).to_0x_hex(),
+            "signature": to_0x_hex_str(signature),
         }
         response = self._post_request(
             f"/api/v1/safes/{safe_address}/messages/", payload
@@ -395,7 +396,7 @@ class TransactionServiceApi(SafeBaseAPI):
         :return: Safe message for provided Safe message hash
         """
         response = self._get_request(
-            f"/api/v1/messages/{HexBytes(safe_message_hash).to_0x_hex()}/"
+            f"/api/v1/messages/{to_0x_hex_str(safe_message_hash)}/"
         )
         if not response.ok:
             raise SafeAPIException(f"Cannot get messages: {response.content!r}")
@@ -422,9 +423,9 @@ class TransactionServiceApi(SafeBaseAPI):
         :param signature:
         :return:
         """
-        payload = {"signature": HexBytes(signature).to_0x_hex()}
+        payload = {"signature": to_0x_hex_str(signature)}
         response = self._post_request(
-            f"/api/v1/messages/{HexBytes(safe_message_hash).to_0x_hex()}/signatures/",
+            f"/api/v1/messages/{to_0x_hex_str(safe_message_hash)}/signatures/",
             payload,
         )
         if not response.ok:
@@ -443,7 +444,7 @@ class TransactionServiceApi(SafeBaseAPI):
         :param to_address: address of the contract. This will be used in case of more than one function identifiers matching.
         :return:
         """
-        payload = {"data": HexBytes(data).to_0x_hex()}
+        payload = {"data": to_0x_hex_str(HexBytes(data))}
         if to_address:
             payload["to"] = to_address
         response = self._post_request("/api/v1/data-decoder/", payload)

--- a/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
+++ b/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
@@ -152,8 +152,7 @@ class TransactionServiceApi(SafeBaseAPI):
 
         if safe_tx.safe_tx_hash != safe_tx_hash:
             raise ApiSafeTxHashNotMatchingException(
-                f"API safe-tx-hash: {safe_tx_hash.hex() if isinstance(safe_tx_hash, bytes) else safe_tx_hash} "
-                f"doesn't match the calculated safe-tx-hash: {safe_tx.safe_tx_hash.hex()}"
+                f"API safe-tx-hash: {HexBytes(safe_tx_hash).to_0x_hex()} doesn't match the calculated safe-tx-hash: {HexBytes(safe_tx.safe_tx_hash).to_0x_hex()}"
             )
 
         return safe_tx
@@ -176,7 +175,7 @@ class TransactionServiceApi(SafeBaseAPI):
         :param safe_tx_hash:
         :return: SafeTx and `tx-hash` if transaction was executed
         """
-        safe_tx_hash_str = HexBytes(safe_tx_hash).hex()
+        safe_tx_hash_str = HexBytes(safe_tx_hash).to_0x_hex()
         response = self._get_request(
             f"/api/v1/multisig-transactions/{safe_tx_hash_str}/"
         )
@@ -258,10 +257,10 @@ class TransactionServiceApi(SafeBaseAPI):
         :param signatures:
         :return: True if new confirmation was created
         """
-        safe_tx_hash_str = HexBytes(safe_tx_hash).hex()
+        safe_tx_hash_str = HexBytes(safe_tx_hash).to_0x_hex()
         response = self._post_request(
-            f"/api/v1/multisig-transactions/{safe_tx_hash_str}/confirmations/",
-            payload={"signature": HexBytes(signatures).hex()},
+            f"/api/v1/multisig-transactions/{safe_tx_hash!r}/confirmations/",
+            payload={"signature": HexBytes(signatures).to_0x_hex()},
         )
         if not response.ok:
             raise SafeAPIException(
@@ -280,7 +279,7 @@ class TransactionServiceApi(SafeBaseAPI):
         add_payload = {
             "delegate": delegate_address,
             "delegator": delegator_address,
-            "signature": HexBytes(signature).hex(),
+            "signature": HexBytes(signature).to_0x_hex(),
             "label": label,
         }
         if safe_address:
@@ -309,7 +308,7 @@ class TransactionServiceApi(SafeBaseAPI):
         """
         remove_payload = {
             "delegator": delegator_address,
-            "signature": HexBytes(signature).hex(),
+            "signature": HexBytes(signature).to_0x_hex(),
         }
         if safe_address:
             remove_payload["safe"] = safe_address
@@ -327,7 +326,7 @@ class TransactionServiceApi(SafeBaseAPI):
         data = {
             "to": safe_tx.to,
             "value": safe_tx.value,
-            "data": safe_tx.data.hex() if safe_tx.data else None,
+            "data": safe_tx.data.to_0x_hex() if safe_tx.data else None,
             "operation": safe_tx.operation,
             "gasToken": safe_tx.gas_token,
             "safeTxGas": safe_tx.safe_tx_gas,
@@ -335,7 +334,7 @@ class TransactionServiceApi(SafeBaseAPI):
             "gasPrice": safe_tx.gas_price,
             "refundReceiver": safe_tx.refund_receiver,
             "nonce": safe_tx.safe_nonce,
-            "contractTransactionHash": safe_tx.safe_tx_hash.hex(),
+            "contractTransactionHash": safe_tx.safe_tx_hash.to_0x_hex(),
             "sender": sender,
             "signature": safe_tx.signatures.hex() if safe_tx.signatures else None,
             "origin": "Safe-CLI",
@@ -380,7 +379,7 @@ class TransactionServiceApi(SafeBaseAPI):
         payload = {
             "message": message,
             "safeAppId": safe_app_id,
-            "signature": HexBytes(signature).hex(),
+            "signature": HexBytes(signature).to_0x_hex(),
         }
         response = self._post_request(
             f"/api/v1/safes/{safe_address}/messages/", payload
@@ -396,7 +395,7 @@ class TransactionServiceApi(SafeBaseAPI):
         :return: Safe message for provided Safe message hash
         """
         response = self._get_request(
-            f"/api/v1/messages/{HexBytes(safe_message_hash).hex()}/"
+            f"/api/v1/messages/{HexBytes(safe_message_hash).to_0x_hex()}/"
         )
         if not response.ok:
             raise SafeAPIException(f"Cannot get messages: {response.content!r}")
@@ -423,9 +422,10 @@ class TransactionServiceApi(SafeBaseAPI):
         :param signature:
         :return:
         """
-        payload = {"signature": HexBytes(signature).hex()}
+        payload = {"signature": HexBytes(signature).to_0x_hex()}
         response = self._post_request(
-            f"/api/v1/messages/{HexBytes(safe_message_hash).hex()}/signatures/", payload
+            f"/api/v1/messages/{HexBytes(safe_message_hash).to_0x_hex()}/signatures/",
+            payload,
         )
         if not response.ok:
             raise SafeAPIException(
@@ -443,7 +443,7 @@ class TransactionServiceApi(SafeBaseAPI):
         :param to_address: address of the contract. This will be used in case of more than one function identifiers matching.
         :return:
         """
-        payload = {"data": HexBytes(data).hex()}
+        payload = {"data": HexBytes(data).to_0x_hex()}
         if to_address:
             payload["to"] = to_address
         response = self._post_request("/api/v1/data-decoder/", payload)

--- a/safe_eth/safe/multi_send.py
+++ b/safe_eth/safe/multi_send.py
@@ -48,7 +48,7 @@ class MultiSendTx:
         self.operation = operation
         self.to = to
         self.value = value
-        self.data = HexBytes(data) if data else b""
+        self.data = HexBytes(data) if data else HexBytes(b"")
         self.old_encoding = old_encoding
 
     def __eq__(self, other):
@@ -69,7 +69,7 @@ class MultiSendTx:
         return 21 + 32 * 2 + self.data_length
 
     def __repr__(self):
-        data = self.data[:4].hex() + ("..." if len(self.data) > 4 else "")
+        data = self.data[:4].to_0x_hex() + ("..." if len(self.data) > 4 else "")
         return (
             f"MultisendTx operation={self.operation.name} to={self.to} value={self.value} "
             f"data={data}"
@@ -288,7 +288,7 @@ class MultiSend:
         )
 
         tx_hash = ethereum_client.send_unsigned_transaction(
-            tx, private_key=deployer_account.key
+            tx, private_key=HexBytes(deployer_account.key).to_0x_hex()
         )
         tx_receipt = ethereum_client.get_transaction_receipt(tx_hash, timeout=120)
         assert tx_receipt

--- a/safe_eth/safe/multi_send.py
+++ b/safe_eth/safe/multi_send.py
@@ -16,6 +16,7 @@ from safe_eth.eth.utils import (
     fast_is_checksum_address,
     get_empty_tx_params,
 )
+from safe_eth.util.util import to_0x_hex_str
 
 logger = getLogger(__name__)
 
@@ -69,7 +70,7 @@ class MultiSendTx:
         return 21 + 32 * 2 + self.data_length
 
     def __repr__(self):
-        data = self.data[:4].to_0x_hex() + ("..." if len(self.data) > 4 else "")
+        data = to_0x_hex_str(self.data[:4]) + ("..." if len(self.data) > 4 else "")
         return (
             f"MultisendTx operation={self.operation.name} to={self.to} value={self.value} "
             f"data={data}"
@@ -288,7 +289,7 @@ class MultiSend:
         )
 
         tx_hash = ethereum_client.send_unsigned_transaction(
-            tx, private_key=HexBytes(deployer_account.key).to_0x_hex()
+            tx, private_key=to_0x_hex_str(deployer_account.key)
         )
         tx_receipt = ethereum_client.get_transaction_receipt(tx_hash, timeout=120)
         assert tx_receipt

--- a/safe_eth/safe/safe.py
+++ b/safe_eth/safe/safe.py
@@ -45,6 +45,7 @@ from safe_eth.eth.utils import (
     get_empty_tx_params,
 )
 
+from ..util.util import to_0x_hex_str
 from .addresses import SAFE_SIMULATE_TX_ACCESSOR_ADDRESS
 from .enums import SafeOperationEnum
 from .exceptions import CannotEstimateGas, CannotRetrieveSafeInfoException
@@ -477,7 +478,7 @@ class Safe(SafeCreator, ContractBase, metaclass=ABCMeta):
                     self.address,
                     gas_estimated,
                     to,
-                    data.to_0x_hex(),
+                    to_0x_hex_str(data),
                 )
                 block_gas_limit = (
                     block_gas_limit

--- a/safe_eth/safe/safe_creator.py
+++ b/safe_eth/safe/safe_creator.py
@@ -16,6 +16,7 @@ from safe_eth.eth.contracts import (
 )
 from safe_eth.eth.utils import get_empty_tx_params
 
+from ..util.util import to_0x_hex_str
 from .exceptions import InvalidERC20Token, InvalidPaymentToken
 from .proxy_factory import ProxyFactory
 from .safe_create2_tx import SafeCreate2Tx, SafeCreate2TxBuilder
@@ -100,7 +101,7 @@ class SafeCreator:
             master_copy_address, initializer
         ).build_transaction({"from": deployer_account.address})
         tx_hash = ethereum_client.send_unsigned_transaction(
-            tx, private_key=HexBytes(deployer_account.key).to_0x_hex()
+            tx, private_key=to_0x_hex_str(deployer_account.key)
         )
         tx_receipt = ethereum_client.get_transaction_receipt(tx_hash, timeout=60)
         assert tx_receipt

--- a/safe_eth/safe/safe_creator.py
+++ b/safe_eth/safe/safe_creator.py
@@ -100,7 +100,7 @@ class SafeCreator:
             master_copy_address, initializer
         ).build_transaction({"from": deployer_account.address})
         tx_hash = ethereum_client.send_unsigned_transaction(
-            tx, private_key=deployer_account.key
+            tx, private_key=HexBytes(deployer_account.key).to_0x_hex()
         )
         tx_receipt = ethereum_client.get_transaction_receipt(tx_hash, timeout=60)
         assert tx_receipt

--- a/safe_eth/safe/safe_signature.py
+++ b/safe_eth/safe/safe_signature.py
@@ -9,7 +9,7 @@ from eth_abi.exceptions import DecodingError
 from eth_account.messages import defunct_hash_message
 from eth_typing import BlockIdentifier, ChecksumAddress, HexAddress, HexStr
 from hexbytes import HexBytes
-from web3.exceptions import Web3Exception
+from web3.exceptions import Web3Exception, Web3RPCError, Web3ValueError
 
 from safe_eth.eth import EthereumClient
 from safe_eth.eth.contracts import (
@@ -288,12 +288,12 @@ class SafeSignatureContract(SafeSignature):
         )
         try:
             return is_valid_signature_fn(
-                self.safe_hash_preimage, self.contract_signature
+                bytes(self.safe_hash_preimage), bytes(self.contract_signature)
             ).call() in (
                 self.EIP1271_MAGIC_VALUE,
                 self.EIP1271_MAGIC_VALUE_UPDATED,
             )
-        except (Web3Exception, DecodingError, ValueError):
+        except (Web3Exception, DecodingError, Web3ValueError, Web3RPCError):
             # Error using `pending` block identifier or contract does not exist
             logger.warning(
                 "Cannot check EIP1271 signature from contract %s", self.owner
@@ -332,7 +332,7 @@ class SafeSignatureApprovedHash(SafeSignature):
                     ).call(block_identifier=block_identifier)
                     == 1
                 )
-            except (Web3Exception, DecodingError, ValueError) as e:
+            except (Web3Exception, DecodingError, Web3ValueError, Web3RPCError) as e:
                 # Error using `pending` block identifier
                 exception = e
         raise exception  # This should never happen

--- a/safe_eth/safe/safe_tx.py
+++ b/safe_eth/safe/safe_tx.py
@@ -83,7 +83,7 @@ class SafeTx:
         self.safe_address = safe_address
         self.to = to or NULL_ADDRESS
         self.value = int(value)
-        self.data = HexBytes(data) if data else b""
+        self.data = HexBytes(data) if data else HexBytes(b"")
         self.operation = int(operation)
         self.safe_tx_gas = int(safe_tx_gas)
         self.base_gas = int(base_gas)
@@ -100,7 +100,7 @@ class SafeTx:
 
     def __str__(self):
         return (
-            f"SafeTx - safe={self.safe_address} - to={self.to} - value={self.value} - data={self.data.hex()} - "
+            f"SafeTx - safe={self.safe_address} - to={self.to} - value={self.value} - data={self.data.to_0x_hex()} - "
             f"operation={self.operation} - safe-tx-gas={self.safe_tx_gas} - base-gas={self.base_gas} - "
             f"gas-price={self.gas_price} - gas-token={self.gas_token} - refund-receiver={self.refund_receiver} - "
             f"signers = {self.signers}"
@@ -415,7 +415,7 @@ class SafeTx:
         :return: Signature
         """
         account = Account.from_key(private_key)
-        signature_dict = account.signHash(self.safe_tx_hash)
+        signature_dict = account.unsafe_sign_hash(self.safe_tx_hash)
         signature = signature_to_bytes(
             signature_dict["v"], signature_dict["r"], signature_dict["s"]
         )

--- a/safe_eth/safe/safe_tx.py
+++ b/safe_eth/safe/safe_tx.py
@@ -16,6 +16,7 @@ from safe_eth.eth.eip712 import eip712_encode
 from safe_eth.eth.ethereum_client import TxSpeed
 
 from ..eth.utils import fast_keccak
+from ..util.util import to_0x_hex_str
 from .exceptions import (
     CouldNotFinishInitialization,
     CouldNotPayGasWithEther,
@@ -100,7 +101,7 @@ class SafeTx:
 
     def __str__(self):
         return (
-            f"SafeTx - safe={self.safe_address} - to={self.to} - value={self.value} - data={self.data.to_0x_hex()} - "
+            f"SafeTx - safe={self.safe_address} - to={self.to} - value={self.value} - data={to_0x_hex_str(self.data)} - "
             f"operation={self.operation} - safe-tx-gas={self.safe_tx_gas} - base-gas={self.base_gas} - "
             f"gas-price={self.gas_price} - gas-token={self.gas_token} - refund-receiver={self.refund_receiver} - "
             f"signers = {self.signers}"

--- a/safe_eth/safe/tests/api/test_transaction_service_api.py
+++ b/safe_eth/safe/tests/api/test_transaction_service_api.py
@@ -15,6 +15,7 @@ from safe_eth.safe.api.transaction_service_api import (
     ApiSafeTxHashNotMatchingException,
     TransactionServiceApi,
 )
+from safe_eth.util.util import to_0x_hex_str
 
 from ...api import SafeAPIException
 from ..mocks.mock_transactions import (
@@ -178,7 +179,7 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             safe_tx_hash_expected = transaction_mock.get("safeTxHash")
 
             self.assertIn(
-                f"API safe-tx-hash: {safe_tx_invalid_hash.to_0x_hex()} doesn't match the calculated safe-tx-hash: {safe_tx_hash_expected}",
+                f"API safe-tx-hash: {to_0x_hex_str(safe_tx_invalid_hash)} doesn't match the calculated safe-tx-hash: {safe_tx_hash_expected}",
                 str(context.exception),
             )
 
@@ -187,7 +188,7 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             with self.assertRaises(SafeAPIException) as context:
                 self.transaction_service_api.get_safe_transaction(safe_tx_hash)
             self.assertIn(
-                f"Cannot get transaction with safe-tx-hash={safe_tx_hash.to_0x_hex()}:",
+                f"Cannot get transaction with safe-tx-hash={to_0x_hex_str(safe_tx_hash)}:",
                 str(context.exception),
             )
 
@@ -200,9 +201,9 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             message_hash = self.transaction_service_api.create_delegate_message_hash(
                 delegate_address
             )
-            signature = HexBytes(
-                delegator_account.unsafe_sign_hash(message_hash).signature
-            ).to_0x_hex()
+            signature = to_0x_hex_str(
+                HexBytes(delegator_account.unsafe_sign_hash(message_hash).signature)
+            )
             self.transaction_service_api.remove_delegate(
                 delegate_address, delegator_account.address, signature
             )
@@ -235,9 +236,9 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             message_hash = self.transaction_service_api.create_delegate_message_hash(
                 delegate_address
             )
-            signature = HexBytes(
-                delegator_account.unsafe_sign_hash(message_hash).signature
-            ).to_0x_hex()
+            signature = to_0x_hex_str(
+                HexBytes(delegator_account.unsafe_sign_hash(message_hash).signature)
+            )
             label = "test label"
             self.transaction_service_api.add_delegate(
                 delegate_address, delegator_account.address, label, signature
@@ -281,7 +282,7 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             to_address = "0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C"
             decoded_data = self.transaction_service_api.decode_data(data, to_address)
             expected_url = "/api/v1/data-decoder/"
-            expected_payload = {"data": HexBytes(data).to_0x_hex(), "to": to_address}
+            expected_payload = {"data": to_0x_hex_str(HexBytes(data)), "to": to_address}
             mock_post_request.assert_called_once_with(expected_url, expected_payload)
             self.assertEqual(decoded_data.get("method"), "approve")
             self.assertEqual(decoded_data.get("parameters")[0].get("name"), "spender")

--- a/safe_eth/safe/tests/api/test_transaction_service_api.py
+++ b/safe_eth/safe/tests/api/test_transaction_service_api.py
@@ -176,8 +176,9 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
                 self.transaction_service_api.get_safe_transaction(safe_tx_invalid_hash)
 
             safe_tx_hash_expected = transaction_mock.get("safeTxHash")
+
             self.assertIn(
-                f"API safe-tx-hash: {safe_tx_invalid_hash.hex()} doesn't match the calculated safe-tx-hash: {safe_tx_hash_expected}",
+                f"API safe-tx-hash: {safe_tx_invalid_hash.to_0x_hex()} doesn't match the calculated safe-tx-hash: {safe_tx_hash_expected}",
                 str(context.exception),
             )
 
@@ -186,7 +187,7 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             with self.assertRaises(SafeAPIException) as context:
                 self.transaction_service_api.get_safe_transaction(safe_tx_hash)
             self.assertIn(
-                f"Cannot get transaction with safe-tx-hash={safe_tx_hash.hex()}:",
+                f"Cannot get transaction with safe-tx-hash={safe_tx_hash.to_0x_hex()}:",
                 str(context.exception),
             )
 
@@ -199,7 +200,9 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             message_hash = self.transaction_service_api.create_delegate_message_hash(
                 delegate_address
             )
-            signature = delegator_account.signHash(message_hash).signature.hex()
+            signature = HexBytes(
+                delegator_account.unsafe_sign_hash(message_hash).signature
+            ).to_0x_hex()
             self.transaction_service_api.remove_delegate(
                 delegate_address, delegator_account.address, signature
             )
@@ -232,7 +235,9 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             message_hash = self.transaction_service_api.create_delegate_message_hash(
                 delegate_address
             )
-            signature = delegator_account.signHash(message_hash).signature.hex()
+            signature = HexBytes(
+                delegator_account.unsafe_sign_hash(message_hash).signature
+            ).to_0x_hex()
             label = "test label"
             self.transaction_service_api.add_delegate(
                 delegate_address, delegator_account.address, label, signature
@@ -276,7 +281,7 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             to_address = "0x4127839cdf4F73d9fC9a2C2861d8d1799e9DF40C"
             decoded_data = self.transaction_service_api.decode_data(data, to_address)
             expected_url = "/api/v1/data-decoder/"
-            expected_payload = {"data": HexBytes(data).hex(), "to": to_address}
+            expected_payload = {"data": HexBytes(data).to_0x_hex(), "to": to_address}
             mock_post_request.assert_called_once_with(expected_url, expected_payload)
             self.assertEqual(decoded_data.get("method"), "approve")
             self.assertEqual(decoded_data.get("parameters")[0].get("name"), "spender")

--- a/safe_eth/safe/tests/test_safe.py
+++ b/safe_eth/safe/tests/test_safe.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 
 from eth_account import Account
 from hexbytes import HexBytes
+from web3.exceptions import Web3RPCError
 
 from safe_eth.eth.constants import GAS_CALL_DATA_BYTE, NULL_ADDRESS
 from safe_eth.eth.contracts import get_safe_contract, get_sign_message_lib_contract
@@ -681,7 +682,7 @@ class TestSafe(SafeTestCaseMixin, TestCase):
             initializer=b"",
         )
         safe = Safe(ethereum_tx_sent.contract_address, self.ethereum_client)
-        with self.assertRaisesMessage(ValueError, "revert"):
+        with self.assertRaisesMessage(Web3RPCError, "revert"):
             self.assertEqual(safe.retrieve_modules(), [])
         self.assertEqual(safe.retrieve_all_info().modules, [])
 

--- a/safe_eth/safe/tests/test_safe_signature.py
+++ b/safe_eth/safe/tests/test_safe_signature.py
@@ -92,7 +92,7 @@ class TestSafeSignature(EthereumTestCaseMixin, TestCase):
             "0x123477d1b1b8dec52329a983ae26238b65f74b7dd9fb28d74ad9548e92aaf195"
         )
         message = defunct_hash_message(primitive=safe_tx_hash)
-        signature = account.signHash(message)["signature"]
+        signature = account.unsafe_sign_hash(message)["signature"]
         signature = signature[:64] + HexBytes(signature[64] + 4)  # Add 4 to v
         safe_signature = SafeSignatureEthSign(signature, safe_tx_hash)
         self.assertEqual(safe_signature.owner, owner)
@@ -119,7 +119,7 @@ class TestSafeSignature(EthereumTestCaseMixin, TestCase):
         safe_tx_hash = HexBytes(
             "0x123477d1b1b8dec52329a983ae26238b65f74b7dd9fb28d74ad9548e92aaf195"
         )
-        signature = account.signHash(safe_tx_hash)["signature"]
+        signature = account.unsafe_sign_hash(safe_tx_hash)["signature"]
         safe_signature = SafeSignatureEOA(signature, safe_tx_hash)
         self.assertEqual(safe_signature.owner, owner)
         self.assertEqual(safe_signature.signature_type, SafeSignatureType.EOA)
@@ -190,7 +190,9 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
         message = "Testing EIP191 message signing"
         message_hash = defunct_hash_message(text=message)
         safe_owner_message_hash = safe_owner.get_message_hash(message_hash)
-        safe_owner_signature = account.signHash(safe_owner_message_hash)["signature"]
+        safe_owner_signature = account.unsafe_sign_hash(safe_owner_message_hash)[
+            "signature"
+        ]
         safe_parent_message_hash = safe.get_message_hash(message_hash)
 
         # Build EIP1271 signature v=0 r=safe v=dynamic_part dynamic_part=size+owner_signature
@@ -240,10 +242,10 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
         safe_tx_hash = safe_tx.safe_tx_hash
 
         safe_owner_1_message_hash = safe_owner_1.get_message_hash(safe_tx_hash_preimage)
-        safe_owner_1_eoa_1_signature = safe_owner_1_eoa_1.signHash(
+        safe_owner_1_eoa_1_signature = safe_owner_1_eoa_1.unsafe_sign_hash(
             safe_owner_1_message_hash
         )["signature"]
-        safe_owner_1_eoa_2_signature = safe_owner_1_eoa_2.signHash(
+        safe_owner_1_eoa_2_signature = safe_owner_1_eoa_2.unsafe_sign_hash(
             safe_owner_1_message_hash
         )["signature"]
         safe_owner_1_eoa_signature = (
@@ -261,7 +263,7 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
         )
 
         safe_owner_2_message_hash = safe_owner_2.get_message_hash(safe_tx_hash_preimage)
-        safe_owner_2_eoa_1_signature = safe_owner_2_eoa_1.signHash(
+        safe_owner_2_eoa_1_signature = safe_owner_2_eoa_1.unsafe_sign_hash(
             safe_owner_2_message_hash
         )["signature"]
 
@@ -274,7 +276,7 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
         )
 
         eoa_signature = SafeSignatureEOA(
-            eoa.signHash(safe_tx_hash)["signature"], safe_tx_hash
+            eoa.unsafe_sign_hash(safe_tx_hash)["signature"], safe_tx_hash
         )
 
         signatures = SafeSignature.export_signatures(
@@ -324,7 +326,9 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
         safe_tx_hash_2_message_hash = safe_contract.functions.getMessageHash(
             safe_tx_hash_2
         ).call()
-        contract_signature = owner_1.signHash(safe_tx_hash_2_message_hash)["signature"]
+        contract_signature = owner_1.unsafe_sign_hash(safe_tx_hash_2_message_hash)[
+            "signature"
+        ]
 
         encoded_contract_signature_with_offset = encode_abi(
             ["bytes"], [contract_signature]
@@ -380,7 +384,9 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
         safe_tx_hash_message_hash = safe_contract.functions.getMessageHash(
             safe_tx_hash
         ).call()
-        contract_signature_2 = owner_1.signHash(safe_tx_hash_message_hash)["signature"]
+        contract_signature_2 = owner_1.unsafe_sign_hash(safe_tx_hash_message_hash)[
+            "signature"
+        ]
         encoded_contract_signature_2 = encode_abi(["bytes"], [contract_signature_2])[
             32:
         ]  # It will {32 bytes offset}{32 bytes size}, we don't need offset

--- a/safe_eth/safe/tests/test_safe_tx.py
+++ b/safe_eth/safe/tests/test_safe_tx.py
@@ -6,6 +6,7 @@ from eth_account import Account
 from hexbytes import HexBytes
 
 from ...eth.utils import get_empty_tx_params
+from ...util.util import to_0x_hex_str
 from ..enums import SafeOperationEnum
 from ..exceptions import NotEnoughSafeTransactionGas, SignaturesDataTooShort
 from ..multi_send import MultiSendOperation, MultiSendTx
@@ -73,7 +74,7 @@ class TestSafeTx(SafeTestCaseMixin, TestCase):
             safe_tx.call(tx_sender_address=self.ethereum_test_account.address), 1
         )
         tx_hash, _ = safe_tx.execute(
-            tx_sender_private_key=self.ethereum_test_account.key.to_0x_hex()
+            tx_sender_private_key=to_0x_hex_str(self.ethereum_test_account.key)
         )
         self.ethereum_client.get_transaction_receipt(tx_hash, timeout=60)
         self.assertEqual(safe.retrieve_nonce(), 1)

--- a/safe_eth/safe/tests/test_safe_tx.py
+++ b/safe_eth/safe/tests/test_safe_tx.py
@@ -73,7 +73,7 @@ class TestSafeTx(SafeTestCaseMixin, TestCase):
             safe_tx.call(tx_sender_address=self.ethereum_test_account.address), 1
         )
         tx_hash, _ = safe_tx.execute(
-            tx_sender_private_key=self.ethereum_test_account.key
+            tx_sender_private_key=self.ethereum_test_account.key.to_0x_hex()
         )
         self.ethereum_client.get_transaction_receipt(tx_hash, timeout=60)
         self.assertEqual(safe.retrieve_nonce(), 1)

--- a/safe_eth/safe/tests/test_signatures.py
+++ b/safe_eth/safe/tests/test_signatures.py
@@ -18,7 +18,7 @@ class TestSafeSignature(SafeTestCaseMixin, TestCase):
         account = Account.create()
         # Random hash
         random_hash = fast_keccak_text("tanxugueiras")
-        signature = account.signHash(random_hash)
+        signature = account.unsafe_sign_hash(random_hash)
         self.assertEqual(
             get_signing_address(random_hash, signature.v, signature.r, signature.s),
             account.address,
@@ -49,7 +49,7 @@ class TestSafeSignature(SafeTestCaseMixin, TestCase):
         )
 
         # Use deprecated isValidSignature method (receives bytes)
-        signature = owner.signHash(safe_message_hash)
+        signature = owner.unsafe_sign_hash(safe_message_hash)
         is_valid_bytes_fn = compatibility_contract.get_function_by_signature(
             "isValidSignature(bytes,bytes)"
         )
@@ -67,7 +67,7 @@ class TestSafeSignature(SafeTestCaseMixin, TestCase):
             safe_message_hash,
         )
 
-        signature = owner.signHash(safe_message_hash)
+        signature = owner.unsafe_sign_hash(safe_message_hash)
         is_valid_bytes_fn = compatibility_contract.get_function_by_signature(
             "isValidSignature(bytes32,bytes)"
         )
@@ -93,7 +93,7 @@ class TestSafeSignature(SafeTestCaseMixin, TestCase):
         )
 
         # Use isValidSignature method (receives bytes)
-        signature = owner.signHash(safe_message_hash)
+        signature = owner.unsafe_sign_hash(safe_message_hash)
 
         self.assertEqual(
             contract.functions.isValidSignature(

--- a/safe_eth/util/util.py
+++ b/safe_eth/util/util.py
@@ -1,6 +1,4 @@
-from typing import Any, Iterable, Sequence, Union
-
-from hexbytes import HexBytes
+from typing import Any, Iterable, Sequence
 
 
 def chunks(elements: Sequence[Any], n: int) -> Iterable[Any]:
@@ -13,12 +11,11 @@ def chunks(elements: Sequence[Any], n: int) -> Iterable[Any]:
         yield elements[i : i + n]
 
 
-def to_0x_hex_str(value: Union[bytes, HexBytes]) -> str:
+def to_0x_hex_str(value: bytes) -> str:
     """
-    Convert bytes or HexBytes to a 0x-prefixed hex string
-    :param value: bytes or HexBytes value
+    Convert bytes to a 0x-prefixed hex string
+
+    :param value: bytes value
     :return: 0x-prefixed hex string
     """
-    if isinstance(value, HexBytes):
-        return value.to_0x_hex()
     return "0x" + value.hex()

--- a/safe_eth/util/util.py
+++ b/safe_eth/util/util.py
@@ -1,4 +1,6 @@
-from typing import Any, Iterable, Sequence
+from typing import Any, Iterable, Sequence, Union
+
+from hexbytes import HexBytes
 
 
 def chunks(elements: Sequence[Any], n: int) -> Iterable[Any]:
@@ -9,3 +11,14 @@ def chunks(elements: Sequence[Any], n: int) -> Iterable[Any]:
     """
     for i in range(0, len(elements), n):
         yield elements[i : i + n]
+
+
+def to_0x_hex_str(value: Union[bytes, HexBytes]) -> str:
+    """
+    Convert bytes or HexBytes to a 0x-prefixed hex string
+    :param value: bytes or HexBytes value
+    :return: 0x-prefixed hex string
+    """
+    if isinstance(value, HexBytes):
+        return value.to_0x_hex()
+    return "0x" + value.hex()


### PR DESCRIPTION
- Closes #1324

Version 7.7.0 of `web3` is the first version of `web3` to support `safe-eth-py` given the [problem with overloaded functions](https://github.com/ethereum/web3.py/pull/3540).

Likewise, it is necessary to update `HexBytes` because of the dependencies between the two libraries.

Migration guides:

- https://eth-account.readthedocs.io/en/stable/release_notes.html#removals
- https://web3py.readthedocs.io/en/latest/migration.html#migrating-from-v6-to-v7
- https://web3py.readthedocs.io/en/latest/internals.html#request-caching
- https://hexbytes.readthedocs.io/en/stable/release_notes.html#breaking-changes