### PR TITLE
Fix Blockscout API client response.

### DIFF
--- a/safe_eth/eth/clients/blockscout_client.py
+++ b/safe_eth/eth/clients/blockscout_client.py
@@ -159,7 +159,7 @@ class BlockscoutClient:
                 name,
                 abi,
                 False,
-                implementations[0]["address"] if implementations else None,
+                implementations[0]["address_hash"] if implementations else None,
             )
         return None
 


### PR DESCRIPTION
Due to a breaking change included in version v9.0.0, the address field of an implementation is now called address_hash. https://github.com/blockscout/blockscout/releases/tag/v9.0.0