### PR TITLE
Update Tx Service v2 API endpoints

### DIFF
--- a/safe_eth/safe/api/transaction_service_api/entities.py
+++ b/safe_eth/safe/api/transaction_service_api/entities.py
@@ -71,11 +71,11 @@ class Transaction(TypedDict):
     data: Optional[HexStr]
     operation: int
     gasToken: Optional[AnyAddressType]
-    safeTxGas: int
-    baseGas: int
+    safeTxGas: str
+    baseGas: str
     gasPrice: str
     refundReceiver: Optional[AnyAddressType]
-    nonce: int
+    nonce: str
     execution_date: str
     submission_date: str
     modified: str

--- a/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
+++ b/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
@@ -151,14 +151,14 @@ class TransactionServiceApi(SafeBaseAPI):
             HexBytes(tx_raw["transactionHash"]) if tx_raw["transactionHash"] else None
         )
 
-        if safe_tx.safe_tx_hash != safe_tx_hash:
+        if safe_tx.safe_tx_hash != HexBytes(safe_tx_hash):
             raise ApiSafeTxHashNotMatchingException(
                 f"API safe-tx-hash: {to_0x_hex_str(HexBytes(safe_tx_hash))} doesn't match the calculated safe-tx-hash: {to_0x_hex_str(HexBytes(safe_tx.safe_tx_hash))}"
             )
 
         return safe_tx
 
-    def get_balances(self, safe_address: str) -> List[Balance]:
+    def get_balances(self, safe_address: ChecksumAddress) -> List[Balance]:
         """
 
         :param safe_address:
@@ -178,7 +178,7 @@ class TransactionServiceApi(SafeBaseAPI):
         """
         safe_tx_hash_str = to_0x_hex_str(HexBytes(safe_tx_hash))
         response = self._get_request(
-            f"/api/v1/multisig-transactions/{safe_tx_hash_str}/"
+            f"/api/v2/multisig-transactions/{safe_tx_hash_str}/"
         )
         if not response.ok:
             raise SafeAPIException(
@@ -203,7 +203,7 @@ class TransactionServiceApi(SafeBaseAPI):
         :param safe_address:
         :return: a list of transactions for provided Safe
         """
-        url = f"/api/v1/safes/{safe_address}/multisig-transactions/"
+        url = f"/api/v2/safes/{safe_address}/multisig-transactions/"
 
         if kwargs:
             query_string = urlencode(
@@ -341,7 +341,7 @@ class TransactionServiceApi(SafeBaseAPI):
             "origin": "Safe-CLI",
         }
         response = self._post_request(
-            f"/api/v1/safes/{safe_tx.safe_address}/multisig-transactions/", data
+            f"/api/v2/safes/{safe_tx.safe_address}/multisig-transactions/", data
         )
         if not response.ok:
             raise SafeAPIException(f"Error posting transaction: {response.content!r}")
@@ -356,7 +356,7 @@ class TransactionServiceApi(SafeBaseAPI):
         """
         payload = {"safeTxHash": safe_tx_hash, "signature": signature}
         response = self._delete_request(
-            f"/api/v1/multisig-transactions/{safe_tx_hash}/", payload
+            f"/api/v2/multisig-transactions/{safe_tx_hash}/", payload
         )
         if not response.ok:
             raise SafeAPIException(f"Error deleting transaction: {response.content!r}")

--- a/safe_eth/safe/tests/api/test_transaction_service_api.py
+++ b/safe_eth/safe/tests/api/test_transaction_service_api.py
@@ -86,7 +86,7 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
                 self.safe_address, limit=2, nonce__lt=30, failed=False
             )
 
-        expected_url = f"/api/v1/safes/{self.safe_address}/multisig-transactions/?limit=2&nonce__lt=30&failed=False"
+        expected_url = f"/api/v2/safes/{self.safe_address}/multisig-transactions/?limit=2&nonce__lt=30&failed=False"
         mock_get_request.assert_called_once_with(expected_url)
 
         # Test valid safe tx has


### PR DESCRIPTION
- Updated API client with V2 endpoints added in this PR(https://github.com/safe-global/safe-transaction-service/pull/2417) in the Tx Service.
- Minor fix when comparing `safe_tx_hash` to validate a transaction and the value of the `safe_tx_hash` is `HexStr`. The value of the attribute obtained when generating a `SafeTx` is `HexBytes`.
- Discarded the upgrade to V2 of the balances endpoint because for the moment there is no deprecation plan. 