### PR TITLE
fix: Error "Argument list too long" when pushing linter commit

### DIFF
--- a/.github/scripts/github_adding_addresses/commit_linter_fixes.py
+++ b/.github/scripts/github_adding_addresses/commit_linter_fixes.py
@@ -1,0 +1,40 @@
+"""
+Commits linter fixes as a single verified commit via the GitHub API.
+"""
+
+import os
+import subprocess
+
+from github import Github, InputGitTreeElement
+
+
+def commit_linter_fixes() -> None:
+    repo = Github(os.environ["GITHUB_TOKEN"]).get_repo(os.environ["GITHUB_REPOSITORY"])
+    branch = os.environ["BRANCH_NAME"]
+    files = (
+        subprocess.check_output(["git", "diff", "--name-only"])
+        .decode()
+        .strip()
+        .split("\n")
+    )
+
+    if not files or not files[0]:
+        print("No linter changes to commit.")
+        return
+
+    parent = repo.get_branch(branch).commit
+    blobs = []
+    for f in files:
+        with open(f) as fh:
+            blobs.append(repo.create_git_blob(fh.read(), "utf-8"))
+    tree = repo.create_git_tree(
+        [InputGitTreeElement(f, "100644", "blob", b.sha) for f, b in zip(files, blobs)],
+        parent.commit.tree,
+    )
+    commit = repo.create_git_commit("Apply linter fixes", tree, [parent.commit])
+    repo.get_git_ref(f"heads/{branch}").edit(commit.sha)
+    print(f"Committed linter fixes: {commit.sha}")
+
+
+if __name__ == "__main__":
+    commit_linter_fixes()

--- a/.github/workflows/create_pr_with_new_address.yml
+++ b/.github/workflows/create_pr_with_new_address.yml
@@ -131,13 +131,11 @@ jobs:
       run: |
         uv run python .github/scripts/github_adding_addresses/create_pr_with_new_address.py
 
-    - uses: fregante/setup-git-user@024bc0b8e177d7e77203b48dab6fb45666854b35 # v2
-
     - name: Run pre-commit
       if: steps.check-comment.outputs.result == 'true'
+      id: run-pre-commit
       env:
         ISSUE_INPUTS: ${{ steps.get-issue-inputs.outputs.result }}
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -euo pipefail
 
@@ -150,6 +148,7 @@ jobs:
           exit 1
         }
         branch_name="add-new-chain-${chain_id}-${version}-addresses"
+        echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
         git pull origin main
         git fetch
         git checkout -b "$branch_name" "origin/$branch_name"
@@ -157,17 +156,18 @@ jobs:
         uv run pre-commit run --all-files || true
 
         if [[ $(git status --porcelain) ]]; then
-          file=$(git diff --name-only)
-          sha=$(gh api "repos/${GITHUB_REPOSITORY}/contents/${file}?ref=${branch_name}" --jq .sha)
-          gh api "repos/${GITHUB_REPOSITORY}/contents/${file}" \
-            --method PUT \
-            -f message="Apply linter fixes" \
-            -f content="$(base64 -w0 < "$file")" \
-            -f sha="$sha" \
-            -f branch="$branch_name"
+          echo "has_linter_changes=true" >> $GITHUB_OUTPUT
         else
-          echo "No changes to commit."
+          echo "has_linter_changes=false" >> $GITHUB_OUTPUT
         fi
+
+    - name: Commit linter fixes
+      if: steps.check-comment.outputs.result == 'true' && steps.run-pre-commit.outputs.has_linter_changes == 'true'
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH_NAME: ${{ steps.run-pre-commit.outputs.branch_name }}
+      run: |
+        uv run python .github/scripts/github_adding_addresses/commit_linter_fixes.py
 
     - name: Add comment to issue
       if: steps.check-comment.outputs.result == 'true'


### PR DESCRIPTION
The `Run pre-commit` step was failing with "Argument list too long" when committing linter fixes via `gh api -f content="$(base64 -w0 < file)"` — the base64-encoded file content exceeded the OS ARG_MAX shell limit.
  
Additionally, the previous `git commit` approach created unverified commits, rejected  by the branch protection rule "Require signed commits".

Replaced the shell approach with a dedicated Python script `commit_linter_fixes.py  that uses the GitHub API (blob → tree → commit → update ref) to produce a single verified commit — same pattern used by `create_pr_with_new_address.py`.