### PR TITLE
Use right fallback handler version for each Safe version

### DIFF
--- a/safe_eth/__init__.py
+++ b/safe_eth/__init__.py
@@ -1,1 +1,1 @@
-VERSION = "7.4.0"
+VERSION = "7.5.0"

--- a/safe_eth/safe/compatibility_fallback_handler.py
+++ b/safe_eth/safe/compatibility_fallback_handler.py
@@ -1,0 +1,61 @@
+from abc import ABCMeta
+from typing import Callable, Optional
+
+from eth_account.signers.local import LocalAccount
+from eth_typing import ChecksumAddress
+from web3 import Web3
+from web3.contract.contract import Contract
+
+from safe_eth.eth import EthereumClient, EthereumTxSent
+from safe_eth.eth.contracts import (
+    ContractBase,
+    get_compatibility_fallback_handler_V1_3_0_contract,
+    get_compatibility_fallback_handler_V1_4_1_contract,
+)
+from safe_eth.eth.utils import get_empty_tx_params
+
+
+class CompatibilityFallbackHandler(ContractBase, metaclass=ABCMeta):
+    def __new__(
+        cls, *args, version: str = "1.4.1", **kwargs
+    ) -> "CompatibilityFallbackHandler":
+        if cls is not CompatibilityFallbackHandler:
+            return super().__new__(cls)
+
+        versions = {
+            "1.3.0": CompatibilityFallbackHandlerV130,
+            "1.4.1": CompatibilityFallbackHandlerV141,
+        }
+        instance_class = versions[version]
+        instance = super().__new__(instance_class)  # type: ignore[type-abstract]
+        return instance
+
+    @classmethod
+    def deploy_contract(
+        cls, ethereum_client: EthereumClient, deployer_account: LocalAccount
+    ) -> EthereumTxSent:
+        """
+        Deploy Proxy Factory contract
+
+        :param ethereum_client:
+        :param deployer_account: Ethereum Account
+        :return: ``EthereumTxSent`` with the deployed contract address
+        """
+        contract_fn = cls.get_contract_fn(cls)  # type: ignore[arg-type]
+        contract = contract_fn(ethereum_client.w3, None)
+        constructor_data = contract.constructor().build_transaction(
+            get_empty_tx_params()
+        )["data"]
+        return ethereum_client.deploy_and_initialize_contract(
+            deployer_account, constructor_data
+        )
+
+
+class CompatibilityFallbackHandlerV130(CompatibilityFallbackHandler):
+    def get_contract_fn(self) -> Callable[[Web3, Optional[ChecksumAddress]], Contract]:
+        return get_compatibility_fallback_handler_V1_3_0_contract
+
+
+class CompatibilityFallbackHandlerV141(CompatibilityFallbackHandler):
+    def get_contract_fn(self) -> Callable[[Web3, Optional[ChecksumAddress]], Contract]:
+        return get_compatibility_fallback_handler_V1_4_1_contract

--- a/safe_eth/safe/safe_creator.py
+++ b/safe_eth/safe/safe_creator.py
@@ -9,7 +9,6 @@ from hexbytes import HexBytes
 from safe_eth.eth import EthereumClient, EthereumTxSent
 from safe_eth.eth.constants import NULL_ADDRESS
 from safe_eth.eth.contracts import (
-    get_compatibility_fallback_handler_contract,
     get_delegate_constructor_proxy_contract,
     get_safe_contract,
     get_simulate_tx_accessor_V1_4_1_contract,
@@ -109,33 +108,6 @@ class SafeCreator:
 
         contract_address = tx_receipt["contractAddress"]
         return EthereumTxSent(tx_hash, tx, contract_address)
-
-    @staticmethod
-    def deploy_compatibility_fallback_handler(
-        ethereum_client: EthereumClient, deployer_account: LocalAccount
-    ) -> EthereumTxSent:
-        """
-        Deploy Last compatibility Fallback handler
-
-        :param ethereum_client:
-        :param deployer_account: Ethereum account
-        :return: ``EthereumTxSent`` with the deployed contract address
-        """
-
-        contract = get_compatibility_fallback_handler_contract(ethereum_client.w3)
-        constructor_data = contract.constructor().build_transaction(
-            get_empty_tx_params()
-        )["data"]
-        ethereum_tx_sent = ethereum_client.deploy_and_initialize_contract(
-            deployer_account, constructor_data
-        )
-        logger.info(
-            "Deployed and initialized Compatibility Fallback Handler version=%s on address %s by %s",
-            "1.4.1",
-            ethereum_tx_sent.contract_address,
-            deployer_account.address,
-        )
-        return ethereum_tx_sent
 
     @staticmethod
     def deploy_simulate_tx_accessor(


### PR DESCRIPTION
- Previously 1.4.1 fallback handler was used for every Safe version
