### PR TITLE
Support secp256r1 / passkey owner signatures (v == 2)

### DIFF
--- a/safe_eth/safe/p256.py
+++ b/safe_eth/safe/p256.py
@@ -1,0 +1,144 @@
+"""
+Pure-Python ``secp256r1`` (NIST P-256) ECDSA signature **verification**.
+
+This is used to validate Safe ``secp256r1`` owner signatures off-chain (the ``v == 2``
+case introduced in Safe ``1.5.0``). On-chain those signatures are verified through the
+``RIP-7212`` / ``EIP-7951`` ``P256VERIFY`` precompile; here we reproduce the same check
+without an RPC call.
+
+Only verification is implemented. No private-key operations are performed, so every input
+is public and the lack of constant-time guarantees is not a concern.
+
+The verification follows the standard ECDSA algorithm. The message hash is used directly as
+the integer ``z`` (matching the precompile, which is fed a pre-computed digest), so the caller
+is responsible for hashing the message beforehand.
+"""
+
+from typing import Optional, Tuple
+
+# Domain parameters for the NIST P-256 (a.k.a. secp256r1, prime256v1) curve.
+# See https://www.secg.org/sec2-v2.pdf section 2.4.2.
+_P = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF
+_A = 0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC
+_B = 0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B
+_N = 0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551
+_GX = 0x6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296
+_GY = 0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F5
+
+# Affine point. ``None`` represents the point at infinity (the group identity).
+Point = Optional[Tuple[int, int]]
+
+# Jacobian point ``(X, Y, Z)`` representing affine ``(X / Z**2, Y / Z**3)``. ``Z == 0`` is the
+# identity. Jacobian coordinates avoid a modular inversion on every group operation, which keeps
+# scalar multiplication cheap in pure Python.
+_JacobianPoint = Tuple[int, int, int]
+_IDENTITY: _JacobianPoint = (0, 0, 0)
+
+
+def _is_on_curve(x: int, y: int) -> bool:
+    """
+    :return: ``True`` if ``(x, y)`` is a valid affine point on the P-256 curve
+    """
+    if not (0 <= x < _P and 0 <= y < _P):
+        return False
+    return (y * y - (x * x * x + _A * x + _B)) % _P == 0
+
+
+def _jacobian_double(point: _JacobianPoint) -> _JacobianPoint:
+    x1, y1, z1 = point
+    if z1 == 0 or y1 == 0:
+        return _IDENTITY
+    # Generic doubling formulas (valid for any ``a``).
+    xx = (x1 * x1) % _P
+    yy = (y1 * y1) % _P
+    yyyy = (yy * yy) % _P
+    zz = (z1 * z1) % _P
+    s = (2 * (((x1 + yy) ** 2) - xx - yyyy)) % _P
+    m = (3 * xx + _A * zz * zz) % _P
+    x3 = (m * m - 2 * s) % _P
+    y3 = (m * (s - x3) - 8 * yyyy) % _P
+    z3 = (((y1 + z1) ** 2) - yy - zz) % _P
+    return (x3, y3, z3)
+
+
+def _jacobian_add(p: _JacobianPoint, q: _JacobianPoint) -> _JacobianPoint:
+    x1, y1, z1 = p
+    x2, y2, z2 = q
+    if z1 == 0:
+        return q
+    if z2 == 0:
+        return p
+    z1z1 = (z1 * z1) % _P
+    z2z2 = (z2 * z2) % _P
+    u1 = (x1 * z2z2) % _P
+    u2 = (x2 * z1z1) % _P
+    s1 = (y1 * z2 * z2z2) % _P
+    s2 = (y2 * z1 * z1z1) % _P
+    if u1 == u2:
+        if s1 != s2:
+            return _IDENTITY  # p == -q, result is the identity
+        return _jacobian_double(p)  # p == q
+    h = (u2 - u1) % _P
+    i = (4 * h * h) % _P
+    j = (h * i) % _P
+    r = (2 * (s2 - s1)) % _P
+    v = (u1 * i) % _P
+    x3 = (r * r - j - 2 * v) % _P
+    y3 = (r * (v - x3) - 2 * s1 * j) % _P
+    z3 = (((z1 + z2) ** 2 - z1z1 - z2z2) * h) % _P
+    return (x3, y3, z3)
+
+
+def _scalar_mult(k: int, point: _JacobianPoint) -> _JacobianPoint:
+    result = _IDENTITY
+    addend = point
+    while k:
+        if k & 1:
+            result = _jacobian_add(result, addend)
+        addend = _jacobian_double(addend)
+        k >>= 1
+    return result
+
+
+def _to_affine(point: _JacobianPoint) -> Point:
+    x, y, z = point
+    if z == 0:
+        return None
+    z_inv = pow(z, -1, _P)
+    z_inv2 = (z_inv * z_inv) % _P
+    return ((x * z_inv2) % _P, (y * z_inv2 * z_inv) % _P)
+
+
+def verify(
+    message_hash: int, r: int, s: int, public_key_x: int, public_key_y: int
+) -> bool:
+    """
+    Verify a ``secp256r1`` (P-256) ECDSA signature.
+
+    :param message_hash: Hash of the signed message as an integer. It must already be the
+        digest, exactly as fed to the ``P256VERIFY`` precompile (no extra hashing is done here)
+    :param r: ECDSA signature ``r`` value
+    :param s: ECDSA signature ``s`` value
+    :param public_key_x: ``x`` coordinate of the signer public key
+    :param public_key_y: ``y`` coordinate of the signer public key
+    :return: ``True`` if the signature is valid, ``False`` otherwise
+    """
+    if not (1 <= r < _N and 1 <= s < _N):
+        return False
+    if not _is_on_curve(public_key_x, public_key_y):
+        return False
+
+    w = pow(s, -1, _N)
+    u1 = (message_hash * w) % _N
+    u2 = (r * w) % _N
+    point = _jacobian_add(
+        _scalar_mult(u1, (_GX, _GY, 1)),
+        _scalar_mult(u2, (public_key_x, public_key_y, 1)),
+    )
+    affine = _to_affine(point)
+    if affine is None:
+        return False
+    # SEC1 v2 4.1.4 step 7: accept iff (x_R mod n) == r. ``r`` is already in [1, _N) by the
+    # guard above, so it needs no reduction. Matching ``mod _N`` (rather than a bare equality)
+    # is the standard check and is what the RIP-7212 / EIP-7951 P256VERIFY precompile does.
+    return affine[0] % _N == r

