### PR TITLE
Create SafeSignatureAsync class

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -68,7 +68,7 @@ jobs:
       env:
         PIP_USE_MIRRORS: true
     - name: Run tests and coverage
-      run: coverage run --source=$SOURCE_FOLDER -m pytest -W ignore::DeprecationWarning -rxXs --reruns 3
+      run: coverage run --source=$SOURCE_FOLDER -m pytest -W ignore::DeprecationWarning -rxXs --reruns 3 --reruns-delay 10
       env:
         SOURCE_FOLDER: safe_eth
         DJANGO_SETTINGS_MODULE: config.settings.test

--- a/safe_eth/safe/safe_signature.py
+++ b/safe_eth/safe/safe_signature.py
@@ -1,7 +1,19 @@
 from abc import ABC, abstractmethod
 from enum import Enum
 from logging import getLogger
-from typing import List, Optional, Sequence, Union
+from typing import (
+    Any,
+    ClassVar,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    Type,
+    TypeVar,
+    Union,
+    cast,
+    runtime_checkable,
+)
 
 from eth_abi import decode as decode_abi
 from eth_abi import encode as encode_abi
@@ -9,6 +21,8 @@ from eth_abi.exceptions import DecodingError
 from eth_account.messages import defunct_hash_message
 from eth_typing import BlockIdentifier, ChecksumAddress, HexAddress, HexStr
 from hexbytes import HexBytes
+from typing_extensions import Self
+from web3 import AsyncWeb3
 from web3.exceptions import Web3Exception, Web3RPCError, Web3ValueError
 
 from safe_eth.eth import EthereumClient
@@ -70,7 +84,20 @@ def uint_to_address(value: int) -> ChecksumAddress:
     )
 
 
-class SafeSignature(ABC):
+TSafeSignature = TypeVar("TSafeSignature", bound="SafeSignatureBase")
+
+
+@runtime_checkable
+class SupportsContractSignature(Protocol):
+    contract_signature: HexBytes
+
+
+class SafeSignatureBase(ABC):
+    contract_signature_cls: ClassVar[Optional[Type["SafeSignatureBase"]]] = None
+    approved_hash_cls: ClassVar[Optional[Type["SafeSignatureBase"]]] = None
+    eoa_cls: ClassVar[Optional[Type["SafeSignatureBase"]]] = None
+    eth_sign_cls: ClassVar[Optional[Type["SafeSignatureBase"]]] = None
+
     def __init__(self, signature: EthereumBytes, safe_hash: EthereumBytes):
         """
         :param signature: Owner signature
@@ -78,19 +105,22 @@ class SafeSignature(ABC):
         """
         self.signature = HexBytes(signature)
         self.safe_hash = HexBytes(safe_hash)
-        self.v, self.r, self.s = signature_split(self.signature)
+        v, r, s = signature_split(self.signature)
+        self.v: int = v
+        self.r: int = r
+        self.s: int = s
 
     def __str__(self):
         return f"SafeSignature type={self.signature_type.name} owner={self.owner}"
 
     @classmethod
     def parse_signature(
-        cls,
+        cls: Type[TSafeSignature],
         signatures: EthereumBytes,
         safe_hash: EthereumBytes,
         safe_hash_preimage: Optional[EthereumBytes] = None,
         ignore_trailing: bool = True,
-    ) -> List["SafeSignature"]:
+    ) -> List[TSafeSignature]:
         """
         :param signatures: One or more signatures appended. EIP1271 data at the end is supported.
         :param safe_hash: Signed hash for the Safe (message or transaction)
@@ -109,7 +139,7 @@ class SafeSignature(ABC):
             signatures
         )  # For contract signatures, to stop parsing at data position
 
-        safe_signatures = []
+        safe_signatures: List[TSafeSignature] = []
         for i in range(0, len(signatures), signature_size):
             if (
                 i >= data_position
@@ -122,7 +152,6 @@ class SafeSignature(ABC):
                 break
             v, r, s = signature_split(signature)
             signature_type = SafeSignatureType.from_v(v)
-            safe_signature: "SafeSignature"
             if signature_type == SafeSignatureType.CONTRACT_SIGNATURE:
                 if s < data_position:
                     data_position = s
@@ -132,24 +161,45 @@ class SafeSignature(ABC):
                 contract_signature = signatures[
                     s + 32 : s + 32 + contract_signature_len
                 ]  # Skip array size (32 bytes)
-                safe_signature = SafeSignatureContract(
-                    signature,
-                    safe_hash,
-                    safe_hash_preimage or safe_hash,
-                    contract_signature,
+                safe_signature_cls = cls._get_contract_signature_cls()
+                safe_signature = cast(
+                    TSafeSignature,
+                    cast(Type[Any], safe_signature_cls)(
+                        signature,
+                        safe_hash,
+                        safe_hash_preimage or safe_hash,
+                        contract_signature,
+                    ),
                 )
             elif signature_type == SafeSignatureType.APPROVED_HASH:
-                safe_signature = SafeSignatureApprovedHash(signature, safe_hash)
+                safe_signature_cls = cls._get_approved_hash_cls()
+                safe_signature = cast(
+                    TSafeSignature,
+                    cast(Type[Any], safe_signature_cls)(signature, safe_hash),
+                )
             elif signature_type == SafeSignatureType.EOA:
-                safe_signature = SafeSignatureEOA(signature, safe_hash)
+                safe_signature_cls = cls._get_eoa_cls()
+                safe_signature = cast(
+                    TSafeSignature,
+                    cast(Type[Any], safe_signature_cls)(signature, safe_hash),
+                )
             elif signature_type == SafeSignatureType.ETH_SIGN:
-                safe_signature = SafeSignatureEthSign(signature, safe_hash)
+                safe_signature_cls = cls._get_eth_sign_cls()
+                safe_signature = cast(
+                    TSafeSignature,
+                    cast(Type[Any], safe_signature_cls)(signature, safe_hash),
+                )
+            else:
+                logger.warning("Unexpected signature %s", signature)
+                continue
 
             safe_signatures.append(safe_signature)
         return safe_signatures
 
     @classmethod
-    def export_signatures(cls, safe_signatures: Sequence["SafeSignature"]) -> HexBytes:
+    def export_signatures(
+        cls, safe_signatures: Sequence["SafeSignatureBase"]
+    ) -> HexBytes:
         """
         Takes a list of SafeSignature objects and exports them as a valid signature for the contract
 
