### PR TITLE
Add Lens Multisend Call ONLY Contract Address

### DIFF
--- a/safe_eth/eth/multicall.py
+++ b/safe_eth/eth/multicall.py
@@ -336,6 +336,7 @@ class Multicall(ContractBase):
         EthereumNetwork.INK_SEPOLIA: "0xcA11bde05977b3631167028862bE2a173976CA11",
         EthereumNetwork.PLUME_MAINNET: "0xcA11bde05977b3631167028862bE2a173976CA11",
         EthereumNetwork.STATUS_NETWORK_SEPOLIA: "0xcA11bde05977b3631167028862bE2a173976CA11",
+        EthereumNetwork.LENS: "0xf220D3b4DFb23C4ade8C88E526C1353AbAcbC38F",
     }
 
     def __init__(


### PR DESCRIPTION
I noticed that this wasn't included yet when someone was making a special case for it in cow/solver-rewards:

cf https://github.com/cowprotocol/solver-rewards/pull/605

Reference:

Lens Block Explorer - https://explorer.lens.xyz/addresses/0xf220D3b4DFb23C4ade8C88E526C1353AbAcbC38F/source

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `EthereumNetwork.LENS` mapping to Multicall contract addresses.
> 
> - **Networks**:
>   - Add `EthereumNetwork.LENS` → `0xf220D3b4DFb23C4ade8C88E526C1353AbAcbC38F` in `safe_eth/eth/multicall.py` `ADDRESSES` map.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c5bf60afcc1c787f694618d601aa43df62406cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->