### PR TITLE
Fix: Ensure HexV2Field properly handles DB and Python values

### DIFF
--- a/safe_eth/eth/django/models.py
+++ b/safe_eth/eth/django/models.py
@@ -196,6 +196,26 @@ class HexV2Field(models.BinaryField):
         defaults.update(kwargs)
         return super().formfield(**defaults)
 
+    def from_db_value(self, value, expression, connection):
+        if value:
+            return HexBytes(bytes(value))
+        return None
+
+    def to_python(self, value):
+        if value is None or isinstance(value, HexBytes):
+            return value
+        return HexBytes(value)
+
+    def get_prep_value(self, value):
+        if value is None:
+            return None
+        try:
+            return bytes(HexBytes(value))
+        except (TypeError, ValueError) as e:
+            raise exceptions.ValidationError(
+                f"Invalid hex value for HexV2Field: {value!r}"
+            ) from e
+
 
 class Keccak256Field(models.BinaryField):
     description = "Keccak256 hash stored as binary"

--- a/safe_eth/eth/django/tests/models.py
+++ b/safe_eth/eth/django/tests/models.py
@@ -3,6 +3,7 @@ from django.db import models
 from ..models import (
     EthereumAddressBinaryField,
     EthereumAddressFastBinaryField,
+    HexV2Field,
     Keccak256Field,
     Uint32Field,
     Uint96Field,
@@ -32,3 +33,7 @@ class Uint32(models.Model):
 
 class Keccak256Hash(models.Model):
     value = Keccak256Field(null=True)
+
+
+class HexV2Hash(models.Model):
+    value = HexV2Field(null=True)


### PR DESCRIPTION
### Description:

This PR improves HexV2Field by implementing the full Django value conversion interface:

- `from_db_value()`: ensures `bytea` values loaded from PostgreSQL are returned as `HexBytes`, instead of `memoryview`.
- `to_python()`: normalizes inputs like `bytes`, `HexBytes`, and `"0x..."` strings to `HexBytes`.
- `get_prep_value()`: ensures only raw `bytes` are sent to the DB, avoiding errors from passing a hex string directly.

This eliminates the need for consumers to subclass the field or manually convert values when reading/writing to the DB.

Fixes https://github.com/safe-global/safe-eth-py/issues/1749