### PR TITLE
Migrate blockscout from graphql to REST api api

### DIFF
--- a/safe_eth/eth/clients/blockscout_client.py
+++ b/safe_eth/eth/clients/blockscout_client.py
@@ -1,4 +1,3 @@
-import json
 import os
 from typing import Any, Dict, Optional
 from urllib.parse import urljoin
@@ -21,137 +20,80 @@ class BlockScoutConfigurationProblem(BlockscoutClientException):
 
 class BlockscoutClient:
     NETWORK_WITH_URL = {
-        EthereumNetwork.GNOSIS: "https://gnosis.blockscout.com/api/v1/graphql",
-        EthereumNetwork.ENERGY_WEB_CHAIN: "https://explorer.energyweb.org/graphiql",
-        EthereumNetwork.ENERGY_WEB_VOLTA_TESTNET: "https://volta-explorer.energyweb.org/graphiql",
-        EthereumNetwork.POLIS_MAINNET: "https://explorer.polis.tech/graphiql",
-        EthereumNetwork.BOBA_NETWORK: "https://blockexplorer.boba.network/graphiql",
-        EthereumNetwork.GATHER_DEVNET_NETWORK: "https://devnet-explorer.gather.network/graphiql",
-        EthereumNetwork.GATHER_TESTNET_NETWORK: "https://testnet-explorer.gather.network/graphiql",
-        EthereumNetwork.GATHER_MAINNET_NETWORK: "https://explorer.gather.network/graphiql",
-        EthereumNetwork.METIS_GOERLI_TESTNET: "https://goerli.explorer.metisdevops.link/graphiql",
-        EthereumNetwork.METIS_ANDROMEDA_MAINNET: "https://andromeda-explorer.metis.io/graphiql",
-        EthereumNetwork.FUSE_MAINNET: "https://explorer.fuse.io/graphiql",
-        EthereumNetwork.VELAS_EVM_MAINNET: "https://evmexplorer.velas.com/graphiql",
-        EthereumNetwork.REI_NETWORK: "https://scan.rei.network/graphiql",
-        EthereumNetwork.REI_CHAIN_TESTNET: "https://scan-test.rei.network/graphiql",
-        EthereumNetwork.METER_MAINNET: "https://scan.meter.io/graphiql",
-        EthereumNetwork.METER_TESTNET: "https://scan-warringstakes.meter.io/graphiql",
-        EthereumNetwork.GODWOKEN_MAINNET: "https://v1.gwscan.com/graphiql",
-        EthereumNetwork.VENIDIUM_TESTNET: "https://evm-testnet.venidiumexplorer.com/graphiql",
-        EthereumNetwork.VENIDIUM_MAINNET: "https://evm.venidiumexplorer.com/graphiql",
-        EthereumNetwork.KAIA_KAIROS_TESTNET: "https://baobab.scope.klaytn.com/graphiql",
-        EthereumNetwork.KAIA_MAINNET: "https://scope.klaytn.com/graphiql",
-        EthereumNetwork.ACALA_NETWORK: "https://blockscout.acala.network/graphiql",
-        EthereumNetwork.KARURA_NETWORK_TESTNET: "https://blockscout.karura.network/graphiql",
-        EthereumNetwork.ASTAR: "https://blockscout.com/astar/graphiql",
-        EthereumNetwork.SHIDEN: "https://blockscout.com/shiden/graphiql",
-        EthereumNetwork.EVMOS: "https://evm.evmos.org/graphiql",
-        EthereumNetwork.EVMOS_TESTNET: "https://evm.evmos.dev/graphiql",
-        EthereumNetwork.KCC_MAINNET: "https://scan.kcc.io/graphiql",
-        EthereumNetwork.KCC_TESTNET: "https://scan-testnet.kcc.network/graphiql",
-        EthereumNetwork.CROSSBELL: "https://scan.crossbell.io/graphiql",
-        EthereumNetwork.ETHEREUM_CLASSIC: "https://blockscout.com/etc/mainnet/graphiql",
-        EthereumNetwork.MORDOR_TESTNET: "https://blockscout.com/etc/mordor/graphiql",
-        EthereumNetwork.SCROLL_SEPOLIA_TESTNET: "https://sepolia-blockscout.scroll.io/graphiql",
-        EthereumNetwork.MANTLE: "https://explorer.mantle.xyz/api/v1/graphql",
-        EthereumNetwork.MANTLE_TESTNET: "https://explorer.testnet.mantle.xyz/graphiql",
-        EthereumNetwork.JAPAN_OPEN_CHAIN_MAINNET: "https://mainnet.japanopenchain.org/graphiql",
-        EthereumNetwork.JAPAN_OPEN_CHAIN_TESTNET: "https://explorer.testnet.japanopenchain.org/graphiql",
-        EthereumNetwork.ZETACHAIN_TESTNET: "https://zetachain-athens-3.blockscout.com/graphiql",
-        EthereumNetwork.SCROLL: "https://blockscout.scroll.io/graphiql",
-        EthereumNetwork.ROOTSTOCK_MAINNET: "https://rootstock.blockscout.com/graphiql",
-        EthereumNetwork.ROOTSTOCK_TESTNET: "https://rootstock-testnet.blockscout.com/graphiql",
-        EthereumNetwork.LINEA: "https://explorer.linea.build/graphiql",
-        EthereumNetwork.LINEA_GOERLI: "https://explorer.goerli.linea.build/graphiql",
-        EthereumNetwork.NEON_EVM_MAINNET: "https://neon.blockscout.com/graphiql",
-        EthereumNetwork.NEON_EVM_DEVNET: "https://neon-devnet.blockscout.com/graphiql",
-        EthereumNetwork.OASIS_SAPPHIRE: "https://explorer.sapphire.oasis.io/graphiql",
-        EthereumNetwork.OASIS_SAPPHIRE_TESTNET: "https://testnet.explorer.sapphire.oasis.dev/graphiql",
-        EthereumNetwork.CASCADIA_TESTNET: "https://explorer.cascadia.foundation/graphiql",
-        EthereumNetwork.TENET: "https://tenetscan.io/graphiql",
-        EthereumNetwork.TENET_TESTNET: "https://testnet.tenetscan.io/graphiql",
-        EthereumNetwork.CRONOS_MAINNET: "https://cronos.org/explorer/graphiql",
-        EthereumNetwork.CRONOS_TESTNET: "https://cronos.org/explorer/testnet3/graphiql",
-        EthereumNetwork.THUNDERCORE_MAINNET: "https://explorer-mainnet.thundercore.com/graphiql",
-        EthereumNetwork.THUNDERCORE_TESTNET: "https://explorer-testnet.thundercore.com/graphiql",
-        EthereumNetwork.PGN_PUBLIC_GOODS_NETWORK: "https://explorer.publicgoods.network/graphiql",
-        EthereumNetwork.SEPOLIA_PGN_PUBLIC_GOODS_NETWORK: "https://explorer.sepolia.publicgoods.network/graphiql",
-        EthereumNetwork.ARTHERA_MAINNET: "https://explorer.arthera.net/graphiql",
-        EthereumNetwork.ARTHERA_TESTNET: "https://explorer-test.arthera.net/graphiql",
-        EthereumNetwork.MANTA_PACIFIC_MAINNET: "https://pacific-explorer.manta.network/graphiql",
-        EthereumNetwork.KROMA: "https://blockscout.kroma.network/graphiql",
-        EthereumNetwork.KROMA_SEPOLIA: "https://blockscout.sepolia.kroma.network/graphiql",
-        EthereumNetwork.ZORA: "https://explorer.zora.energy/graphiql",
-        EthereumNetwork.ZORA_SEPOLIA_TESTNET: "https://sepolia.explorer.zora.energy/graphiql",
-        EthereumNetwork.HAQQ_NETWORK: "https://explorer.haqq.network/graphiql",
-        EthereumNetwork.HAQQ_CHAIN_TESTNET: "https://explorer.testedge2.haqq.network/graphiql",
-        EthereumNetwork.MODE: "https://explorer.mode.network/graphiql",
-        EthereumNetwork.MODE_TESTNET: "https://sepolia.explorer.mode.network/graphiql",
-        EthereumNetwork.MANTLE_SEPOLIA_TESTNET: "https://explorer.sepolia.mantle.xyz/api/v1/graphql",
-        EthereumNetwork.OP_SEPOLIA_TESTNET: "https://optimism-sepolia.blockscout.com/graphiql",
-        EthereumNetwork.UNREAL_OLD: "https://unreal.blockscout.com/graphiql",
-        EthereumNetwork.TAIKO_KATLA_L2: "https://explorer.katla.taiko.xyz/graphiql",
-        EthereumNetwork.SEI_DEVNET: "https://seitrace.com/graphiql",
-        EthereumNetwork.LISK_SEPOLIA_TESTNET: "https://sepolia-blockscout.lisk.com/api/v1/graphql",
-        EthereumNetwork.BOTANIX_TESTNET: "https://blockscout.botanixlabs.dev/graphiql",
-        EthereumNetwork.REYA_NETWORK: "https://explorer.reya.network/graphiql",
-        EthereumNetwork.AURORIA_TESTNET: "https://auroria.explorer.stratisevm.com/graphiql",
-        EthereumNetwork.STRATIS_MAINNET: "https://explorer.stratisevm.com/graphiql",
-        EthereumNetwork.SHIMMEREVM: "https://explorer.evm.shimmer.network/graphiql",
-        EthereumNetwork.IOTA_EVM: "https://iota-evm.blockscout.com/graphiql",
-        EthereumNetwork.BITROCK_MAINNET: "https://explorer.bit-rock.io/api/v1/graphql",
-        EthereumNetwork.BITROCK_TESTNET: "https://testnetscan.bit-rock.io/api/v1/graphql",
-        EthereumNetwork.OP_CELESTIA_RASPBERRY: "https://opcelestia-raspberry.gelatoscout.com/api/v1/graphql",
-        EthereumNetwork.POLYGON_BLACKBERRY: "https://polygon-blackberry.gelatoscout.com/api/v1/graphql",
-        EthereumNetwork.ARBITRUM_BLUEBERRY: "https://arb-blueberry.gelatoscout.com/api/v1/graphql",
-        EthereumNetwork.RSS3_VSL_SEPOLIA_TESTNET: "https://scan.testnet.rss3.io/api/v1/graphql",
-        EthereumNetwork.RSS3_VSL_MAINNET: "https://scan.rss3.io/api/v1/graphql",
-        EthereumNetwork.CROSSFI_TESTNET: "https://scan.testnet.ms/graphiql",
-        EthereumNetwork.ASTAR_ZKYOTO: "https://astar-zkyoto.blockscout.com/api/v1/graphql",
-        EthereumNetwork.SAAKURU_MAINNET: "https://explorer.saakuru.network/graphiql",
-        EthereumNetwork.REDSTONE: "https://explorer.redstone.xyz/api/v1/graphql",
-        EthereumNetwork.GARNET_HOLESKY: "https://api.explorer.garnet.qry.live/api/v1/graphql",
-        EthereumNetwork.TAIKO_HEKLA_L2: "https://blockscoutapi.hekla.taiko.xyz/graphiql",
-        EthereumNetwork.ASTAR_ZKEVM: "https://astar-zkevm.explorer.startale.com/api/v1/graphql",
-        EthereumNetwork.RE_AL: "https://explorer.re.al/api/v1/graphql",
-        EthereumNetwork.UNREAL: "https://unreal.blockscout.com/api/v1/graphql",
-        EthereumNetwork.LISK: "https://blockscout.lisk.com/api/v1/graphql",
-        EthereumNetwork.LORENZO: "https://scan.lorenzo-protocol.xyz/api/v1/graphql",
-        EthereumNetwork.DODOCHAIN_TESTNET: "https://testnet-scan.dodochain.com/api/v1/graphql",
-        EthereumNetwork.ETHERLINK_MAINNET: "https://explorer.etherlink.com/api/v1/graphql",
-        EthereumNetwork.ETHERLINK_TESTNET: "https://testnet-explorer.etherlink.com/api/v1/graphql",
-        EthereumNetwork.FLARE_MAINNET: "https://flare-explorer.flare.network/graphiql",
-        EthereumNetwork.AUTONOMYS_TESTNET_NOVA_DOMAIN: "https://nova.subspace.network/api/v1/graphql",
-        EthereumNetwork.GNOSIS_CHIADO_TESTNET: "https://gnosis-chiado.blockscout.com/api/v1/graphql",
-        EthereumNetwork.SONGBIRD_CANARY_NETWORK: "https://songbird-explorer.flare.network/graphiql",
-        EthereumNetwork.SONGBIRD_TESTNET_COSTON: "https://coston-explorer.flare.network/graphiql",
-        EthereumNetwork.FLARE_TESTNET_COSTON2: "https://coston2-explorer.flare.network/graphiql",
-        EthereumNetwork.NAL_SEPOLIA_TESTNET: "https://testnet-scan.nal.network/api/v1/graphql",
-        EthereumNetwork.ALEPH_ZERO_EVM: "https://evm-explorer.alephzero.org/api/v1/graphql",
-        EthereumNetwork.SKOPJE_TESTNET: "https://skopje-explorer.gptprotocol.io/api/v1/graphql",
-        EthereumNetwork.GPT_MAINNET: "https://explorer.gptprotocol.io/api/v1/graphql",
-        EthereumNetwork.BOB_SEPOLIA: "https://bob-sepolia.explorer.gobob.xyz/api/v1/graphql",
-        EthereumNetwork.SNAXCHAIN: "https://explorer.snaxchain.io/api/v1/graphql",
-        EthereumNetwork.Q_MAINNET: "https://explorer.q.org/api/v1/graphql",
-        EthereumNetwork.Q_TESTNET: "https://explorer.qtestnet.org/api/v1/graphql",
-        EthereumNetwork.VANA_MOKSHA_TESTNET: "https://api.moksha.vanascan.io/api/v1/graphql",
-        EthereumNetwork.CONNEXT_SEPOLIA: "https://scan.testnet.everclear.org/api/v1/graphql",
-        EthereumNetwork.EVERCLEAR_MAINNET: "https://scan.everclear.org/api/v1/graphql",
-        EthereumNetwork.BAHAMUT: "https://api.ftnscan.com/api/v1/graphql",
-        EthereumNetwork.GAME7_TESTNET: "https://testnet.game7.io/api/v1/graphql",
-        EthereumNetwork.GAME7: "https://mainnet.game7.io/api/v1/graphql",
-        EthereumNetwork.MORPH_HOLESKY: "https://explorer-api-holesky.morphl2.io/api/v1/graphql",
-        EthereumNetwork.INK_SEPOLIA: "https://explorer-sepolia.inkonchain.com/api/v1/graphql",
-        EthereumNetwork.STORY_ODYSSEY_TESTNET: "https://odyssey-testnet-explorer.storyscan.xyz/api/v1/graphql",
-        EthereumNetwork.SWELLCHAIN_TESTNET: "https://swell-testnet-explorer.alt.technology/api/v1/graphql",
-        EthereumNetwork.PLUME_DEVNET: "https://test-explorer.plumenetwork.xyz/api/v1/graphql",
-        EthereumNetwork.PLUME_MAINNET: "https://phoenix-explorer.plumenetwork.xyz/api/v1/graphql",
-        EthereumNetwork.SWELLCHAIN: "https://explorer.swellnetwork.io/api/v1/graphql",
-        EthereumNetwork.HASHKEY_CHAIN_TESTNET: "https://hashkeychain-testnet-explorer.alt.technology/api/v1/graphql",
-        EthereumNetwork.EXSAT_TESTNET: "https://scan-testnet.exsat.network/api/v1/graphql",
-        EthereumNetwork.HASHKEY_CHAIN: "https://explorer.hsk.xyz/api/v1/graphql",
-        EthereumNetwork.EXSAT_MAINNET: "https://scan.exsat.network/api/v1/graphql",
+        EthereumNetwork.ACALA_NETWORK: "https://blockscout.acala.network/api/v2/",
+        EthereumNetwork.ALEPH_ZERO_EVM: "https://evm-explorer.alephzero.org/api/v2/",
+        EthereumNetwork.ARBITRUM_BLUEBERRY: "https://arb-blueberry.gelatoscout.com/api/v2/",
+        EthereumNetwork.ARTHERA_MAINNET: "https://explorer.arthera.net/api/v2/",
+        EthereumNetwork.ARTHERA_TESTNET: "https://explorer-test.arthera.net/api/v2/",
+        EthereumNetwork.ASTAR_ZKEVM: "https://astar-zkevm.explorer.startale.com/api/v2/",
+        EthereumNetwork.AURORIA_TESTNET: "https://auroria.explorer.stratisevm.com/api/v2/",
+        EthereumNetwork.BAHAMUT: "https://api.ftnscan.com/api/v2/",
+        EthereumNetwork.BOB_SEPOLIA: "https://bob-sepolia.explorer.gobob.xyz/api/v2/",
+        EthereumNetwork.BITROCK_TESTNET: "https://testnetscan.bit-rock.io/api/v2/",
+        EthereumNetwork.CONNEXT_SEPOLIA: "https://scan.testnet.everclear.org/api/v2/",
+        EthereumNetwork.DODOCHAIN_TESTNET: "https://testnet-scan.dodochain.com/api/v2/",
+        EthereumNetwork.EVERCLEAR_MAINNET: "https://scan.everclear.org/api/v2/",
+        EthereumNetwork.EVMOS: "https://evm.evmos.org/api/v2/",
+        EthereumNetwork.ETHERLINK_MAINNET: "https://explorer.etherlink.com/api/v2/",
+        EthereumNetwork.EXSAT_MAINNET: "https://scan.exsat.network/api/v2/",
+        EthereumNetwork.EXSAT_TESTNET: "https://scan-testnet.exsat.network/api/v2/",
+        EthereumNetwork.FLARE_MAINNET: "https://flare-explorer.flare.network/api/v2/",
+        EthereumNetwork.FLARE_TESTNET_COSTON2: "https://coston2-explorer.flare.network/api/v2/",
+        EthereumNetwork.GAME7: "https://mainnet.game7.io/api/v2/",
+        EthereumNetwork.GAME7_TESTNET: "https://testnet.game7.io/api/v2/",
+        EthereumNetwork.GNOSIS: "https://gnosis.blockscout.com/api/v2/",
+        EthereumNetwork.GNOSIS_CHIADO_TESTNET: "https://gnosis-chiado.blockscout.com/api/v2/",
+        EthereumNetwork.GPT_MAINNET: "https://explorer.gptprotocol.io/api/v2/",
+        EthereumNetwork.HAQQ_CHAIN_TESTNET: "https://explorer.testedge2.haqq.network/api/v2/",
+        EthereumNetwork.HAQQ_NETWORK: "https://explorer.haqq.network/api/v2/",
+        EthereumNetwork.HASHKEY_CHAIN: "https://explorer.hsk.xyz/api/v2/",
+        EthereumNetwork.HASHKEY_CHAIN_TESTNET: "https://hashkeychain-testnet-explorer.alt.technology/api/v2/",
+        EthereumNetwork.IOTA_EVM: "https://iota-evm.blockscout.com/api/v2/",
+        EthereumNetwork.INK_SEPOLIA: "https://explorer-sepolia.inkonchain.com/api/v2/",
+        EthereumNetwork.JAPAN_OPEN_CHAIN_MAINNET: "https://mainnet.japanopenchain.org/api/v2/",
+        EthereumNetwork.JAPAN_OPEN_CHAIN_TESTNET: "https://explorer.testnet.japanopenchain.org/api/v2/",
+        EthereumNetwork.KAIA_KAIROS_TESTNET: "https://baobab.scope.klaytn.com/api/v2/",
+        EthereumNetwork.KAIA_MAINNET: "https://scope.klaytn.com/api/v2/",
+        EthereumNetwork.KROMA: "https://blockscout.kroma.network/api/v2/",
+        EthereumNetwork.KROMA_SEPOLIA: "https://blockscout.sepolia.kroma.network/api/v2/",
+        EthereumNetwork.LISK: "https://blockscout.lisk.com/api/v2/",
+        EthereumNetwork.LISK_SEPOLIA_TESTNET: "https://sepolia-blockscout.lisk.com/api/v2/",
+        EthereumNetwork.LORENZO: "https://scan.lorenzo-protocol.xyz/api/v2/",
+        EthereumNetwork.MANTLE: "https://explorer.mantle.xyz/api/v2/",
+        EthereumNetwork.MANTLE_SEPOLIA_TESTNET: "https://explorer.sepolia.mantle.xyz/api/v2/",
+        EthereumNetwork.MANTLE_TESTNET: "https://explorer.testnet.mantle.xyz/api/v2/",
+        EthereumNetwork.MANTLE_TESTNET: "https://explorer.testnet.mantle.xyz/api/v2/",
+        EthereumNetwork.MANTA_PACIFIC_MAINNET: "https://pacific-explorer.manta.network/api/v2/",
+        EthereumNetwork.METER_MAINNET: "https://scan.meter.io/api/v2/",
+        EthereumNetwork.METER_TESTNET: "https://scan-warringstakes.meter.io/api/v2/",
+        EthereumNetwork.MODE: "https://explorer.mode.network/api/v2/",
+        EthereumNetwork.MODE_TESTNET: "https://sepolia.explorer.mode.network/api/v2/",
+        EthereumNetwork.NAL_SEPOLIA_TESTNET: "https://testnet-scan.nal.network/api/v2/",
+        EthereumNetwork.NEON_EVM_DEVNET: "https://neon-devnet.blockscout.com/api/v2/",
+        EthereumNetwork.NEON_EVM_MAINNET: "https://neon.blockscout.com/api/v2/",
+        EthereumNetwork.OP_CELESTIA_RASPBERRY: "https://opcelestia-raspberry.gelatoscout.com/api/v2/",
+        EthereumNetwork.OP_SEPOLIA_TESTNET: "https://optimism-sepolia.blockscout.com/api/v2/",
+        EthereumNetwork.PLUME_DEVNET: "https://test-explorer.plumenetwork.xyz/api/v2/",
+        EthereumNetwork.PLUME_MAINNET: "https://phoenix-explorer.plumenetwork.xyz/api/v2/",
+        EthereumNetwork.Q_MAINNET: "https://explorer.q.org/api/v2/",
+        EthereumNetwork.Q_TESTNET: "https://explorer.qtestnet.org/api/v2/",
+        EthereumNetwork.REDSTONE: "https://explorer.redstone.xyz/api/v2/",
+        EthereumNetwork.RE_AL: "https://explorer.re.al/api/v2/",
+        EthereumNetwork.REYA_NETWORK: "https://explorer.reya.network/api/v2/",
+        EthereumNetwork.ROOTSTOCK_MAINNET: "https://rootstock.blockscout.com/api/v2/",
+        EthereumNetwork.ROOTSTOCK_TESTNET: "https://rootstock-testnet.blockscout.com/api/v2/",
+        EthereumNetwork.SAAKURU_MAINNET: "https://explorer.saakuru.network/api/v2/",
+        EthereumNetwork.SNAXCHAIN: "https://explorer.snaxchain.io/api/v2/",
+        EthereumNetwork.SONGBIRD_CANARY_NETWORK: "https://songbird-explorer.flare.network/api/v2/",
+        EthereumNetwork.SONGBIRD_TESTNET_COSTON: "https://coston-explorer.flare.network/api/v2/",
+        EthereumNetwork.STORY_ODYSSEY_TESTNET: "https://odyssey-testnet-explorer.storyscan.xyz/api/v2/",
+        EthereumNetwork.SWELLCHAIN: "https://explorer.swellnetwork.io/api/v2/",
+        EthereumNetwork.SWELLCHAIN_TESTNET: "https://swell-testnet-explorer.alt.technology/api/v2/",
+        EthereumNetwork.TAIKO_HEKLA_L2: "https://blockscoutapi.hekla.taiko.xyz/api/v2/",
+        EthereumNetwork.VANA_MOKSHA_TESTNET: "https://api.moksha.vanascan.io/api/v2/",
+        EthereumNetwork.ZETACHAIN_TESTNET: "https://zetachain-athens-3.blockscout.com/api/v2/",
+        EthereumNetwork.ZORA: "https://explorer.zora.energy/api/v2/",
+        EthereumNetwork.ZORA_SEPOLIA_TESTNET: "https://sepolia.explorer.zora.energy/api/v2/",
     }
 
     def __init__(
@@ -162,19 +104,19 @@ class BlockscoutClient:
         ),
     ):
         self.network = network