--- a/safe_eth/safe/safe_signature.py
+++ b/safe_eth/safe/safe_signature.py
@@ -204,7 +204,8 @@ class SafeSignatureBase(ABC):
         cls, safe_signatures: Sequence["SafeSignatureBase"]
     ) -> HexBytes:
         """
-        Takes a list of SafeSignature objects and exports them as a valid signature for the contract
+        Takes a list of SafeSignature objects and exports them as a valid EIP1271
+        signature for the contract
 
         :param safe_signatures:
         :return: Valid signature for the Safe contract
@@ -239,10 +240,10 @@ class SafeSignatureBase(ABC):
 
     def export_signature(self) -> HexBytes:
         """
-        Exports signature in a format that's valid individually. That's important for contract signatures, as it
-        will fix the offset
+        Exports this **single** signature in a format that's valid on its own. For contract signatures it fixes
+        the dynamic-data offset assuming the signature is isolated (``dynamic_offset = 65``).
 
-        :return:
+        :return: Standalone, single-signature blob
         """
         return self.signature
 
@@ -348,6 +349,13 @@ class SafeSignatureContractMixin(SafeSignatureBase):
         return SafeSignatureType.CONTRACT_SIGNATURE
 
     def export_signature(self) -> HexBytes:
+        """
+        Exports this **single** signature in a format that's valid on its own. Fix
+        the dynamic-data offset assuming the signature is isolated (``dynamic_offset = 65``).
+
+        :return: Standalone, single-signature blob
+        """
+
         # encode_abi adds {32 bytes offset}{32 bytes size}. We don't need offset
         contract_signature_padded = encode_abi(["bytes"], [self.contract_signature])[
             32:

--- a/safe_eth/safe/safe_signature.py
+++ b/safe_eth/safe/safe_signature.py
@@ -33,7 +33,12 @@ from safe_eth.eth.contracts import (
     get_compatibility_fallback_handler_V1_4_1_contract,
     get_safe_contract,
 )
-from safe_eth.eth.utils import fast_to_checksum_address
+from safe_eth.eth.utils import (
+    fast_bytes_to_checksum_address,
+    fast_keccak,
+    fast_to_checksum_address,
+)
+from safe_eth.safe import p256
 from safe_eth.safe.signatures import (
     get_signing_address,
     signature_split,
@@ -59,6 +64,7 @@ class SafeSignatureType(IntEnum):
     APPROVED_HASH = 1
     EOA = 2
     ETH_SIGN = 3
+    SECP256R1 = 4  # secp256r1 / passkey signature (Safe >= 1.5.0, RIP-7212/EIP-7951)
 
     @staticmethod
     def from_v(v: int) -> "SafeSignatureType":
@@ -66,6 +72,8 @@ class SafeSignatureType(IntEnum):
             return SafeSignatureType.CONTRACT_SIGNATURE
         elif v == 1:
             return SafeSignatureType.APPROVED_HASH
+        elif v == 2:
+            return SafeSignatureType.SECP256R1
         elif v > 30:
             return SafeSignatureType.ETH_SIGN
         else:
@@ -100,6 +108,7 @@ class SafeSignatureBase(ABC):
     approved_hash_cls: ClassVar[Optional[Type["SafeSignatureBase"]]] = None
     eoa_cls: ClassVar[Optional[Type["SafeSignatureBase"]]] = None
     eth_sign_cls: ClassVar[Optional[Type["SafeSignatureBase"]]] = None
+    p256_cls: ClassVar[Optional[Type["SafeSignatureBase"]]] = None
 
     def __init__(self, signature: EthereumBytes, safe_hash: EthereumBytes):
         """
