### PR TITLE
Skip if fail etherscan V1

### DIFF
--- a/safe_eth/eth/tests/clients/test_etherscan_client.py
+++ b/safe_eth/eth/tests/clients/test_etherscan_client.py
@@ -19,6 +19,7 @@ class TestEtherscanClient(TestCase):
 
         return EtherscanClient(network, api_key=etherscan_api_key)
 
+    @pytest.mark.xfail(reason="Test might fail due to API key limits, we don't retry")
     def test_etherscan_get_abi(self):
         try:
             etherscan_api = self.get_etherscan_api(EthereumNetwork.MAINNET)


### PR DESCRIPTION
# Description
We are deprecating Etherscan V1, so we don't retry and skip the test if fails, mainly because a rate limit.