### PR TITLE
Fix integration tests broken by stale on-chain liquidity

### DIFF
--- a/safe_eth/eth/tests/test_oracles.py
+++ b/safe_eth/eth/tests/test_oracles.py
@@ -12,6 +12,7 @@ from ..oracles import (
     AaveOracle,
     BalancerOracle,
     CannotGetPriceFromOracle,
+    CowswapOracle,
     CreamOracle,
     CurveOracle,
     EnzymeOracle,
@@ -109,9 +110,8 @@ class TestUniswapV2Oracle(EthereumTestCaseMixin, TestCase):
         self.assertEqual(oracles_get_decimals.cache_info().currsize, 0)
 
         price = uniswap_v2_oracle.get_price(
-            gno_token_mainnet_address, weth_token_mainnet_address
+            wbtc_token_mainnet_address, weth_token_mainnet_address
         )
-        self.assertLess(price, 1)
         self.assertGreater(price, 0)
 
         self.assertEqual(oracles_get_decimals.cache_info().currsize, 2)
@@ -443,8 +443,8 @@ class TestMooniswapOracle(EthereumTestCaseMixin, TestCase):
         ethereum_client = EthereumClient(mainnet_node)
 
         self.assertTrue(MooniswapOracle.is_available(ethereum_client))
-        uniswap_oracle = UniswapV2Oracle(ethereum_client)
-        mooniswap_oracle = MooniswapOracle(ethereum_client, uniswap_oracle)
+        cowswap_oracle = CowswapOracle(ethereum_client)
+        mooniswap_oracle = MooniswapOracle(ethereum_client, cowswap_oracle)
         mooniswap_pool_address = "0x6a11F3E5a01D129e566d783A7b6E8862bFD66CcA"  # 1inch Liquidity Pool (ETH-WBTC)
         other_version_mooniswap_pool_address = (
             "0x8a2f2F8637deb4Ee7C9400A240d27E3A32147dA4"  # Mooniswap V1 (OWL-GNO)


### PR DESCRIPTION
- Closes https://linear.app/safe-global/issue/PLA-1428/fix-integration-tests-broken-by-insufficient-on-chain-liquidity

  The test was pricing GNO/WETH via UniswapV2Oracle. The UniswapV2 pair for GNO/WETH ([0x3e8468f66d30Fc99F745481d4B383f89861702C6](https://etherscan.io/address/0x3e8468f66d30Fc99F745481d4B383f89861702C6#readContract)) still exists but its reserves are nearly empty:
                                                                                                                                                                                                                                                                                                                          
  _reserve0 (GNO,  18 decimals): 14179908944582388397 → ~14.18 GNO
  _reserve1 (WETH, 18 decimals):   813414680818461755 → ~0.81 WETH                                                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                                                                                          
  The oracle requires at least 2 units of each token:                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                          
  if reserves_1 / 10**decimals_1 < 2 or reserves_2 / 10**decimals_2 < 2:                                                                                                                                                                                                                                                  
      raise CannotGetPriceFromOracle("Not enough liquidity...")                                                                                                                                                                                                                                                           
   
  0.81 WETH < 2 → raises CannotGetPriceFromOracle. GNO liquidity migrated from UniswapV2 to CoW Protocol and UniswapV3 over time.                                                                                                                                                                                         
                  
  Fix: replaced GNO/WETH with WBTC/WETH, which maintains deep liquidity on UniswapV2.                                                                                                                                                                                                                                     
                  
  ---                                                                                                                                                                                                                                                                                                                     
  TestMooniswapOracle.test_get_pool_token_price
                                               
  The test was pricing the Mooniswap V1 OWL-GNO pool (0x8a2f2F8637deb4Ee7C9400A240d27E3A32147dA4) using UniswapV2Oracle as the internal price oracle for its token components. getTokens() returns [OWL, GNO] correctly, but both tokens fail to price via UniswapV2:
                                                                                                                                                                                                                                                                                                                          
  OWL/WETH: Not enough liquidity for pair token_1=0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4
  GNO/WETH: Not enough liquidity for pair token_1=0x6810e776880C02933D47DB1b9fc05908e5386b96                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                          
  UniswapV3 also fails for both:                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                                                          
  OWL: Uniswap V3 pool does not exist for 0x1A5F9352Af8aF974bFC03399e3767DF6370d82e4                                                                                                                                                                                                                                      
  GNO: Not enough liquidity on uniswap v3 for pair token_1=0x6810e776880C02933D47DB1b9fc05908e5386b96                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                          
  CowswapOracle succeeds for both, as it aggregates liquidity across multiple DEXs via the CoW Protocol off-chain API:                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                          
  OWL: 3.5474281101614e-06 ETH                                                                                                                                                                                                                                                                                            
  GNO: 0.05623105718269129 ETH                                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                                                          
  Fix: replaced UniswapV2Oracle with CowswapOracle as the price oracle passed to MooniswapOracle.  