@@ -174,6 +183,24 @@ class SafeSignatureBase(ABC):
                         contract_signature,
                     ),
                 )
+            elif signature_type == SafeSignatureType.SECP256R1:
+                # The data pointer `s` points to a fixed 128 bytes dynamic part:
+                # {32 bytes signature r}{32 bytes signature s}{32 bytes public key x}{32 bytes public key y}
+                # Unlike contract signatures, there's no length prefix as the size is fixed
+                if s < data_position:
+                    data_position = s
+                passkey_signature = signatures[
+                    s : s + SafeSignatureP256Mixin.PASSKEY_SIGNATURE_LENGTH
+                ]
+                safe_signature_cls = cls._get_p256_cls()
+                safe_signature = cast(
+                    TSafeSignature,
+                    cast(Type[Any], safe_signature_cls)(
+                        signature,
+                        safe_hash,
+                        passkey_signature,
+                    ),
+                )
             elif signature_type == SafeSignatureType.APPROVED_HASH:
                 safe_signature_cls = cls._get_approved_hash_cls()
                 safe_signature = cast(
@@ -215,6 +242,9 @@ class SafeSignatureBase(ABC):
         dynamic_part = b""
         dynamic_offset = len(safe_signatures) * 65
         contract_signature_cls = cls._get_contract_signature_cls()
+        # ``p256_cls`` is resolved lazily: only require it when a P256 signature is actually
+        # present, so subclasses that don't wire it up keep working for other signature types.
+        p256_cls = cls.p256_cls
 
         # Signatures must be sorted by owner
         for safe_signature in sorted(safe_signatures, key=lambda s: s.owner.lower()):
@@ -234,6 +264,16 @@ class SafeSignatureBase(ABC):
                 ]
                 dynamic_part += contract_signature
                 dynamic_offset += len(contract_signature)
+            elif p256_cls is not None and isinstance(safe_signature, p256_cls):
+                # The dynamic part is a fixed 128 bytes blob without a length prefix
+                passkey_signature = cast(
+                    "SafeSignatureP256Mixin", safe_signature
+                ).passkey_signature
+                signature += signature_to_bytes(
+                    safe_signature.v, safe_signature.r, dynamic_offset
+                )
+                dynamic_part += bytes(passkey_signature)
+                dynamic_offset += len(passkey_signature)
             else:
                 signature += safe_signature.export_signature()
         return HexBytes(signature + dynamic_part)
