### PR TITLE
Add method to get the base url for etherscan_client

### DIFF
--- a/safe_eth/eth/clients/etherscan_client_v2.py
+++ b/safe_eth/eth/clients/etherscan_client_v2.py
@@ -127,6 +127,16 @@ class EtherscanClientV2:
             item.get("chainid") == str(network.value) for item in supported_networks
         )
 
+    def get_base_url(self) -> Optional[str]:
+        """
+        :param network: The Ethereum network to check.
+        :return: Base url for the current network
+        """
+        for network in self.get_supported_networks():
+            if network.get("chainid") == str(self.network.value):
+                return network.get("blockexplorer")
+        return None
+
     @staticmethod
     def _process_contract_metadata(
         contract_data: Dict[str, Any]

--- a/safe_eth/eth/tests/clients/test_blockscout_client.py
+++ b/safe_eth/eth/tests/clients/test_blockscout_client.py
@@ -9,7 +9,7 @@ from .mocks import safe_proxy_abi_mock, sourcify_safe_metadata
 
 
 class TestBlockscoutClient(unittest.TestCase):
-    @pytest.mark.flaky(reruns=5)
+    @pytest.mark.flaky(reruns=5, delay=2)
     def test_blockscout_client(self):
         with self.assertRaises(BlockScoutConfigurationProblem):
             BlockscoutClient(EthereumNetwork.MAINNET)

--- a/safe_eth/eth/tests/clients/test_etherscan_client_v2.py
+++ b/safe_eth/eth/tests/clients/test_etherscan_client_v2.py
@@ -21,7 +21,7 @@ class TestEtherscanClientV2(TestCase):
 
         return EtherscanClientV2(network, api_key=etherscan_api_key)
 
-    @pytest.mark.flaky(reruns=5)
+    @pytest.mark.flaky(reruns=5, delay=2)
     def test_etherscan_get_abi(self):
         try:
             etherscan_api = self.get_etherscan_api(EthereumNetwork.MAINNET)
@@ -45,7 +45,7 @@ class TestEtherscanClientV2(TestCase):
         except EtherscanRateLimitError:
             self.skipTest("Etherscan rate limit reached")
 
-    @pytest.mark.flaky(reruns=5)
+    @pytest.mark.flaky(reruns=5, delay=2)
     def test_etherscan_get_contract_metadata(self):
         try:
             etherscan_api = self.get_etherscan_api(EthereumNetwork.MAINNET)
@@ -61,7 +61,7 @@ class TestEtherscanClientV2(TestCase):
         except EtherscanRateLimitError:
             self.skipTest("Etherscan rate limit reached")
 
-    @pytest.mark.flaky(reruns=5)
+    @pytest.mark.flaky(reruns=5, delay=2)
     def test_is_supported_network(self):
         try:
             self.assertTrue(
@@ -69,6 +69,16 @@ class TestEtherscanClientV2(TestCase):
             )
             self.assertFalse(
                 EtherscanClientV2.is_supported_network(EthereumNetwork.UNKNOWN)
+            )
+        except EtherscanRateLimitError:
+            self.skipTest("Etherscan rate limit reached")
+
+    @pytest.mark.flaky(reruns=5, delay=2)
+    def test_get_base_url(self):
+        try:
+            self.assertEqual(
+                EtherscanClientV2(EthereumNetwork.POLYGON).get_base_url(),
+                "https://polygonscan.com/",
             )
         except EtherscanRateLimitError:
             self.skipTest("Etherscan rate limit reached")
@@ -84,7 +94,7 @@ class TestAsyncEtherscanClientV2(unittest.IsolatedAsyncioTestCase):
 
         return AsyncEtherscanClientV2(network, api_key=etherscan_api_key)
 
-    @pytest.mark.flaky(reruns=5)
+    @pytest.mark.flaky(reruns=5, delay=2)
     async def test_async_etherscan_get_abi(self):
         try:
             etherscan_api = self.get_etherscan_api(EthereumNetwork.MAINNET)


### PR DESCRIPTION
For example, for polygon the base url is polygonscan.com, so this method allows to generate links for clients

A delay for flaky test rerun was also added
