### PR TITLE
swap max_fee_per_gas and max_priority_fee_per_gas order in UserOperationV07 constructor for consistency

### DIFF
--- a/safe_eth/eth/account_abstraction/user_operation.py
+++ b/safe_eth/eth/account_abstraction/user_operation.py
@@ -91,8 +91,8 @@ class UserOperation:
                 int(user_operation["callGasLimit"], 16),
                 int(user_operation["verificationGasLimit"], 16),
                 int(user_operation["preVerificationGas"], 16),
-                int(user_operation["maxPriorityFeePerGas"], 16),
                 int(user_operation["maxFeePerGas"], 16),
+                int(user_operation["maxPriorityFeePerGas"], 16),
                 HexBytes(user_operation["signature"]),
                 ChecksumAddress(user_operation_response["entryPoint"]),
                 ChecksumAddress(user_operation["factory"])
@@ -176,8 +176,8 @@ class UserOperationV07:
     call_gas_limit: int
     verification_gas_limit: int
     pre_verification_gas: int
-    max_priority_fee_per_gas: int
     max_fee_per_gas: int
+    max_priority_fee_per_gas: int
     signature: bytes
     entry_point: ChecksumAddress
     factory: Optional[ChecksumAddress] = None


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Aligns `UserOperationV07` gas fee field ordering with EntryPoint v0.7 expectations.
> 
> - Reorders `UserOperationV07` fields to `max_fee_per_gas` then `max_priority_fee_per_gas`
> - Updates `from_bundler_response` construction to pass `maxFeePerGas` before `maxPriorityFeePerGas`
> - Maintains consistency with `gas_fees` packing and v0.7 `PackedUserOperation` layout
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d574ce492117469e68f7f8c1c759281048263462. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->