-        self.grahpql_url = self.NETWORK_WITH_URL.get(network, "")
+        self.api_url = self.NETWORK_WITH_URL.get(network, "")
         self.request_timeout = request_timeout
-        if not self.grahpql_url:
+        if not self.api_url:
             raise BlockScoutConfigurationProblem(
                 f"Network {network.name} - {network.value} not supported"
             )
         self.http_session = requests.Session()
 
     def build_url(self, path: str):
-        return urljoin(self.grahpql_url, path)
+        return urljoin(self.api_url, path)
 
-    def _do_request(self, url: str, query: str) -> Optional[Dict[str, Any]]:
-        response = self.http_session.post(url, json={"query": query}, timeout=10)
+    def _do_request(self, url: str) -> Optional[Dict[str, Any]]:
+        response = self.http_session.get(url, timeout=10)
         if not response.ok:
             return None
 
@@ -190,22 +132,22 @@ class BlockscoutClient:
         :param contract_data:
         :return:
         """
-        if (
-            "error" not in contract_data
-            and contract_data.get("data", {}).get("address", {})
-            and contract_data["data"]["address"]["smartContract"]
-        ):
-            smart_contract = contract_data["data"]["address"]["smartContract"]
+        if abi := contract_data.get("abi"):
+            name = contract_data["name"]
+            implementations: list = contract_data.get("implementations", [])
             return ContractMetadata(
-                smart_contract["name"], json.loads(smart_contract["abi"]), False
+                name,
+                abi,
+                False,
+                implementations[0]["address"] if implementations else None,
             )
         return None
 
     def get_contract_metadata(
         self, address: ChecksumAddress
     ) -> Optional[ContractMetadata]:
-        query = '{address(hash: "%s") { hash, smartContract {name, abi} }}' % address
-        contract_data = self._do_request(self.grahpql_url, query)
+        contract_request = self.build_url(f"smart-contracts/{address}")
+        contract_data = self._do_request(contract_request)
         if contract_data:
             return self._process_contract_metadata(contract_data)
         return None
@@ -226,12 +168,12 @@ class AsyncBlockscoutClient(BlockscoutClient):
             connector=aiohttp.TCPConnector(limit_per_host=max_requests)
         )
 
-    async def _async_do_request(self, url: str, query: str) -> Optional[Dict[str, Any]]:
+    async def _async_do_request(self, url: str) -> Optional[Dict[str, Any]]:
         """
         Asynchronous version of _do_request
         """
-        async with self.async_session.post(
-            url, json={"query": query}, timeout=self.request_timeout
+        async with self.async_session.get(
+            url, timeout=self.request_timeout
         ) as response:
             if not response.ok:
                 return None
@@ -241,8 +183,8 @@ class AsyncBlockscoutClient(BlockscoutClient):
     async def async_get_contract_metadata(
         self, address: ChecksumAddress
     ) -> Optional[ContractMetadata]:
-        query = '{address(hash: "%s") { hash, smartContract {name, abi} }}' % address
-        contract_data = await self._async_do_request(self.grahpql_url, query)
+        contract_request = self.build_url(f"smart-contracts/{address}")
+        contract_data = await self._async_do_request(contract_request)
         if contract_data:
             return self._process_contract_metadata(contract_data)
         return None

--- a/safe_eth/eth/tests/clients/mocks.py
+++ b/safe_eth/eth/tests/clients/mocks.py
@@ -1010,3 +1010,14 @@ etherscan_source_code_mock = [
         "SwarmSource": "bzzr://eba952a8e826ae22d1831da9d381d7b6c153687b8cb43c646ad31acd2ce84288",
     }
 ]
+
+safe_proxy_abi_mock = [
+    {
+        "inputs": [
+            {"internalType": "address", "name": "_singleton", "type": "address"}
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor",
+    },
+    {"stateMutability": "payable", "type": "fallback"},
+]

--- a/safe_eth/eth/tests/clients/test_blockscout_client.py
+++ b/safe_eth/eth/tests/clients/test_blockscout_client.py
@@ -7,7 +7,7 @@ import pytest
 from ... import EthereumNetwork
 from ...clients import BlockscoutClient, BlockScoutConfigurationProblem
 from ...clients.blockscout_client import AsyncBlockscoutClient
-from .mocks import sourcify_safe_metadata
+from .mocks import safe_proxy_abi_mock, sourcify_safe_metadata
 
 
 class TestBlockscoutClient(TestCase):
@@ -24,6 +24,15 @@ class TestBlockscoutClient(TestCase):
         )
         self.assertEqual(contract_metadata.name, "GnosisSafe")
         self.assertEqual(contract_metadata.abi, safe_master_copy_abi)
+        self.assertEqual(contract_metadata.implementation, None)
+
+        proxy_address = "0xfca7Da0a0290D7BcBEcD93bE124756fC9B6F8E6A"
+        implementation_address = "0x3E5c63644E683549055b9Be8653de26E0B4CD36E"
+        contract_metadata = blockscout_client.get_contract_metadata(proxy_address)
+        self.assertEqual(contract_metadata.name, "GnosisSafeProxy")
+        self.assertEqual(contract_metadata.implementation, implementation_address)
+        self.assertEqual(contract_metadata.abi, safe_proxy_abi_mock)
+
         random_address = "0xaE32496491b53841efb51829d6f886387708F99a"
         self.assertIsNone(blockscout_client.get_contract_metadata(random_address))
 
@@ -38,6 +47,16 @@ class TestAsyncBlockscoutClient(unittest.IsolatedAsyncioTestCase):
         )
         self.assertEqual(contract_metadata.name, "GnosisSafe")
         self.assertEqual(contract_metadata.abi, safe_master_copy_abi)
+
+        self.assertEqual(contract_metadata.implementation, None)
+
+        proxy_address = "0xfca7Da0a0290D7BcBEcD93bE124756fC9B6F8E6A"
+        implementation_address = "0x3E5c63644E683549055b9Be8653de26E0B4CD36E"
+        contract_metadata = blockscout_client.get_contract_metadata(proxy_address)
+        self.assertEqual(contract_metadata.name, "GnosisSafeProxy")
+        self.assertEqual(contract_metadata.implementation, implementation_address)
+        self.assertEqual(contract_metadata.abi, safe_proxy_abi_mock)
+
         random_address = "0xaE32496491b53841efb51829d6f886387708F99a"
         self.assertIsNone(
             await blockscout_client.async_get_contract_metadata(random_address)


### PR DESCRIPTION
Closes #1508 
# Description
This PR will deprecate blockscout GraphQL in favor of REST API. 
The following chains are not supporting the Blockscout API due they are using old version of BlockScout. 
```
[(<EthereumNetwork.ENERGY_WEB_CHAIN: 246>,
  'https://explorer.energyweb.org/graphiql'),
 (<EthereumNetwork.ENERGY_WEB_VOLTA_TESTNET: 73799>,
  'https://volta-explorer.energyweb.org/graphiql'),
 (<EthereumNetwork.BOBA_NETWORK: 288>,
  'https://blockexplorer.boba.network/graphiql'),
 (<EthereumNetwork.GATHER_DEVNET_NETWORK: 486217935>,
  'https://devnet-explorer.gather.network/graphiql'),
 (<EthereumNetwork.GATHER_TESTNET_NETWORK: 356256156>,
  'https://testnet-explorer.gather.network/graphiql'),
 (<EthereumNetwork.GATHER_MAINNET_NETWORK: 192837465>,
  'https://explorer.gather.network/graphiql'),
 (<EthereumNetwork.VELAS_EVM_MAINNET: 106>,
  'https://evmexplorer.velas.com/graphiql'),
 (<EthereumNetwork.REI_NETWORK: 47805>, 'https://scan.rei.network/graphiql'),
 (<EthereumNetwork.REI_CHAIN_TESTNET: 55556>,
  'https://scan-test.rei.network/graphiql'),
 (<EthereumNetwork.GODWOKEN_MAINNET: 71402>, 'https://v1.gwscan.com/graphiql'),
 (<EthereumNetwork.VENIDIUM_TESTNET: 4918>,
  'https://evm-testnet.venidiumexplorer.com/graphiql'),
 (<EthereumNetwork.VENIDIUM_MAINNET: 4919>,
  'https://evm.venidiumexplorer.com/graphiql'),
 (<EthereumNetwork.ASTAR: 592>, 'https://blockscout.com/astar/graphiql'),
 (<EthereumNetwork.SHIDEN: 336>, 'https://blockscout.com/shiden/graphiql'),
 (<EthereumNetwork.EVMOS_TESTNET: 9000>, 'https://evm.evmos.dev/graphiql'),
 (<EthereumNetwork.KCC_MAINNET: 321>, 'https://scan.kcc.io/graphiql'),
 (<EthereumNetwork.KCC_TESTNET: 322>,
  'https://scan-testnet.kcc.network/graphiql'),
 (<EthereumNetwork.CROSSBELL: 3737>, 'https://scan.crossbell.io/graphiql'),
 (<EthereumNetwork.ETHEREUM_CLASSIC: 61>,
  'https://blockscout.com/etc/mainnet/graphiql'),
 (<EthereumNetwork.MORDOR_TESTNET: 63>,
  'https://blockscout.com/etc/mordor/graphiql'),
 (<EthereumNetwork.TENET: 1559>, 'https://tenetscan.io/graphiql'),
 (<EthereumNetwork.TENET_TESTNET: 155>,
  'https://testnet.tenetscan.io/graphiql'),
 (<EthereumNetwork.CRONOS_MAINNET: 25>,
  'https://cronos.org/explorer/graphiql'),
 (<EthereumNetwork.CRONOS_TESTNET: 338>,
  'https://cronos.org/explorer/testnet3/graphiql'),
 (<EthereumNetwork.THUNDERCORE_MAINNET: 108>,
  'https://explorer-mainnet.thundercore.com/graphiql'),
 (<EthereumNetwork.THUNDERCORE_TESTNET: 18>,
  'https://explorer-testnet.thundercore.com/graphiql'),
 (<EthereumNetwork.SEI_DEVNET: 713715>, 'https://seitrace.com/graphiql'),
 (<EthereumNetwork.BOTANIX_TESTNET: 3636>,
  'https://blockscout.botanixlabs.dev/graphiql'),
 (<EthereumNetwork.POLYGON_BLACKBERRY: 94204209>,
  'https://polygon-blackberry.gelatoscout.com/api/v1/graphql'),
 (<EthereumNetwork.CROSSFI_TESTNET: 4157>, 'https://scan.testnet.ms/graphiql'),
 (<EthereumNetwork.AUTONOMYS_TESTNET_NOVA_DOMAIN: 490000>,
  'https://nova.subspace.network/api/v1/graphql')]
```