### PR TITLE
Update local version of Postgres

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: ["3.10", 3.11, 3.12, 3.13]
     services:
       postgres:
-        image: postgres:13
+        image: postgres:16-alpine
         env:
           POSTGRES_PASSWORD: postgres
         options: >-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: postgres:15-alpine
+    image: postgres:16-alpine
     ports:
       - "5432:5432"
     environment:


### PR DESCRIPTION
To try to keep the PROD version aligned with the test environment, it is necessary to update the Postgres version to version 16.