### PR TITLE
Update Ethereum addresses for MONAD_TESTNET in addresses.py

### DIFF
--- a/safe_eth/safe/addresses.py
+++ b/safe_eth/safe/addresses.py
@@ -3173,22 +3173,22 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ),  # v1.4.1+L2
     ],
     EthereumNetwork.MONAD_TESTNET: [
-        ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 44512678, "1.3.0"),  # v1.3.0
+        ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 210088, "1.3.0"),  # v1.3.0
         (
             "0xfb1bffC9d739B8D520DaF37dF666da4C687191EA",
-            44512665,
+            210095,
             "1.3.0+L2",
         ),  # v1.3.0+L2
-        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 1161044, "1.3.0"),  # v1.3.0
+        ("0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552", 203584, "1.3.0"),  # v1.3.0
         (
             "0x3E5c63644E683549055b9Be8653de26E0B4CD36E",
-            166595,
+            203591,
             "1.3.0+L2",
         ),  # v1.3.0+L2
-        ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 3834631, "1.4.1"),  # v1.4.1
+        ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 210143, "1.4.1"),  # v1.4.1
         (
             "0x29fcB43b46531BcA003ddC8FCB67FFE91900C762",
-            3834625,
+            210150,
             "1.4.1+L2",
         ),  # v1.4.1+L2
     ],
@@ -4702,9 +4702,9 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 3229132),  # v1.4.1
     ],
     EthereumNetwork.MONAD_TESTNET: [
-        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 44512587),  # v1.3.0
-        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 166610),  # v1.3.0
-        ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 3834528),  # v1.4.1
+        ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 210082),  # v1.3.0
+        ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 203577),  # v1.3.0
+        ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 210138),  # v1.4.1
     ],
     EthereumNetwork.MANTRACHAIN_MAINNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 8933860),  # v1.3.0


### PR DESCRIPTION
- Adjusted master copy and proxy addresses for version 1.3.0 and 1.4.1.
- Updated corresponding block numbers to reflect recent changes.

This ensures the addresses are current and accurate for the specified Ethereum network.