### PR TITLE
fix: safe-eth-py bugfixes batch 1 (caches, django, checksum addressing)

### DIFF
--- a/safe_eth/eth/contracts/__init__.py
+++ b/safe_eth/eth/contracts/__init__.py
@@ -64,7 +64,7 @@ contracts = {
     "multi_send_V1_4_1": "MultiSend_V1_4_1.json",
     "multi_send_V1_5_0": "MultiSend_V1_5_0.json",
     "multi_send_call_only_V1_4_1": "MultiSendCallOnly_V1_4_1.json",
-    "multi_send_call_only_V1_5_0": "MultiSendCallOnly_V1_4_1.json",
+    "multi_send_call_only_V1_5_0": "MultiSendCallOnly_V1_5_0.json",
     "paying_proxy": "PayingProxy.json",
     "proxy": "Proxy_V1_1_1.json",
     "proxy_factory_V1_0_0": "ProxyFactory_V1_0_0.json",

--- a/safe_eth/eth/django/models.py
+++ b/safe_eth/eth/django/models.py
@@ -108,11 +108,12 @@ class EthereumAddressFastBinaryField(EthereumAddressBinaryField):
                     if len(value) != 20:
                         raise ValueError(
                             "Cannot convert %s to a checksum address, 20 bytes were expected"
+                            % value.hex()
                         )
                 return ChecksumAddress(
                     HexAddress(HexStr(to_normalized_address(value)[2:]))
                 )
-            except ValueError:
+            except (TypeError, ValueError):
                 raise exceptions.ValidationError(
                     self.error_messages["invalid"],
                     code="invalid",

--- a/safe_eth/eth/django/validators.py
+++ b/safe_eth/eth/django/validators.py
@@ -10,7 +10,7 @@ def validate_address(address: str):
         address_bytes = HexBytes(address)
         if len(address_bytes) != 20:
             raise ValueError
-    except ValueError:
+    except (TypeError, ValueError):
         raise ValidationError(
             "%(address)s is not a valid EthereumAddress",
             params={"address": address},

--- a/safe_eth/eth/multicall.py
+++ b/safe_eth/eth/multicall.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, List, Optional, Sequence, Tuple
 import eth_abi
 from eth_abi.exceptions import DecodingError
 from eth_account.signers.local import LocalAccount
-from eth_typing import BlockIdentifier, BlockNumber, ChecksumAddress, HexAddress, HexStr
+from eth_typing import BlockIdentifier, BlockNumber, ChecksumAddress
 from hexbytes import HexBytes
 from web3 import Web3
 from web3._utils.abi import map_abi_data
@@ -22,7 +22,7 @@ from . import EthereumClient, EthereumNetwork, EthereumNetworkNotSupported
 from .contracts import ContractBase, get_multicall_v3_contract
 from .ethereum_client import EthereumTxSent
 from .exceptions import BatchCallFunctionFailed, ContractAlreadyDeployed
-from .utils import get_empty_tx_params
+from .utils import fast_to_checksum_address, get_empty_tx_params
 
 logger = logging.getLogger(__name__)
 
@@ -358,7 +358,7 @@ class Multicall(ContractBase):
         mainnet_address = self.ADDRESSES.get(EthereumNetwork.MAINNET)
         if not address and mainnet_address:
             # Try with Multicall V3 deterministic address
-            address = ChecksumAddress(HexAddress(HexStr(mainnet_address)))
+            address = fast_to_checksum_address(mainnet_address)
             if not ethereum_client.is_contract(address):
                 raise EthereumNetworkNotSupported(
                     "Multicall contract not available for %s", ethereum_network.name
@@ -367,7 +367,7 @@ class Multicall(ContractBase):
         if not address:
             raise ValueError("Contract address cannot be none")
 
-        super().__init__(ChecksumAddress(HexAddress(HexStr(address))), ethereum_client)
+        super().__init__(fast_to_checksum_address(address), ethereum_client)
 
     def get_contract_fn(self) -> Callable[[Web3, Optional[ChecksumAddress]], Contract]:
         return get_multicall_v3_contract

--- a/safe_eth/eth/utils.py
+++ b/safe_eth/eth/utils.py
@@ -24,7 +24,7 @@ def get_empty_tx_params() -> TxParams:
     }
 
 
-@lru_cache(maxsize=int(os.getenv("CACHE_KECCAK", 512)))
+@lru_cache(maxsize=int(os.getenv("CACHE_KECCAK", 1024)))
 def _keccak_256(value: bytes) -> keccak_256:
     return keccak_256(value)
 
@@ -89,7 +89,7 @@ def _build_checksum_address(
     )
 
 
-@lru_cache(maxsize=int(os.getenv("CACHE_CHECKSUM_ADDRESS", 1_000_000_000)))
+@lru_cache(maxsize=int(os.getenv("CACHE_CHECKSUM_ADDRESS", 500_000)))
 def _fast_to_checksum_address(address: HexAddress):
     address_hash = fast_keccak_hex(address.encode())
     return _build_checksum_address(address, address_hash)

--- a/safe_eth/safe/account_abstraction/safe_operation.py
+++ b/safe_eth/safe/account_abstraction/safe_operation.py
@@ -1,7 +1,7 @@
 import dataclasses
 import datetime
 import logging
-from functools import cache, cached_property
+from functools import cached_property
 from typing import Optional, Union
 from zoneinfo import ZoneInfo
 
@@ -153,7 +153,6 @@ class SafeOperation:
             )
         return _domain_separator_cache[key]
 
-    @cache
     def get_safe_operation_hash(
         self, chain_id: int, module_address: ChecksumAddress
     ) -> bytes:

--- a/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
+++ b/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
@@ -359,7 +359,9 @@ class TransactionServiceApi(SafeBaseAPI):
             "nonce": safe_tx.safe_nonce,
             "contractTransactionHash": to_0x_hex_str(safe_tx.safe_tx_hash),
             "sender": sender,
-            "signature": safe_tx.signatures.hex() if safe_tx.signatures else None,
+            "signature": (
+                to_0x_hex_str(safe_tx.signatures) if safe_tx.signatures else None
+            ),
             "origin": "Safe-CLI",
         }
         response = self._post_request(

--- a/safe_eth/safe/signatures.py
+++ b/safe_eth/safe/signatures.py
@@ -5,6 +5,7 @@ from eth_keys.exceptions import BadSignature
 from hexbytes import HexBytes
 
 from safe_eth.eth.constants import NULL_ADDRESS
+from safe_eth.eth.utils import fast_to_checksum_address
 
 
 def signature_split(
@@ -58,6 +59,6 @@ def get_signing_address(signed_hash: bytes, v: int, r: int, s: int) -> str:
     """
     try:
         public_key = keys.ecdsa_recover(signed_hash, keys.Signature(vrs=(v - 27, r, s)))
-        return public_key.to_checksum_address()
+        return fast_to_checksum_address(public_key.to_canonical_address())
     except BadSignature:
         return NULL_ADDRESS


### PR DESCRIPTION
## Summary

Independent, low-risk bugfixes and optimizations found during the `safe-eth-py` package review (batch 1).

## Changes

- **`eth/utils.py`** — bound the checksum-address LRU cache default (`1_000_000_000` → `500_000`, still env-configurable) to avoid unbounded growth / OOM in long-running indexers.
- **`safe/account_abstraction/safe_operation.py`** — drop `@cache` on the `get_safe_operation_hash` instance method (it pinned every `SafeOperation` via `self` in the cache key — a leak).
- **`eth/django/{models,validators}.py`** — catch `(TypeError, ValueError)` so `None`/wrong-type input raises a clean `ValidationError` instead of an uncaught `TypeError`; fix an uninterpolated `%s` in the error message.
- **`safe/signatures.py`** — `get_signing_address` uses `fast_to_checksum_address` instead of the slow eth-keys path.
- **`eth/multicall.py`** — validate/normalize addresses via `fast_to_checksum_address` instead of no-op `ChecksumAddress(HexAddress(HexStr(...)))` casts.
- **`eth/contracts/__init__.py`** — `multi_send_call_only_V1_5_0` now points at `MultiSendCallOnly_V1_5_0.json` (was the 1.4.1 file → wrong bytecode).
- **`safe/api/transaction_service_api.py`** — `post_transaction` is now using `0x` as expected

Related to PLA-1568