@@ -285,6 +325,10 @@ class SafeSignatureBase(ABC):
     @classmethod
     def _get_eth_sign_cls(cls) -> Type["SafeSignatureBase"]:
         return cls._ensure_class(cls.eth_sign_cls, "eth_sign_cls")
+
+    @classmethod
+    def _get_p256_cls(cls) -> Type["SafeSignatureBase"]:
+        return cls._ensure_class(cls.p256_cls, "p256_cls")
 
 
 class SafeSignature(SafeSignatureBase):
@@ -413,6 +457,117 @@ class SafeSignatureEOAMixin(SafeSignatureBase):
     @property
     def signature_type(self) -> SafeSignatureType:
         return SafeSignatureType.EOA
+
+
+class SafeSignatureP256Mixin(SafeSignatureBase):
+    """
+    ``secp256r1`` (NIST P-256) owner signature, a.k.a. *passkey* / WebAuthn signature,
+    supported by Safe ``>= 1.5.0`` via the RIP-7212 / EIP-7951 ``P256VERIFY`` precompile
+    (``v == 2``).
+
+    Like a contract signature, the static 65 bytes part encodes the owner address in ``r``
+    and a data pointer in ``s``. The pointer references a **fixed 128 bytes** dynamic part
+    (no length prefix), laid out as::
+
+        {32 bytes signature r}{32 bytes signature s}{32 bytes public key x}{32 bytes public key y}
+
+    The owner address is checked to be ``keccak256(public_key_x || public_key_y)[12:]`` and
+    the signature is verified off-chain against the ``safe_hash`` over the P-256 curve.
+    """
+
+    PASSKEY_SIGNATURE_LENGTH = 128
+
+    def __init__(
+        self,
+        signature: EthereumBytes,
+        safe_hash: EthereumBytes,
+        passkey_signature: EthereumBytes,
+    ):
+        """
+        :param signature: Static 65 bytes part ``r || s || v`` (``v == 2``)
+        :param safe_hash: Signed hash for the Safe (message or transaction)
+        :param passkey_signature: 128 bytes dynamic part
+            ``signature_r || signature_s || public_key_x || public_key_y``
+        """
+        super().__init__(signature, safe_hash)
+        self.passkey_signature: HexBytes = HexBytes(passkey_signature)
+
+    @classmethod
+    def from_values(
+        cls,
+        safe_owner: ChecksumAddress,
+        safe_hash: EthereumBytes,
+        passkey_signature: EthereumBytes,
+    ) -> Self:
+        signature = signature_to_bytes(
+            2, int.from_bytes(HexBytes(safe_owner), byteorder="big"), 65
+        )
+        return cls(signature, safe_hash, passkey_signature)
+
+    @property
+    def signature_r(self) -> int:
+        return int.from_bytes(self.passkey_signature[0:32], "big")
+
+    @property
+    def signature_s(self) -> int:
+        return int.from_bytes(self.passkey_signature[32:64], "big")
+
+    @property
+    def public_key_x(self) -> int:
+        return int.from_bytes(self.passkey_signature[64:96], "big")
+
+    @property
+    def public_key_y(self) -> int:
+        return int.from_bytes(self.passkey_signature[96:128], "big")
+
+    @property
+    def owner(self) -> ChecksumAddress:
+        # The owner address is encoded into `r`, just like for contract signatures
+        return uint_to_address(self.r)
+
+    @property
+    def signer_address(self) -> ChecksumAddress:
+        """
+        :return: Address derived from the public key, ``keccak256(public_key_x || public_key_y)[12:]``.
+            For a valid signature it must match :attr:`owner`
+        """
+        return fast_bytes_to_checksum_address(
+            fast_keccak(bytes(self.passkey_signature[64:128]))[-20:]
+        )
+
+    @property
+    def signature_type(self) -> SafeSignatureType:
+        return SafeSignatureType.SECP256R1
+
+    def export_signature(self) -> HexBytes:
+        """
+        Exports this **single** signature in a format that's valid on its own. Fix
+        the dynamic-data offset assuming the signature is isolated (``dynamic_offset = 65``).
+
+        :return: Standalone, single-signature blob
+        """
+        return HexBytes(
+            signature_to_bytes(self.v, self.r, 65) + bytes(self.passkey_signature)
+        )
+
+    def _is_valid(self) -> bool:
+        """
+        Off-chain validation, shared by the sync and async implementations. No RPC call is
+        needed as ``secp256r1`` signatures are self-contained.
+
+        :return: ``True`` if the public key matches the owner and the signature is valid
+        """
+        if len(self.passkey_signature) != self.PASSKEY_SIGNATURE_LENGTH:
+            return False
+        if self.signer_address != self.owner:
+            return False
+        return p256.verify(
+            int.from_bytes(self.safe_hash, "big"),
+            self.signature_r,
+            self.signature_s,
+            self.public_key_x,
+            self.public_key_y,
+        )
 
 
 class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
