### PR TITLE
fix: correct oracle price math for non-18-decimal tokens

### DIFF
--- a/safe_eth/eth/oracles/kyber.py
+++ b/safe_eth/eth/oracles/kyber.py
@@ -13,6 +13,8 @@ from .utils import get_decimals
 
 logger = logging.getLogger(__name__)
 
+EXPECTED_RATE_PRECISION = 1e18
+
 
 class KyberOracle(PriceOracle):
     """
@@ -84,7 +86,7 @@ class KyberOracle(PriceOracle):
                 token_address_1, token_address_2, int(token_unit)
             ).call()
 
-            price = expected_rate / 1e18
+            price = expected_rate / EXPECTED_RATE_PRECISION
 
             if price <= 0.0:
                 # Try again the opposite
@@ -94,7 +96,9 @@ class KyberOracle(PriceOracle):
                 ) = self.kyber_network_proxy_contract.functions.getExpectedRate(
                     token_address_2, token_address_1, int(token_unit)
                 ).call()
-                price = (1e18 / expected_rate) if expected_rate else 0
+                price = (
+                    (EXPECTED_RATE_PRECISION / expected_rate) if expected_rate else 0
+                )
 
             if price <= 0.0:
                 message = (

--- a/safe_eth/eth/oracles/kyber.py
+++ b/safe_eth/eth/oracles/kyber.py
@@ -94,7 +94,7 @@ class KyberOracle(PriceOracle):
                 ) = self.kyber_network_proxy_contract.functions.getExpectedRate(
                     token_address_2, token_address_1, int(token_unit)
                 ).call()
-                price = (token_unit / expected_rate) if expected_rate else 0
+                price = (1e18 / expected_rate) if expected_rate else 0
 
             if price <= 0.0:
                 message = (

--- a/safe_eth/eth/oracles/oracles.py
+++ b/safe_eth/eth/oracles/oracles.py
@@ -471,7 +471,7 @@ class UniswapV2Oracle(PricePoolOracle, PriceOracle):
             ):
                 try:
                     price = self.get_price(str(token_address))
-                    total_value = (reserves / 10**decimals_1) * price
+                    total_value = (reserves / 10**decimals) * price
                     return (total_value * 2) / (total_supply / 1e18)
                 except CannotGetPriceFromOracle:
                     continue


### PR DESCRIPTION
## Summary

Two correctness fixes to oracle price math that produce silently-wrong prices for tokens that do not use 18 decimals.

## Changes

- **`eth/oracles/oracles.py` — `UniswapV2Oracle.get_pool_token_price`**: the loop over both pool tokens computed `total_value` using the outer `decimals_1` instead of the per-iteration loop variable `decimals`. When pricing token0 fails and the loop falls through to token1, `reserves_2` was divided by token0's decimals, making the LP-token price off by `10**(decimals_2 - decimals_1)` for mixed-decimal pools (e.g. WETH 18 / USDC 6). Now uses the loop variable `decimals`.

- **`eth/oracles/kyber.py` — `KyberOracle.get_price`**: the reverse-rate fallback inverted the 1e18-scaled Kyber rate with `token_unit` (`10**decimals` of token0) instead of `1e18`. For non-18-decimal tokens this made the fallback price off by `10**(18 - decimals)` (e.g. 10^12 too small for USDC). The forward path already divides by `1e18`; the fallback now does `1e18 / expected_rate`.

Closes PLA-1569