### PR TITLE
chore: improve existing BlockscoutClient detection

### DIFF
--- a/.github/scripts/github_adding_addresses/create_pr_with_new_address.py
+++ b/.github/scripts/github_adding_addresses/create_pr_with_new_address.py
@@ -146,6 +146,9 @@ def upsert_explorer_client_url(
     file = repo.get_contents(file_path, ref=branch_name)
     content = file.decoded_content.decode("utf-8")
 
+    # Normalize URL: always add trailing slash so "api/v2" and "api/v2/" are treated identically
+    client_url = client_url.rstrip("/") + "/"
+
     match = re.search(
         config_enum_name + r" = \{\n(.+?)(\n\s*}.*)", content, re.MULTILINE | re.DOTALL
     )
@@ -157,13 +160,13 @@ def upsert_explorer_client_url(
             (
                 line
                 for line in url_lines
-                if re.search(f'EthereumNetwork.{chain_enum_name}: "{client_url}"', line)
+                if re.search(f'EthereumNetwork.{chain_enum_name}:', line)
             ),
             None,
         )
 
         if existing_entry:
-            print(f"Entry with URL '{client_url}' already exists.")
+            print(f"Entry for EthereumNetwork.{chain_enum_name} already exists.")
         else:
             new_entry = f'        EthereumNetwork.{chain_enum_name}: "{client_url}",'
             url_lines.append(new_entry)

--- a/.github/scripts/github_adding_addresses/create_pr_with_new_address.py
+++ b/.github/scripts/github_adding_addresses/create_pr_with_new_address.py
@@ -146,7 +146,7 @@ def upsert_explorer_client_url(
     file = repo.get_contents(file_path, ref=branch_name)
     content = file.decoded_content.decode("utf-8")
 
-    # Normalize URL: always add trailing slash so "api/v2" and "api/v2/" are treated identically
+    # Normalize URL: always add trailing slash so "api/v2" and "api/v2/" are equivalent
     client_url = client_url.rstrip("/") + "/"
 
     match = re.search(
@@ -160,7 +160,7 @@ def upsert_explorer_client_url(
             (
                 line
                 for line in url_lines
-                if re.search(f'EthereumNetwork.{chain_enum_name}:', line)
+                if re.search(f"EthereumNetwork.{chain_enum_name}:", line)
             ),
             None,
         )


### PR DESCRIPTION
## Summary

Currently the script adds a new line if the explorer is added with or without trailing slash. We detect if a client is already added and in that case we skip it.

## Other considerations

I was considering updating Client URL if it was detected for an existing network and different links.