@@ -547,6 +702,15 @@ class SafeSignatureEOA(SafeSignatureEOAMixin, SafeSignature):
         return True
 
 
+class SafeSignatureP256(SafeSignatureP256Mixin, SafeSignature):
+    def is_valid(
+        self,
+        ethereum_client: Optional[EthereumClient] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
+        return self._is_valid()
+
+
 class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync):
     async def _check_eip1271(
         self,
@@ -679,12 +843,23 @@ class SafeSignatureEOAAsync(SafeSignatureEOAMixin, SafeSignatureAsync):
         return True
 
 
+class SafeSignatureP256Async(SafeSignatureP256Mixin, SafeSignatureAsync):
+    async def is_valid(
+        self,
+        web3: Optional[AsyncWeb3] = None,
+        safe_address: Optional[str] = None,
+    ) -> bool:
+        return self._is_valid()
+
+
 SafeSignature.contract_signature_cls = SafeSignatureContract
 SafeSignature.approved_hash_cls = SafeSignatureApprovedHash
 SafeSignature.eoa_cls = SafeSignatureEOA
 SafeSignature.eth_sign_cls = SafeSignatureEthSign
+SafeSignature.p256_cls = SafeSignatureP256
 
 SafeSignatureAsync.contract_signature_cls = SafeSignatureContractAsync
 SafeSignatureAsync.approved_hash_cls = SafeSignatureApprovedHashAsync
 SafeSignatureAsync.eoa_cls = SafeSignatureEOAAsync
 SafeSignatureAsync.eth_sign_cls = SafeSignatureEthSignAsync
+SafeSignatureAsync.p256_cls = SafeSignatureP256Async

--- a/safe_eth/safe/tests/test_p256.py
+++ b/safe_eth/safe/tests/test_p256.py
@@ -1,0 +1,76 @@
+import hashlib
+import unittest
+
+from .. import p256
+
+# Known-answer vectors from RFC 6979 Appendix A.2.5 (NIST P-256, SHA-256).
+# https://datatracker.ietf.org/doc/html/rfc6979#appendix-A.2.5
+PUBLIC_KEY_X = 0x60FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6
+PUBLIC_KEY_Y = 0x7903FE1008B8BC99A41AE9E95628BC64F2F1B20C2D7E9F5177A3C294D4462299
+
+# message "sample"
+SAMPLE_HASH = int.from_bytes(hashlib.sha256(b"sample").digest(), "big")
+SAMPLE_R = 0xEFD48B2AACB6A8FD1140DD9CD45E81D69D2C877B56AAF991C34D0EA84EAF3716
+SAMPLE_S = 0xF7CB1C942D657C41D436C7A1B6E29F65F3E900DBB9AFF4064DC4AB2F843ACDA8
+
+# message "test"
+TEST_HASH = int.from_bytes(hashlib.sha256(b"test").digest(), "big")
+TEST_R = 0xF1ABB023518351CD71D881567B1EA663ED3EFCF6C5132B354F28D3B0B7D38367
+TEST_S = 0x019F4113742A2B14BD25926B49C649155F267E60D3814B4C0CC84250E46F0083
+
+
+class TestP256(unittest.TestCase):
+    def test_verify_valid_signatures(self):
+        self.assertTrue(
+            p256.verify(SAMPLE_HASH, SAMPLE_R, SAMPLE_S, PUBLIC_KEY_X, PUBLIC_KEY_Y)
+        )
+        self.assertTrue(
+            p256.verify(TEST_HASH, TEST_R, TEST_S, PUBLIC_KEY_X, PUBLIC_KEY_Y)
+        )
+
+    def test_verify_wrong_message(self):
+        # `sample` signature against `test` digest must not verify
+        self.assertFalse(
+            p256.verify(TEST_HASH, SAMPLE_R, SAMPLE_S, PUBLIC_KEY_X, PUBLIC_KEY_Y)
+        )
+
+    def test_verify_tampered_signature(self):
+        self.assertFalse(
+            p256.verify(SAMPLE_HASH, SAMPLE_R + 1, SAMPLE_S, PUBLIC_KEY_X, PUBLIC_KEY_Y)
+        )
+        self.assertFalse(
+            p256.verify(SAMPLE_HASH, SAMPLE_R, SAMPLE_S + 1, PUBLIC_KEY_X, PUBLIC_KEY_Y)
+        )
+
+    def test_verify_wrong_public_key(self):
+        self.assertFalse(
+            p256.verify(SAMPLE_HASH, SAMPLE_R, SAMPLE_S, PUBLIC_KEY_X + 1, PUBLIC_KEY_Y)
+        )
+
+    def test_verify_signature_out_of_range(self):
+        # `r` and `s` must be in [1, n-1]
+        self.assertFalse(
+            p256.verify(SAMPLE_HASH, 0, SAMPLE_S, PUBLIC_KEY_X, PUBLIC_KEY_Y)
+        )
+        self.assertFalse(
+            p256.verify(SAMPLE_HASH, SAMPLE_R, 0, PUBLIC_KEY_X, PUBLIC_KEY_Y)
+        )
+        self.assertFalse(
+            p256.verify(SAMPLE_HASH, p256._N, SAMPLE_S, PUBLIC_KEY_X, PUBLIC_KEY_Y)
+        )
+        self.assertFalse(
+            p256.verify(SAMPLE_HASH, SAMPLE_R, p256._N, PUBLIC_KEY_X, PUBLIC_KEY_Y)
+        )
+
+    def test_verify_public_key_not_on_curve(self):
+        self.assertFalse(p256._is_on_curve(PUBLIC_KEY_X, PUBLIC_KEY_Y + 1))
+        self.assertFalse(
+            p256.verify(SAMPLE_HASH, SAMPLE_R, SAMPLE_S, PUBLIC_KEY_X, PUBLIC_KEY_Y + 1)
+        )
+
+    def test_generator_on_curve(self):
+        self.assertTrue(p256._is_on_curve(p256._GX, p256._GY))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/safe_eth/safe/tests/test_safe_signature.py
+++ b/safe_eth/safe/tests/test_safe_signature.py
@@ -1,4 +1,5 @@
 import asyncio
+import hashlib
 import logging
 
 from django.test import TestCase
@@ -11,7 +12,12 @@ from eth_account.messages import defunct_hash_message
 from hexbytes import HexBytes
 from web3 import AsyncHTTPProvider, AsyncWeb3, Web3
 
-from safe_eth.eth.utils import fast_keccak, fast_keccak_text, get_empty_tx_params
+from safe_eth.eth.utils import (
+    fast_bytes_to_checksum_address,
+    fast_keccak,
+    fast_keccak_text,
+    get_empty_tx_params,
+)
 
 from ...eth.contracts import (
     get_compatibility_fallback_handler_contract,
@@ -30,6 +36,8 @@ from ..safe_signature import (
     SafeSignatureEOAAsync,
     SafeSignatureEthSign,
     SafeSignatureEthSignAsync,
+    SafeSignatureP256,
+    SafeSignatureP256Async,
     SafeSignatureType,
 )
 from ..signatures import signature_to_bytes
@@ -312,6 +320,121 @@ class TestSafeSignature(EthereumTestCaseMixin, TestCase):
         safe_tx_hash = fast_keccak_text("Legoshi")
         for value in (b"", "", None):
             self.assertEqual(SafeSignature.parse_signature(value, safe_tx_hash), [])
+
+
+# secp256r1 / passkey vector built from RFC 6979 Appendix A.2.5 (NIST P-256, SHA-256),
+# message "sample". The Safe hash is the SHA-256 digest of "sample", which is fed directly
+# to the P256VERIFY precompile (no extra hashing).
+P256_PUBLIC_KEY_X = 0x60FED4BA255A9D31C961EB74C6356D68C049B8923B61FA6CE669622E60F29FB6
+P256_PUBLIC_KEY_Y = 0x7903FE1008B8BC99A41AE9E95628BC64F2F1B20C2D7E9F5177A3C294D4462299
+P256_SIGNATURE_R = 0xEFD48B2AACB6A8FD1140DD9CD45E81D69D2C877B56AAF991C34D0EA84EAF3716
+P256_SIGNATURE_S = 0xF7CB1C942D657C41D436C7A1B6E29F65F3E900DBB9AFF4064DC4AB2F843ACDA8
+P256_SAFE_HASH = HexBytes(hashlib.sha256(b"sample").digest())
+P256_PASSKEY_SIGNATURE = (
+    P256_SIGNATURE_R.to_bytes(32, "big")
+    + P256_SIGNATURE_S.to_bytes(32, "big")
+    + P256_PUBLIC_KEY_X.to_bytes(32, "big")
+    + P256_PUBLIC_KEY_Y.to_bytes(32, "big")
+)
+P256_OWNER = fast_bytes_to_checksum_address(
+    fast_keccak(
+        P256_PUBLIC_KEY_X.to_bytes(32, "big") + P256_PUBLIC_KEY_Y.to_bytes(32, "big")
+    )[-20:]
+)
+
+
+class TestSafeSignatureP256(TestCase):
+    def test_from_v(self):
+        self.assertEqual(SafeSignatureType.from_v(2), SafeSignatureType.SECP256R1)
+
+    def test_p256_signature(self):
+        safe_signature = SafeSignatureP256.from_values(
+            P256_OWNER, P256_SAFE_HASH, P256_PASSKEY_SIGNATURE
+        )
+        self.assertEqual(safe_signature.signature_type, SafeSignatureType.SECP256R1)
+        self.assertEqual(safe_signature.v, 2)
+        self.assertEqual(safe_signature.owner, P256_OWNER)
+        self.assertEqual(safe_signature.signer_address, P256_OWNER)
+        self.assertEqual(safe_signature.signature_r, P256_SIGNATURE_R)
+        self.assertEqual(safe_signature.signature_s, P256_SIGNATURE_S)
+        self.assertEqual(safe_signature.public_key_x, P256_PUBLIC_KEY_X)
+        self.assertEqual(safe_signature.public_key_y, P256_PUBLIC_KEY_Y)
+        self.assertTrue(safe_signature.is_valid())
+        self.assertTrue(str(safe_signature))  # Test __str__
+
+    def test_p256_signature_invalid_hash(self):
+        safe_signature = SafeSignatureP256.from_values(
+            P256_OWNER, fast_keccak_text("not-the-signed-hash"), P256_PASSKEY_SIGNATURE
+        )
+        self.assertFalse(safe_signature.is_valid())
+
+    def test_p256_signature_owner_mismatch(self):
+        # Owner that does not match `keccak256(public_key)[12:]`
+        wrong_owner = "0x" + "12" * 20
+        safe_signature = SafeSignatureP256.from_values(
+            wrong_owner, P256_SAFE_HASH, P256_PASSKEY_SIGNATURE
+        )
+        self.assertNotEqual(safe_signature.owner, safe_signature.signer_address)
+        self.assertFalse(safe_signature.is_valid())
+
+    def test_parse_signature(self):
+        safe_signature = SafeSignatureP256.from_values(
+            P256_OWNER, P256_SAFE_HASH, P256_PASSKEY_SIGNATURE
+        )
+        signatures = SafeSignature.export_signatures([safe_signature])
+        # 65 bytes static part + 128 bytes dynamic part
+        self.assertEqual(len(signatures), 65 + 128)
+
+        parsed_signatures = SafeSignature.parse_signature(signatures, P256_SAFE_HASH)
+        self.assertEqual(len(parsed_signatures), 1)
+        parsed = parsed_signatures[0]
+        self.assertIsInstance(parsed, SafeSignatureP256)
+        self.assertEqual(parsed.signature_type, SafeSignatureType.SECP256R1)
+        self.assertEqual(parsed.owner, P256_OWNER)
+        self.assertEqual(bytes(parsed.passkey_signature), P256_PASSKEY_SIGNATURE)
+        self.assertTrue(parsed.is_valid())
+
+    def test_export_signature_standalone(self):
+        safe_signature = SafeSignatureP256.from_values(
+            P256_OWNER, P256_SAFE_HASH, P256_PASSKEY_SIGNATURE
+        )
+        exported = safe_signature.export_signature()
+        parsed = SafeSignature.parse_signature(exported, P256_SAFE_HASH)[0]
+        self.assertEqual(parsed.owner, P256_OWNER)
+        self.assertTrue(parsed.is_valid())
+
+    def test_export_signatures_mixed(self):
+        # An EOA signer plus a passkey signer, both signing the same hash
+        account = Account.create()
+        eoa_signature = SafeSignatureEOA(
+            account.unsafe_sign_hash(P256_SAFE_HASH)["signature"], P256_SAFE_HASH
+        )
+        p256_signature = SafeSignatureP256.from_values(
+            P256_OWNER, P256_SAFE_HASH, P256_PASSKEY_SIGNATURE
+        )
+
+        signatures = SafeSignature.export_signatures([eoa_signature, p256_signature])
+        self.assertEqual(len(signatures), 2 * 65 + 128)
+
+        parsed_signatures = SafeSignature.parse_signature(signatures, P256_SAFE_HASH)
+        self.assertEqual(len(parsed_signatures), 2)
+        # Signers must be sorted ascending by owner
+        owners = [s.owner.lower() for s in parsed_signatures]
+        self.assertEqual(owners, sorted(owners))
+        self.assertTrue(all(s.is_valid() for s in parsed_signatures))
+
+    def test_p256_signature_async(self):
+        safe_signature = SafeSignatureP256Async.from_values(
+            P256_OWNER, P256_SAFE_HASH, P256_PASSKEY_SIGNATURE
+        )
+        self.assertEqual(safe_signature.signature_type, SafeSignatureType.SECP256R1)
+        self.assertTrue(asyncio.run(safe_signature.is_valid()))
+
+        parsed = SafeSignatureAsync.parse_signature(
+            SafeSignature.export_signatures([safe_signature]), P256_SAFE_HASH
+        )[0]
+        self.assertIsInstance(parsed, SafeSignatureP256Async)
+        self.assertTrue(asyncio.run(parsed.is_valid()))
 
 
 class TestSafeContractSignature(SafeTestCaseMixin, TestCase):


### PR DESCRIPTION
## What

Adds support for **secp256r1 / passkey owner signatures** (`v == 2`) introduced in Safe `1.5.0` via RIP-7212 / EIP-7951, plus the signature-docs improvements already on this branch.

This is finding #1 of the internal signature audit: previously `v == 2` fell through to the EOA branch, silently recovering `NULL_ADDRESS`, leaving `is_valid()` returning `True` unconditionally, and desyncing `parse_signature` whenever more signatures followed.

## Changes

- **`safe_eth/safe/p256.py`** — pure-Python NIST P-256 ECDSA *verification* (Jacobian point arithmetic), **no new dependencies**. Verification only: all inputs are public, so constant-time guarantees are not required.
- **`SafeSignatureType.SECP256R1`** + a `from_v(v == 2)` branch.
- **`SafeSignatureP256` / `SafeSignatureP256Async`** — parse the fixed 128-byte dynamic part (`sig_r || sig_s || qx || qy`, no length prefix), enforce `owner == keccak256(qx || qy)[12:]` and verify the signature off-chain against the Safe hash. This matches the on-chain `GS028` condition in `checkNSignatures`.
- **`parse_signature`** now consumes the 128 dynamic bytes for `v == 2` (fixing the iterator desync), and **`export_signatures`** writes correct cumulative offsets for passkey signers mixed with EOA / contract signers.

## Tests

- `tests/test_p256.py` — RFC 6979 known-answer vectors (valid, tampered, wrong message, out-of-range `r`/`s`, off-curve public key).
- `tests/test_safe_signature.py::TestSafeSignatureP256`

Closes PLA-1565