@@ -160,18 +210,23 @@ class SafeSignature(ABC):
         signature = b""
         dynamic_part = b""
         dynamic_offset = len(safe_signatures) * 65
+        contract_signature_cls = cls._get_contract_signature_cls()
+
         # Signatures must be sorted by owner
         for safe_signature in sorted(safe_signatures, key=lambda s: s.owner.lower()):
-            if isinstance(safe_signature, SafeSignatureContract):
+            if isinstance(safe_signature, contract_signature_cls):
+                contract_signature_holder = cast(
+                    SupportsContractSignature, safe_signature
+                )
                 signature += signature_to_bytes(
                     safe_signature.v, safe_signature.r, dynamic_offset
                 )
                 # encode_abi adds {32 bytes offset}{32 bytes size}. We don't need offset
                 contract_signature_padded = encode_abi(
-                    ["bytes"], [safe_signature.contract_signature]
+                    ["bytes"], [contract_signature_holder.contract_signature]
                 )[32:]
                 contract_signature = contract_signature_padded[
-                    : 32 + len(safe_signature.contract_signature)
+                    : 32 + len(contract_signature_holder.contract_signature)
                 ]
                 dynamic_part += contract_signature
                 dynamic_offset += len(contract_signature)
@@ -190,18 +245,9 @@ class SafeSignature(ABC):
 
     @property
     @abstractmethod
-    def owner(self):
+    def owner(self) -> ChecksumAddress:
         """
         :return: Decode owner from signature, without any further validation (signature can be not valid)
-        """
-        raise NotImplementedError
-
-    @abstractmethod
-    def is_valid(self, ethereum_client: EthereumClient, safe_address: str) -> bool:
-        """
-        :param ethereum_client: Required for Contract Signature and Approved Hash check
-        :param safe_address: Required for Approved Hash check
-        :return: `True` if signature is valid, `False` otherwise
         """
         raise NotImplementedError
 
@@ -210,8 +256,59 @@ class SafeSignature(ABC):
     def signature_type(self) -> SafeSignatureType:
         raise NotImplementedError
 
+    @classmethod
+    def _ensure_class(
+        cls,
+        candidate: Optional[Type["SafeSignatureBase"]],
+        attribute: str,
+    ) -> Type["SafeSignatureBase"]:
+        if candidate is None:
+            raise SafeSignatureException(f"{cls.__name__} does not define {attribute}")
+        return candidate
 
-class SafeSignatureContract(SafeSignature):
+    @classmethod
+    def _get_contract_signature_cls(cls) -> Type["SafeSignatureBase"]:
+        return cls._ensure_class(cls.contract_signature_cls, "contract_signature_cls")
+
+    @classmethod
+    def _get_approved_hash_cls(cls) -> Type["SafeSignatureBase"]:
+        return cls._ensure_class(cls.approved_hash_cls, "approved_hash_cls")
+
+    @classmethod
+    def _get_eoa_cls(cls) -> Type["SafeSignatureBase"]:
+        return cls._ensure_class(cls.eoa_cls, "eoa_cls")
+
+    @classmethod
+    def _get_eth_sign_cls(cls) -> Type["SafeSignatureBase"]:
+        return cls._ensure_class(cls.eth_sign_cls, "eth_sign_cls")
+
+
+class SafeSignature(SafeSignatureBase):
+    @abstractmethod
+    def is_valid(
+        self,
+        ethereum_client: Optional[EthereumClient] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
+        """
+        :param ethereum_client: Required for Contract Signature and Approved Hash check
+        :param safe_address: Required for Approved Hash check
+        :return: `True` if signature is valid, `False` otherwise
+        """
+        raise NotImplementedError
+
+
+class SafeSignatureAsync(SafeSignatureBase):
+    @abstractmethod
+    async def is_valid(
+        self,
+        web3: Optional[AsyncWeb3] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
+        raise NotImplementedError
+
+
+class SafeSignatureContractMixin(SafeSignatureBase):
     EIP1271_MAGIC_VALUE = HexBytes(0x20C13B0B)
     EIP1271_MAGIC_VALUE_UPDATED = HexBytes(0x1626BA7E)
 
@@ -222,15 +319,9 @@ class SafeSignatureContract(SafeSignature):
         safe_hash_preimage: EthereumBytes,
         contract_signature: EthereumBytes,
     ):
-        """
-        :param signature:
-        :param safe_hash: Signed hash for the Safe (message or transaction)
-        :param safe_hash_preimage: ``safe_hash`` preimage for EIP1271 validation
-        :param contract_signature:
-        """
         super().__init__(signature, safe_hash)
-        self.safe_hash_preimage = HexBytes(safe_hash_preimage)
-        self.contract_signature = HexBytes(contract_signature)
+        self.safe_hash_preimage: HexBytes = HexBytes(safe_hash_preimage)
+        self.contract_signature: HexBytes = HexBytes(contract_signature)
 
     @classmethod
     def from_values(
@@ -239,7 +330,7 @@ class SafeSignatureContract(SafeSignature):
         safe_hash: EthereumBytes,
         safe_hash_preimage: EthereumBytes,
         contract_signature: EthereumBytes,
-    ) -> "SafeSignatureContract":
+    ) -> Self:
         signature = signature_to_bytes(
             0, int.from_bytes(HexBytes(safe_owner), byteorder="big"), 65
         )
