### PR TITLE
Update CODEOWNERS team name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence.
-* @safe-global/mainframe
+* @safe-global/revenue

--- a/.github/workflows/create_pr_with_new_address.yml
+++ b/.github/workflows/create_pr_with_new_address.yml
@@ -21,7 +21,7 @@ jobs:
           const comment = context.payload.comment.body;
           const teamMembers = await github.rest.teams.listMembersInOrg({
             org: 'safe-global',
-            team_slug: 'mainframe',
+            team_slug: 'revenue',
           });
           const isMember = context.payload.sender.type === 'User' && teamMembers.data.some(member => member.login === context.payload.sender.login);
           if (comment.trim() === '/execute' && isMember) {


### PR DESCRIPTION
Fix team name from deprecated `mainframe` to new team name `revenue` https://github.com/orgs/safe-global/teams/revenue