@@ -247,11 +338,6 @@ class SafeSignatureContract(SafeSignature):
 
     @property
     def owner(self) -> ChecksumAddress:
-        """
-        :return: Address of contract signing. No further checks to get the owner are needed,
-            but it could be a non-existing contract
-        """
-
         return uint_to_address(self.r)
 
     @property
@@ -259,11 +345,6 @@ class SafeSignatureContract(SafeSignature):
         return SafeSignatureType.CONTRACT_SIGNATURE
 
     def export_signature(self) -> HexBytes:
-        """
-        Fix offset (s) and append `contract_signature` at the end of the signature
-
-        :return:
-        """
         # encode_abi adds {32 bytes offset}{32 bytes size}. We don't need offset
         contract_signature_padded = encode_abi(["bytes"], [self.contract_signature])[
             32:
@@ -277,7 +358,62 @@ class SafeSignatureContract(SafeSignature):
             signature_to_bytes(self.v, self.r, dynamic_offset) + contract_signature
         )
 
-    def is_valid(self, ethereum_client: EthereumClient, *args) -> bool:
+
+class SafeSignatureApprovedHashMixin(SafeSignatureBase):
+    @property
+    def owner(self) -> ChecksumAddress:
+        return uint_to_address(self.r)
+
+    @property
+    def signature_type(self) -> SafeSignatureType:
+        return SafeSignatureType.APPROVED_HASH
+
+    @classmethod
+    def build_for_owner(cls, owner: str, safe_hash: str) -> Self:
+        r = owner.lower().replace("0x", "").rjust(64, "0")
+        s = "0" * 64
+        v = "01"
+        return cls(HexBytes(r + s + v), safe_hash)
+
+
+class SafeSignatureEthSignMixin(SafeSignatureBase):
+    @property
+    def owner(self) -> ChecksumAddress:
+        # defunct_hash_message prepends `\x19Ethereum Signed Message:\n32`
+        message_hash = defunct_hash_message(primitive=self.safe_hash)
+        return cast(
+            ChecksumAddress,
+            get_signing_address(message_hash, self.v - 4, self.r, self.s),
+        )
+
+    @property
+    def signature_type(self) -> SafeSignatureType:
+        return SafeSignatureType.ETH_SIGN
+
+
+class SafeSignatureEOAMixin(SafeSignatureBase):
+    @property
+    def owner(self) -> ChecksumAddress:
+        return cast(
+            ChecksumAddress,
+            get_signing_address(self.safe_hash, self.v, self.r, self.s),
+        )
+
+    @property
+    def signature_type(self) -> SafeSignatureType:
+        return SafeSignatureType.EOA
+
+
+class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
+    def is_valid(
+        self,
+        ethereum_client: Optional[EthereumClient] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
+        if ethereum_client is None:
+            raise ValueError(
+                "ethereum_client is required to validate contract signature"
+            )
         compatibility_fallback_handler = get_compatibility_fallback_handler_contract(
             ethereum_client.w3, self.owner
         )
@@ -301,27 +437,21 @@ class SafeSignatureContract(SafeSignature):
         return False
 
 
-class SafeSignatureApprovedHash(SafeSignature):
-    @property
-    def owner(self):
-        return uint_to_address(self.r)
+class SafeSignatureApprovedHash(SafeSignatureApprovedHashMixin, SafeSignature):
+    def is_valid(
+        self,
+        ethereum_client: Optional[EthereumClient] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
+        if ethereum_client is None:
+            raise ValueError("ethereum_client is required to validate approved hash")
+        if safe_address is None:
+            raise ValueError("safe_address is required to validate approved hash")
 
-    @property
-    def signature_type(self):
-        return SafeSignatureType.APPROVED_HASH
-
-    @classmethod
-    def build_for_owner(cls, owner: str, safe_hash: str) -> "SafeSignatureApprovedHash":
-        r = owner.lower().replace("0x", "").rjust(64, "0")
-        s = "0" * 64
-        v = "01"
-        return cls(HexBytes(r + s + v), safe_hash)
-
-    def is_valid(self, ethereum_client: EthereumClient, safe_address: str) -> bool:
         safe_contract = get_safe_contract(
             ethereum_client.w3, ChecksumAddress(HexAddress(HexStr(safe_address)))
         )
-        exception: Exception
+        exception: Optional[Exception] = None
 
         block_identifiers: List[BlockIdentifier] = ["pending", "latest"]
         for block_identifier in block_identifiers:
@@ -333,34 +463,117 @@ class SafeSignatureApprovedHash(SafeSignature):
                     == 1
                 )
             except (Web3Exception, DecodingError, Web3ValueError, Web3RPCError) as e:
-                # Error using `pending` block identifier
                 exception = e
-        raise exception  # This should never happen
+        if exception:
+            raise exception
+        raise SafeSignatureException("Could not validate approved hash signature")
 
 
-class SafeSignatureEthSign(SafeSignature):
-    @property
-    def owner(self):
-        # defunct_hash_message prepends `\x19Ethereum Signed Message:\n32`
-        message_hash = defunct_hash_message(primitive=self.safe_hash)
-        return get_signing_address(message_hash, self.v - 4, self.r, self.s)
-
-    @property
-    def signature_type(self):
-        return SafeSignatureType.ETH_SIGN
-
-    def is_valid(self, *args) -> bool:
+class SafeSignatureEthSign(SafeSignatureEthSignMixin, SafeSignature):
+    def is_valid(
+        self,
+        ethereum_client: Optional[EthereumClient] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
         return True
 
 
-class SafeSignatureEOA(SafeSignature):
-    @property
-    def owner(self):
-        return get_signing_address(self.safe_hash, self.v, self.r, self.s)
-
-    @property
-    def signature_type(self):
-        return SafeSignatureType.EOA
-
-    def is_valid(self, *args) -> bool:
+class SafeSignatureEOA(SafeSignatureEOAMixin, SafeSignature):
+    def is_valid(
+        self,
+        ethereum_client: Optional[EthereumClient] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
         return True
+
+
+class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync):
+    async def is_valid(
+        self,
+        web3: Optional[AsyncWeb3] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
+        if web3 is None:
+            raise ValueError("web3 is required to validate contract signature")
+        compatibility_fallback_handler = get_compatibility_fallback_handler_contract(
+            cast(Any, web3), self.owner
+        )
+        is_valid_signature_fn = (
+            compatibility_fallback_handler.get_function_by_signature(
+                "isValidSignature(bytes,bytes)"
+            )
+        )
+        try:
+            result = await is_valid_signature_fn(
+                bytes(self.safe_hash_preimage), bytes(self.contract_signature)
+            ).call()
+            return result in (
+                self.EIP1271_MAGIC_VALUE,
+                self.EIP1271_MAGIC_VALUE_UPDATED,
+            )
+        except (Web3Exception, DecodingError, Web3ValueError, Web3RPCError):
+            logger.warning(
+                "Cannot check EIP1271 signature from contract %s", self.owner
+            )
+        return False
+
+
+class SafeSignatureApprovedHashAsync(
+    SafeSignatureApprovedHashMixin, SafeSignatureAsync
+):
+    async def is_valid(
+        self,
+        web3: Optional[AsyncWeb3] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
+        if web3 is None:
+            raise ValueError("web3 is required to validate approved hash")
+        if safe_address is None:
+            raise ValueError("safe_address is required to validate approved hash")
+
+        safe_contract = get_safe_contract(
+            cast(Any, web3), ChecksumAddress(HexAddress(HexStr(safe_address)))
+        )
+        exception: Optional[Exception] = None
+
+        block_identifiers: List[BlockIdentifier] = ["pending", "latest"]
+        for block_identifier in block_identifiers:
+            try:
+                approved_hashes = await safe_contract.functions.approvedHashes(
+                    self.owner, self.safe_hash
+                ).call(block_identifier=block_identifier)
+                return approved_hashes == 1
+            except (Web3Exception, DecodingError, Web3ValueError, Web3RPCError) as e:
+                exception = e
+        if exception:
+            raise exception
+        raise SafeSignatureException("Could not validate approved hash signature")
+
+
+class SafeSignatureEthSignAsync(SafeSignatureEthSignMixin, SafeSignatureAsync):
+    async def is_valid(
+        self,
+        web3: Optional[AsyncWeb3] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
+        return True
+
+
+class SafeSignatureEOAAsync(SafeSignatureEOAMixin, SafeSignatureAsync):
+    async def is_valid(
+        self,
+        web3: Optional[AsyncWeb3] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
+        return True
+
+
+SafeSignature.contract_signature_cls = SafeSignatureContract
+SafeSignature.approved_hash_cls = SafeSignatureApprovedHash
+SafeSignature.eoa_cls = SafeSignatureEOA
+SafeSignature.eth_sign_cls = SafeSignatureEthSign
+
+SafeSignatureAsync.contract_signature_cls = SafeSignatureContractAsync
+SafeSignatureAsync.approved_hash_cls = SafeSignatureApprovedHashAsync
+SafeSignatureAsync.eoa_cls = SafeSignatureEOAAsync
+SafeSignatureAsync.eth_sign_cls = SafeSignatureEthSignAsync

--- a/safe_eth/safe/tests/test_safe_signature.py
+++ b/safe_eth/safe/tests/test_safe_signature.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 
 from django.test import TestCase
@@ -8,7 +9,7 @@ from eth_abi.packed import encode_packed
 from eth_account import Account
 from eth_account.messages import defunct_hash_message
 from hexbytes import HexBytes
-from web3 import Web3
+from web3 import AsyncHTTPProvider, AsyncWeb3, Web3
 
 from safe_eth.eth.utils import fast_keccak, fast_keccak_text
 
@@ -16,9 +17,14 @@ from ...eth.tests.ethereum_test_case import EthereumTestCaseMixin
 from ..safe_signature import (
     SafeSignature,
     SafeSignatureApprovedHash,
+    SafeSignatureApprovedHashAsync,
+    SafeSignatureAsync,
     SafeSignatureContract,
+    SafeSignatureContractAsync,
     SafeSignatureEOA,
+    SafeSignatureEOAAsync,
     SafeSignatureEthSign,
+    SafeSignatureEthSignAsync,
     SafeSignatureType,
 )
 from ..signatures import signature_to_bytes
@@ -27,16 +33,111 @@ from .safe_test_case import SafeTestCaseMixin
 logger = logging.getLogger(__name__)
 
 
+def _contract_signature_sample():
+    owner = "0x05c85Ab5B09Eb8A55020d72daf6091E04e264af9"
+    safe_tx_hash = HexBytes(
+        "0x4c9577d1b1b8dec52329a983ae26238b65f74b7dd9fb28d74ad9548e92aaf196"
+    )
+    signature = HexBytes(
+        "0x00000000000000000000000005c85ab5b09eb8a55020d72daf6091e04e264af900000000000000000000000"
+        "0000000000000000000000000000000000000000000"
+    )
+    return owner, safe_tx_hash, signature
+
+
+def _approved_hash_signature_sample():
+    owner = "0x05c85Ab5B09Eb8A55020d72daf6091E04e264af9"
+    safe_tx_hash = HexBytes(
+        "0x4c9577d1b1b8dec52329a983ae26238b65f74b7dd9fb28d74ad9548e92aaf196"
+    )
+    signature = HexBytes(
+        "0x00000000000000000000000005c85ab5b09eb8a55020d72daf6091e04e264af900000000000000000000000"
+        "0000000000000000000000000000000000000000001"
+    )
+    return owner, safe_tx_hash, signature
+
+
+def build_eip1271_signature_for_message(test_case: "SafeTestCaseMixin"):
+    account = Account.create()
+    safe_owner = test_case.deploy_test_safe(owners=[account.address])
+    safe = test_case.deploy_test_safe(owners=[safe_owner.address])
+
+    message = "Testing EIP191 message signing"
+    message_hash = defunct_hash_message(text=message)
+    safe_owner_message_hash = safe_owner.get_message_hash(message_hash)
+    safe_owner_signature = account.unsafe_sign_hash(safe_owner_message_hash)[
+        "signature"
+    ]
+    safe_parent_message_hash = safe.get_message_hash(message_hash)
+
+    signature_1271 = (
+        signature_to_bytes(
+            0, int.from_bytes(HexBytes(safe_owner.address), byteorder="big"), 65
+        )
+        + eth_abi.encode(["bytes"], [safe_owner_signature])[32:]
+    )
+    return signature_1271, safe_parent_message_hash, message_hash
+
+
+def setup_safe_contract_signature_case(test_case: "SafeTestCaseMixin"):
+    owner = test_case.ethereum_test_account
+    safe = test_case.deploy_test_safe_v1_1_1(
+        owners=[owner.address], initial_funding_wei=Web3.to_wei(0.01, "ether")
+    )
+    safe_contract = safe.contract
+    safe_tx_hash = fast_keccak_text("test")
+    signature_r = HexBytes(safe.address.replace("0x", "").rjust(64, "0"))
+    signature_s = HexBytes(
+        "41".rjust(64, "0")
+    )  # Position of end of signature 0x41 == 65
+    signature_v = HexBytes("00")
+    contract_signature = HexBytes(
+        "0" * 64
+    )  # First 32 bytes signature size, in this case 0
+    signature = signature_r + signature_s + signature_v + contract_signature
+
+    return {
+        "owner": owner,
+        "safe": safe,
+        "safe_contract": safe_contract,
+        "safe_tx_hash": safe_tx_hash,
+        "signature": signature,
+        "signature_r": signature_r,
+        "signature_s": signature_s,
+        "signature_v": signature_v,
+    }
+
+
+class AsyncSignatureTestMixin:
+    async_w3: AsyncWeb3
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.async_w3 = AsyncWeb3(AsyncHTTPProvider(cls.ethereum_node_url))
+
+    @classmethod
+    def tearDownClass(cls):
+        async def close_async_resources():
+            if cls.async_w3:
+                await cls.async_w3.provider.disconnect()
+
+        asyncio.run(close_async_resources())
+        super().tearDownClass()
+
+    def _run_async(self, coroutine):
+        return asyncio.run(coroutine)
+
+    def _is_valid_async(self, signature, *args):
+        async def runner():
+            return await signature.is_valid(self.async_w3, *args)
+
+        return self._run_async(runner())
+
+
 class TestSafeSignature(EthereumTestCaseMixin, TestCase):
     def test_contract_signature(self):
-        owner = "0x05c85Ab5B09Eb8A55020d72daf6091E04e264af9"
-        safe_tx_hash = HexBytes(
-            "0x4c9577d1b1b8dec52329a983ae26238b65f74b7dd9fb28d74ad9548e92aaf196"
-        )
-        signature = HexBytes(
-            "0x00000000000000000000000005c85ab5b09eb8a55020d72daf6091e04e264af900000000000000000000000"
-            "0000000000000000000000000000000000000000000"
-        )
+        owner, safe_tx_hash, signature = _contract_signature_sample()
         safe_signature = SafeSignatureContract(signature, safe_tx_hash, b"", b"")
         self.assertEqual(safe_signature.owner, owner)
         self.assertEqual(
@@ -46,14 +147,7 @@ class TestSafeSignature(EthereumTestCaseMixin, TestCase):
         self.assertFalse(safe_signature.is_valid(self.ethereum_client))
 
     def test_approved_hash_signature(self):
-        owner = "0x05c85Ab5B09Eb8A55020d72daf6091E04e264af9"
-        safe_tx_hash = HexBytes(
-            "0x4c9577d1b1b8dec52329a983ae26238b65f74b7dd9fb28d74ad9548e92aaf196"
-        )
-        signature = HexBytes(
-            "0x00000000000000000000000005c85ab5b09eb8a55020d72daf6091e04e264af900000000000000000000000"
-            "0000000000000000000000000000000000000000001"
-        )
+        owner, safe_tx_hash, signature = _approved_hash_signature_sample()
         safe_signature = SafeSignatureApprovedHash(signature, safe_tx_hash)
         self.assertEqual(safe_signature.owner, owner)
         self.assertEqual(safe_signature.signature_type, SafeSignatureType.APPROVED_HASH)
@@ -182,27 +276,11 @@ class TestSafeSignature(EthereumTestCaseMixin, TestCase):
 
 class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
     def test_contract_signature_for_message(self):
-        account = Account.create()
-        safe_owner = self.deploy_test_safe(owners=[account.address])
-        safe = self.deploy_test_safe(owners=[safe_owner.address])
-
-        safe_address = safe.address
-        message = "Testing EIP191 message signing"
-        message_hash = defunct_hash_message(text=message)
-        safe_owner_message_hash = safe_owner.get_message_hash(message_hash)
-        safe_owner_signature = account.unsafe_sign_hash(safe_owner_message_hash)[
-            "signature"
-        ]
-        safe_parent_message_hash = safe.get_message_hash(message_hash)
-
-        # Build EIP1271 signature v=0 r=safe v=dynamic_part dynamic_part=size+owner_signature
-        signature_1271 = (
-            signature_to_bytes(
-                0, int.from_bytes(HexBytes(safe_owner.address), byteorder="big"), 65
-            )
-            + eth_abi.encode(["bytes"], [safe_owner_signature])[32:]
-        )
-
+        (
+            signature_1271,
+            safe_parent_message_hash,
+            message_hash,
+        ) = build_eip1271_signature_for_message(self)
         safe_signatures = SafeSignature.parse_signature(
             signature_1271, safe_parent_message_hash, message_hash
         )
@@ -287,20 +365,15 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
         safe_tx.execute(self.ethereum_test_account.key)
 
     def test_contract_signature(self):
-        owner_1 = self.ethereum_test_account
-        safe = self.deploy_test_safe_v1_1_1(
-            owners=[owner_1.address], initial_funding_wei=Web3.to_wei(0.01, "ether")
-        )
-        safe_contract = safe.contract
-        safe_tx_hash = fast_keccak_text("test")
-        signature_r = HexBytes(safe.address.replace("0x", "").rjust(64, "0"))
-        signature_s = HexBytes(
-            "41".rjust(64, "0")
-        )  # Position of end of signature `0x41 == 65`
-        signature_v = HexBytes("00")
-        # First 32 bytes signature size, in this case 0
-        contract_signature = HexBytes("0" * 64)
-        signature = signature_r + signature_s + signature_v + contract_signature
+        fixture = setup_safe_contract_signature_case(self)
+        owner_1 = fixture["owner"]
+        safe = fixture["safe"]
+        safe_contract = fixture["safe_contract"]
+        safe_tx_hash = fixture["safe_tx_hash"]
+        signature = fixture["signature"]
+        signature_r = fixture["signature_r"]
+        signature_s = fixture["signature_s"]
+        signature_v = fixture["signature_v"]
 
         safe_signature = SafeSignature.parse_signature(signature, safe_tx_hash)[0]
         self.assertIsInstance(safe_signature, SafeSignatureContract)
@@ -420,5 +493,258 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
                 exported_signature.contract_signature, safe_signature.contract_signature
             )
             self.assertTrue(exported_signature.is_valid(self.ethereum_client, None))
+            count += 1
+        self.assertEqual(count, 2)
+
+
+class TestSafeSignatureAsync(AsyncSignatureTestMixin, EthereumTestCaseMixin, TestCase):
+    def test_contract_signature(self):
+        owner, safe_tx_hash, signature = _contract_signature_sample()
+        safe_signature = SafeSignatureContractAsync(signature, safe_tx_hash, b"", b"")
+        self.assertEqual(safe_signature.owner, owner)
+        self.assertEqual(
+            safe_signature.signature_type, SafeSignatureType.CONTRACT_SIGNATURE
+        )
+        self.assertTrue(str(safe_signature))
+        self.assertFalse(self._is_valid_async(safe_signature))
+
+    def test_approved_hash_signature(self):
+        owner, safe_tx_hash, signature = _approved_hash_signature_sample()
+        safe_signature = SafeSignatureApprovedHashAsync(signature, safe_tx_hash)
+        self.assertEqual(safe_signature.owner, owner)
+        self.assertEqual(safe_signature.signature_type, SafeSignatureType.APPROVED_HASH)
+        self.assertTrue(str(safe_signature))
+
+    def test_approved_hash_signature_build(self):
+        owner = Account.create().address
+        safe_tx_hash = fast_keccak_text("random")
+        safe_signature = SafeSignatureApprovedHashAsync.build_for_owner(
+            owner, safe_tx_hash
+        )
+        self.assertEqual(len(safe_signature.signature), 65)
+        self.assertEqual(safe_signature.signature_type, SafeSignatureType.APPROVED_HASH)
+        self.assertEqual(safe_signature.owner, owner)
+
+        safe_signature = SafeSignatureAsync.parse_signature(
+            safe_signature.signature, safe_tx_hash
+        )[0]
+        self.assertEqual(safe_signature.signature_type, SafeSignatureType.APPROVED_HASH)
+        self.assertEqual(safe_signature.owner, owner)
+
+    def test_eth_sign_signature(self):
+        account = Account.create()
+        owner = account.address
+        safe_tx_hash = HexBytes(
+            "0x123477d1b1b8dec52329a983ae26238b65f74b7dd9fb28d74ad9548e92aaf195"
+        )
+        message = defunct_hash_message(primitive=safe_tx_hash)
+        signature = account.unsafe_sign_hash(message)["signature"]
+        signature = signature[:64] + HexBytes(signature[64] + 4)
+        safe_signature = SafeSignatureEthSignAsync(signature, safe_tx_hash)
+        self.assertEqual(safe_signature.owner, owner)
+        self.assertEqual(safe_signature.signature_type, SafeSignatureType.ETH_SIGN)
+        self.assertTrue(self._is_valid_async(safe_signature))
+        self.assertTrue(str(safe_signature))
+
+    def test_eoa_signature(self):
+        owner = "0xADb7CB706e9A1bd9F96a397da340bF34a9984E1E"
+        safe_tx_hash = HexBytes(
+            "0x4c9577d1b1b8dec52329a983ae26238b65f74b7dd9fb28d74ad9548e92aaf196"
+        )
+        signature = HexBytes(
+            "0x5dccf9f1375cee56331a67867a0b05a828894c2b76dee84546ec663997d7548257cb2d606087ee7590b966e"
+            "958d97a65528ae941a0f7e5050949f618629509c81b"
+        )
+        safe_signature = SafeSignatureEOAAsync(signature, safe_tx_hash)
+        self.assertEqual(safe_signature.owner, owner)
+        self.assertEqual(safe_signature.signature_type, SafeSignatureType.EOA)
+        self.assertTrue(self._is_valid_async(safe_signature))
+
+        account = Account.create()
+        owner = account.address
+        safe_tx_hash = HexBytes(
+            "0x123477d1b1b8dec52329a983ae26238b65f74b7dd9fb28d74ad9548e92aaf195"
+        )
+        signature = account.unsafe_sign_hash(safe_tx_hash)["signature"]
+        safe_signature = SafeSignatureEOAAsync(signature, safe_tx_hash)
+        self.assertEqual(safe_signature.owner, owner)
+        self.assertEqual(safe_signature.signature_type, SafeSignatureType.EOA)
+        self.assertTrue(self._is_valid_async(safe_signature))
+        self.assertTrue(str(safe_signature))
+
+    def test_parse_signature(self):
+        owner_1 = "0x05c85Ab5B09Eb8A55020d72daf6091E04e264af9"
+        owner_2 = "0xADb7CB706e9A1bd9F96a397da340bF34a9984E1E"
+        safe_tx_hash = HexBytes(
+            "0x4c9577d1b1b8dec52329a983ae26238b65f74b7dd9fb28d74ad9548e92aaf196"
+        )
+        signatures = HexBytes(
+            "0x00000000000000000000000005c85ab5b09eb8a55020d72daf6091e04e264af90000000000000000000000"
+            "000000000000000000000000000000000000000000015dccf9f1375cee56331a67867a0b05a828894c2b76de"
+            "e84546ec663997d7548257cb2d606087ee7590b966e958d97a65528ae941a0f7e5050949f618629509c81b"
+        )
+
+        s1, s2 = SafeSignatureAsync.parse_signature(signatures, safe_tx_hash)
+        self.assertEqual(s1.owner, owner_1)
+        self.assertEqual(s1.signature_type, SafeSignatureType.APPROVED_HASH)
+        self.assertIsInstance(s1, SafeSignatureApprovedHashAsync)
+        self.assertEqual(s2.signature_type, SafeSignatureType.EOA)
+        self.assertEqual(s2.owner, owner_2)
+        self.assertTrue(self._is_valid_async(s2))
+        self.assertIsInstance(s2, SafeSignatureEOAAsync)
+
+    def test_parse_signature_with_trailing_zeroes(self):
+        signatures = HexBytes(
+            "0x9173a0b0895c28cdc82729f0a66e3645820a2e395cadad588463ab483e42b3df6e8b05d258e58c5255136"
+            "0e032733b507f731001cce6b5391b7750439c8cffc020000000000000000000000000dc5299b629ef24fdec"
+            "fbb240c00fc79fabb9cf9700000000000000000000000000000000000000000000000000000000000000000"
+            "1000000000000000000000000000000000000000000000000000000000000"
+        )
+        parsed_signatures = SafeSignatureAsync.parse_signature(signatures, "")
+        self.assertEqual(len(parsed_signatures), 2)
+        self.assertEqual(
+            parsed_signatures[0].signature_type, SafeSignatureType.ETH_SIGN
+        )
+        self.assertEqual(
+            parsed_signatures[1].signature_type, SafeSignatureType.APPROVED_HASH
+        )
+
+    def test_parse_signature_empty(self):
+        safe_tx_hash = fast_keccak_text("Legoshi")
+        for value in (b"", "", None):
+            self.assertEqual(
+                SafeSignatureAsync.parse_signature(value, safe_tx_hash), []
+            )
+
+
+class TestSafeContractSignatureAsync(AsyncSignatureTestMixin, SafeTestCaseMixin):
+    def test_contract_signature_for_message(self):
+        (
+            signature_1271,
+            safe_parent_message_hash,
+            message_hash,
+        ) = build_eip1271_signature_for_message(self)
+        safe_signatures = SafeSignatureAsync.parse_signature(
+            signature_1271, safe_parent_message_hash, message_hash
+        )
+        self.assertEqual(len(safe_signatures), 1)
+        self.assertTrue(self._is_valid_async(safe_signatures[0]))
+
+    def test_contract_signature(self):
+        fixture = setup_safe_contract_signature_case(self)
+        owner = fixture["owner"]
+        safe = fixture["safe"]
+        safe_contract = fixture["safe_contract"]
+        safe_tx_hash = fixture["safe_tx_hash"]
+        signature = fixture["signature"]
+        signature_r = fixture["signature_r"]
+        signature_s = fixture["signature_s"]
+        signature_v = fixture["signature_v"]
+
+        safe_signature = SafeSignatureAsync.parse_signature(signature, safe_tx_hash)[0]
+        self.assertIsInstance(safe_signature, SafeSignatureContractAsync)
+        self.assertFalse(self._is_valid_async(safe_signature, None))
+
+        tx = safe_contract.functions.signMessage(safe_tx_hash).build_transaction(
+            {"from": safe.address}
+        )
+        safe_tx = safe.build_multisig_tx(safe.address, 0, tx["data"])
+        safe_tx.sign(owner.key)
+        safe_tx.execute(owner.key)
+
+        safe_signature = SafeSignatureAsync.parse_signature(signature, safe_tx_hash)[0]
+        self.assertTrue(self._is_valid_async(safe_signature, None))
+        self.assertIsInstance(safe_signature, SafeSignatureContractAsync)
+
+        safe_tx_hash_2 = fast_keccak_text("test2")
+        safe_signature = SafeSignatureAsync.parse_signature(signature, safe_tx_hash_2)[
+            0
+        ]
+        self.assertFalse(self._is_valid_async(safe_signature, None))
+
+        safe_tx_hash_2_message_hash = safe_contract.functions.getMessageHash(
+            safe_tx_hash_2
+        ).call()
+        contract_signature = owner.unsafe_sign_hash(safe_tx_hash_2_message_hash)[
+            "signature"
+        ]
+
+        encoded_contract_signature_with_offset = encode_abi(
+            ["bytes"], [contract_signature]
+        )
+        encoded_contract_signature = encoded_contract_signature_with_offset[32:]
+        crafted_signature = (
+            signature_r + signature_s + signature_v + encoded_contract_signature
+        )
+        safe_signature = SafeSignatureAsync.parse_signature(
+            crafted_signature, safe_tx_hash_2
+        )[0]
+        self.assertEqual(contract_signature, safe_signature.contract_signature)
+        self.assertTrue(self._is_valid_async(safe_signature, None))
+
+    def test_contract_multiple_signatures(self):
+        owner = self.ethereum_test_account
+        safe = self.deploy_test_safe_v1_1_1(
+            owners=[owner.address], initial_funding_wei=Web3.to_wei(0.01, "ether")
+        )
+        safe_contract = safe.contract
+        safe_tx_hash = fast_keccak_text("test")
+
+        tx = safe_contract.functions.signMessage(safe_tx_hash).build_transaction(
+            {"from": safe.address}
+        )
+        safe_tx = safe.build_multisig_tx(safe.address, 0, tx["data"])
+        safe_tx.sign(owner.key)
+        safe_tx.execute(owner.key)
+
+        signature_r_1 = HexBytes(safe.address.replace("0x", "").rjust(64, "0"))
+        signature_s_1 = HexBytes("82".rjust(64, "0"))
+        signature_v_1 = HexBytes("00")
+        contract_signature_1 = b""
+        encoded_contract_signature_1 = encode_abi(["bytes"], [contract_signature_1])[
+            32:
+        ]
+
+        signature_r_2 = HexBytes(safe.address.replace("0x", "").rjust(64, "0"))
+        signature_s_2 = HexBytes("a2".rjust(64, "0"))
+        signature_v_2 = HexBytes("00")
+        safe_tx_hash_message_hash = safe_contract.functions.getMessageHash(
+            safe_tx_hash
+        ).call()
+        contract_signature_2 = owner.unsafe_sign_hash(safe_tx_hash_message_hash)[
+            "signature"
+        ]
+        encoded_contract_signature_2 = encode_abi(["bytes"], [contract_signature_2])[
+            32:
+        ]
+
+        signature = (
+            signature_r_1
+            + signature_s_1
+            + signature_v_1
+            + signature_r_2
+            + signature_s_2
+            + signature_v_2
+            + encoded_contract_signature_1
+            + encoded_contract_signature_2
+        )
+
+        count = 0
+        for safe_signature, contract_signature in zip(
+            SafeSignatureAsync.parse_signature(signature, safe_tx_hash),
+            [contract_signature_1, contract_signature_2],
+        ):
+            self.assertEqual(safe_signature.contract_signature, contract_signature)
+            self.assertTrue(self._is_valid_async(safe_signature, None))
+            self.assertEqual(
+                safe_signature.signature_type, SafeSignatureType.CONTRACT_SIGNATURE
+            )
+            exported_signature = SafeSignatureAsync.parse_signature(
+                safe_signature.export_signature(), safe_tx_hash
+            )[0]
+            self.assertEqual(
+                exported_signature.contract_signature, safe_signature.contract_signature
+            )
+            self.assertTrue(self._is_valid_async(exported_signature, None))
             count += 1
         self.assertEqual(count, 2)


### PR DESCRIPTION
- Class uses `AsyncWeb3` and it's intented for async usage
- Old `SafeSignature` class is not modified for compatibility

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce async `SafeSignature` variants with `AsyncWeb3`, refactor core signature logic into a shared base/mixins, and add matching async tests; CI adds pytest rerun delay.
> 
> - **Safe signature API**:
>   - Introduce `SafeSignatureAsync` with async implementations: `SafeSignatureContractAsync`, `SafeSignatureApprovedHashAsync`, `SafeSignatureEOAAsync`, `SafeSignatureEthSignAsync` (using `AsyncWeb3`).
>   - Refactor into `SafeSignatureBase` plus mixins (`*Mixin`) and type-parameterized parsing/export via class vars (`contract_signature_cls`, etc.).
>   - Improve typing and utilities (e.g., `SupportsContractSignature`, `uint_to_address`, stricter validations, clearer errors).
> - **Parsing/Export**:
>   - `parse_signature`/`export_signatures` generalized to work for both sync and async subclasses; contract signatures handled via protocol and dynamic offsets.
> - **Tests**:
>   - Add async test suite mirroring sync tests with helpers (`AsyncSignatureTestMixin`, fixtures) and coverage for parse/validate/export cases.
> - **CI**:
>   - pytest step adds `--reruns-delay 10` to reruns.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0074a47d446a2ff7698e1d466edf8742cbbe64ab. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->