### PR TITLE
Allow building AsyncEthereumClient without blocking network calls

### DIFF
--- a/safe_eth/eth/async_ethereum_client.py
+++ b/safe_eth/eth/async_ethereum_client.py
@@ -49,7 +49,6 @@ from web3.exceptions import (
     TransactionNotFound,
     Web3Exception,
 )
-from web3.middleware import ExtraDataToPOAMiddleware
 from web3.types import (
     BlockData,
     BlockIdentifier,
@@ -500,6 +499,10 @@ class AsyncEthereumClient(EthereumClient):
     The ``aiohttp`` session used for JSON-RPC batches is created lazily, one per
     running event loop, so the same instance works across loops (and is safe to
     create outside a running loop, e.g. in ``__init__``).
+
+    Constructing the client performs no network I/O, so it can be built inside a
+    running event loop (e.g. in a FastAPI handler) without blocking it, even if
+    the RPC url is not reachable.
     """
 
     # Narrow the manager types overridden in __init__ for the type checker
@@ -517,7 +520,7 @@ class AsyncEthereumClient(EthereumClient):
         use_request_caching: bool = True,
         batch_request_max_size: int = 500,
     ):
-        # Builds the blocking w3/slow_w3 + detects the network (cached chainId)
+        # Builds the blocking w3/slow_w3
         super().__init__(
             ethereum_node_url,
             provider_timeout=provider_timeout,
@@ -545,18 +548,7 @@ class AsyncEthereumClient(EthereumClient):
         self.async_w3: AsyncWeb3 = AsyncWeb3(self.async_w3_provider)
         self.async_slow_w3: AsyncWeb3 = AsyncWeb3(self.async_w3_slow_provider)
 
-        for async_w3 in self.async_w3, self.async_slow_w3:
-            # Don't spend resources converting dictionaries to attribute dictionaries
-            async_w3.middleware_onion.remove("attrdict")
-
-        # POA middleware (reuse the network already detected by the sync __init__)
-        try:
-            inject_poa = self.get_network() != EthereumNetwork.MAINNET
-        except (IOError, OSError):
-            inject_poa = True
-        if inject_poa:
-            for async_w3 in self.async_w3, self.async_slow_w3:
-                async_w3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
+        self._adjust_middlewares(self.async_w3, self.async_slow_w3)
 
         # Replace the sync managers built by super().__init__ with async-capable ones
         self.erc20 = AsyncErc20Manager(self)
@@ -569,7 +561,12 @@ class AsyncEthereumClient(EthereumClient):
 
     @cached_property
     def multicall(self) -> Optional["AsyncMulticall"]:  # type: ignore # noqa F821
-        """Async ``Multicall`` for this network, or ``None`` if unsupported."""
+        """
+        Async ``Multicall`` for this network, or ``None`` if unsupported.
+
+        Detecting the Multicall address uses the blocking sync methods; inside a
+        running event loop use :meth:`async_get_multicall` instead.
+        """
         # Imported lazily to avoid a circular import (multicall imports the package),
         # mirroring EthereumClient.multicall.
         from .multicall import AsyncMulticall
@@ -579,6 +576,25 @@ class AsyncEthereumClient(EthereumClient):
         except EthereumNetworkNotSupported:
             logger.warning("Multicall not supported for this network")
             return None
+
+    async def async_get_multicall(self) -> Optional["AsyncMulticall"]:  # type: ignore # noqa F821
+        """
+        Async counterpart of :attr:`multicall`: detect the Multicall address with
+        the async RPC methods, so a running event loop is never blocked. Memoized
+        in the same slot used by the cached property, so both share one instance.
+        """
+        if "multicall" not in self.__dict__:
+            from .multicall import AsyncMulticall
+
+            try:
+                multicall: Optional["AsyncMulticall"] = (
+                    await AsyncMulticall.async_create(self)
+                )
+            except EthereumNetworkNotSupported:
+                logger.warning("Multicall not supported for this network")
+                multicall = None
+            self.multicall = multicall
+        return self.multicall
 
     # --- Session lifecycle ------------------------------------------------
 
@@ -885,10 +901,11 @@ class AsyncEthereumClient(EthereumClient):
         when available (unless ``force_batch_call=True``), matching the sync client,
         including raw revert bytes for failed calls on the Multicall path.
         """
-        if self.multicall and not force_batch_call:  # Multicall is more optimal
+        multicall = None if force_batch_call else await self.async_get_multicall()
+        if multicall:  # Multicall is more optimal
             return [
                 result.return_data_decoded
-                for result in await self.multicall.async_try_aggregate(
+                for result in await multicall.async_try_aggregate(
                     contract_functions,
                     require_success=raise_exception,
                     block_identifier=block_identifier,
@@ -915,10 +932,11 @@ class AsyncEthereumClient(EthereumClient):
         ``Multicall`` when available (unless ``force_batch_call=True``), matching the
         sync client.
         """
-        if self.multicall and not force_batch_call:  # Multicall is more optimal
+        multicall = None if force_batch_call else await self.async_get_multicall()
+        if multicall:  # Multicall is more optimal
             return [
                 result.return_data_decoded
-                for result in await self.multicall.async_try_aggregate_same_function(
+                for result in await multicall.async_try_aggregate_same_function(
                     contract_function,
                     contract_addresses,
                     require_success=raise_exception,

--- a/safe_eth/eth/ethereum_client.py
+++ b/safe_eth/eth/ethereum_client.py
@@ -23,7 +23,7 @@ from eth_account import Account
 from eth_account.signers.local import LocalAccount
 from eth_typing import URI, BlockNumber, ChecksumAddress, Hash32, HexAddress, HexStr
 from hexbytes import HexBytes
-from web3 import HTTPProvider, Web3
+from web3 import AsyncWeb3, HTTPProvider, Web3
 from web3._utils.abi import map_abi_data
 from web3._utils.method_formatters import (
     block_result_formatter,
@@ -1471,6 +1471,9 @@ class EthereumClient:
         :param retry_count: Retry count for failed requests
         :param use_request_caching: Use web3 request caching https://web3py.readthedocs.io/en/latest/internals.html#request-caching
         :param batch_request_max_size: Max size for JSON RPC Batch requests. Some providers have a limitation on 500
+
+        Constructing the client performs no network I/O, the RPC is first contacted
+        when a method requiring it is called.
         """
         # Per-instance cache for values that never change (chainId, client version...).
         # Using an instance dict instead of ``functools.cache`` avoids keeping every
@@ -1497,27 +1500,30 @@ class EthereumClient:
         self.w3: Web3 = Web3(self.w3_provider)
         self.slow_w3: Web3 = Web3(self.w3_slow_provider)
 
-        # Adjust Web3.py middleware
-        for w3 in self.w3, self.slow_w3:
-            # Don't spend resources con converting dictionaries to attribute dictionaries
-            w3.middleware_onion.remove("attrdict")
-
-        # The geth_poa_middleware is required to connect to geth --dev or the Goerli public network.
-        # It may also be needed for other EVM compatible blockchains like Polygon or BNB Chain (Binance Smart Chain).
-        try:
-            if self.get_network() != EthereumNetwork.MAINNET:
-                for w3 in self.w3, self.slow_w3:
-                    w3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
-        except (IOError, OSError):
-            # For tests using dummy connections (like IPC)
-            for w3 in self.w3, self.slow_w3:
-                w3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
+        self._adjust_middlewares(self.w3, self.slow_w3)
 
         self.erc20: Erc20Manager = Erc20Manager(self)
         self.erc721: Erc721Manager = Erc721Manager(self)
         self.tracing: TracingManager = TracingManager(self)
         self.batch_call_manager: BatchCallManager = BatchCallManager(self)
         self.batch_request_max_size = batch_request_max_size
+
+    @staticmethod
+    def _adjust_middlewares(*w3s: Union[Web3, AsyncWeb3]) -> None:
+        """
+        Adjust Web3.py middlewares:
+
+        - Remove ``attrdict``: don't spend resources converting dictionaries to
+          attribute dictionaries.
+        - Inject ``ExtraDataToPOAMiddleware``: required for PoA-based chains like
+          Polygon or BNB Chain. It's always injected to avoid a blocking
+          ``eth_chainId`` call during ``__init__`` just to detect the network.
+          On Mainnet its only effect is that block responses expose
+          ``proofOfAuthorityData`` instead of ``extraData``.
+        """
+        for w3 in w3s:
+            w3.middleware_onion.remove("attrdict")
+            w3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
 
     def __str__(self):
         return f"EthereumClient for url={self.ethereum_node_url}"

--- a/safe_eth/eth/multicall.py
+++ b/safe_eth/eth/multicall.py
@@ -354,21 +354,50 @@ class Multicall(ContractBase):
         ethereum_client: EthereumClient,
         multicall_contract_address: Optional[ChecksumAddress] = None,
     ):
-        ethereum_network = ethereum_client.get_network()
-        address = multicall_contract_address or self.ADDRESSES.get(ethereum_network)
-        mainnet_address = self.ADDRESSES.get(EthereumNetwork.MAINNET)
-        if not address and mainnet_address:
-            # Try with Multicall V3 deterministic address
-            address = fast_to_checksum_address(mainnet_address)
-            if not ethereum_client.is_contract(address):
-                raise EthereumNetworkNotSupported(
-                    "Multicall contract not available for %s", ethereum_network.name
-                )
+        # Only detect the address when not provided, as it requires network requests
+        # (`eth_chainId` if not cached, maybe `eth_getCode`)
+        address = (
+            fast_to_checksum_address(multicall_contract_address)
+            if multicall_contract_address
+            else self._detect_multicall_address(ethereum_client)
+        )
+        super().__init__(address, ethereum_client)
 
-        if not address:
+    @classmethod
+    def _multicall_address_candidate(
+        cls, ethereum_network: EthereumNetwork
+    ) -> Tuple[ChecksumAddress, bool]:
+        """
+        :return: Tuple of the candidate Multicall address for the network and whether
+            it must be checked for code: the network's known address doesn't need it,
+            the Multicall V3 deterministic address fallback (mainnet's) is only valid
+            if deployed on the network
+        """
+        address = cls.ADDRESSES.get(ethereum_network)
+        if address:
+            return fast_to_checksum_address(address), False
+
+        mainnet_address = cls.ADDRESSES.get(EthereumNetwork.MAINNET)
+        if not mainnet_address:
             raise ValueError("Contract address cannot be none")
+        return fast_to_checksum_address(mainnet_address), True
 
-        super().__init__(fast_to_checksum_address(address), ethereum_client)
+    @classmethod
+    def _detect_multicall_address(
+        cls, ethereum_client: EthereumClient
+    ) -> ChecksumAddress:
+        """
+        :return: Multicall address for the client's network, falling back to the
+            Multicall V3 deterministic address if it has code
+        :raises EthereumNetworkNotSupported: if no Multicall contract is available
+        """
+        ethereum_network = ethereum_client.get_network()
+        address, needs_code_check = cls._multicall_address_candidate(ethereum_network)
+        if needs_code_check and not ethereum_client.is_contract(address):
+            raise EthereumNetworkNotSupported(
+                "Multicall contract not available for %s", ethereum_network.name
+            )
+        return address
 
     def get_contract_fn(self) -> Callable[[Web3, Optional[ChecksumAddress]], Contract]:
         return get_multicall_v3_contract
@@ -639,6 +668,39 @@ class AsyncMulticall(Multicall):
     ):
         super().__init__(ethereum_client, multicall_contract_address)
         self.async_w3: AsyncWeb3 = ethereum_client.async_w3
+
+    @classmethod
+    async def async_create(
+        cls,
+        ethereum_client: "AsyncEthereumClient",  # type: ignore # noqa F821
+        multicall_contract_address: Optional[ChecksumAddress] = None,
+    ) -> "AsyncMulticall":
+        """
+        Build an ``AsyncMulticall`` detecting the address through the async RPC
+        methods, so a running event loop is never blocked (``__init__`` detects
+        it with the blocking sync methods).
+        """
+        address = (
+            multicall_contract_address
+            or await cls._async_detect_multicall_address(ethereum_client)
+        )
+        return cls(ethereum_client, address)
+
+    @classmethod
+    async def _async_detect_multicall_address(
+        cls,
+        ethereum_client: "AsyncEthereumClient",  # type: ignore # noqa F821
+    ) -> ChecksumAddress:
+        """
+        Async counterpart of :meth:`Multicall._detect_multicall_address`
+        """
+        ethereum_network = await ethereum_client.async_get_network()
+        address, needs_code_check = cls._multicall_address_candidate(ethereum_network)
+        if needs_code_check and not await ethereum_client.async_is_contract(address):
+            raise EthereumNetworkNotSupported(
+                "Multicall contract not available for %s", ethereum_network.name
+            )
+        return address
 
     @cached_property
     def async_contract(self):

--- a/safe_eth/eth/tests/test_async_ethereum_client.py
+++ b/safe_eth/eth/tests/test_async_ethereum_client.py
@@ -29,9 +29,12 @@ from ..ethereum_network import EthereumNetwork
 from .mocks.mock_internal_txs import creation_internal_txs, internal_txs_errored
 from .test_ethereum_client import (
     FAILED_BATCH_CALL_RESULT,
+    UNREACHABLE_NODE_URL,
     TestERC20Module,
     TestEthereumClient,
+    TestEthereumClientConstruction,
     TestTracingManager,
+    forbid_rpc_calls,
 )
 
 # Manager attributes that must themselves be wrapped in a proxy
@@ -251,3 +254,68 @@ class TestAsyncEthereumClient(AsyncEthereumClientTestMixin, TestEthereumClient):
             [make_function()], raise_exception=False
         )
         self.assertEqual(async_result, sync_result)
+
+
+class TestAsyncEthereumClientConstruction(TestEthereumClientConstruction):
+    """Reuse the sync construction tests, checking the async w3 instances too."""
+
+    ethereum_client_cls = AsyncEthereumClient
+
+    def get_w3_instances(self, ethereum_client):
+        return (
+            ethereum_client.w3,
+            ethereum_client.slow_w3,
+            ethereum_client.async_w3,
+            ethereum_client.async_slow_w3,
+        )
+
+    def test_init_inside_running_event_loop(self):
+        # Building the client in a coroutine (e.g. a FastAPI handler) must not
+        # perform blocking calls, even with an unreachable RPC
+        async def build():
+            return self.ethereum_client_cls(UNREACHABLE_NODE_URL)
+
+        with forbid_rpc_calls():
+            asyncio.run(build())
+
+    def test_async_get_multicall_performs_no_sync_requests(self):
+        # First use of Multicall detects its address, but must do it through the
+        # async RPC methods, never blocking the event loop
+        async def run():
+            async_ethereum_client = self.ethereum_client_cls(UNREACHABLE_NODE_URL)
+            with mock.patch.object(
+                AsyncEthereumClient,
+                "async_get_chain_id",
+                new_callable=mock.AsyncMock,
+                return_value=EthereumNetwork.GNOSIS.value,
+            ):
+                multicall = await async_ethereum_client.async_get_multicall()
+            self.assertIsNotNone(multicall)
+            # Memoized, and shared with the `multicall` cached property
+            self.assertIs(await async_ethereum_client.async_get_multicall(), multicall)
+            self.assertIs(async_ethereum_client.multicall, multicall)
+
+        with forbid_rpc_calls():
+            asyncio.run(run())
+
+    def test_async_get_multicall_network_not_supported(self):
+        async def run():
+            async_ethereum_client = self.ethereum_client_cls(UNREACHABLE_NODE_URL)
+            with (
+                mock.patch.object(
+                    AsyncEthereumClient,
+                    "async_get_chain_id",
+                    new_callable=mock.AsyncMock,
+                    return_value=4_815_162_342,  # EthereumNetwork.UNKNOWN
+                ),
+                mock.patch.object(
+                    AsyncEthereumClient,
+                    "async_is_contract",
+                    new_callable=mock.AsyncMock,
+                    return_value=False,
+                ),
+            ):
+                self.assertIsNone(await async_ethereum_client.async_get_multicall())
+
+        with forbid_rpc_calls():
+            asyncio.run(run())

--- a/safe_eth/eth/tests/test_ethereum_client.py
+++ b/safe_eth/eth/tests/test_ethereum_client.py
@@ -1,3 +1,4 @@
+from contextlib import contextmanager
 from typing import Any, Dict, List, Sequence
 from unittest import mock
 from unittest.mock import MagicMock
@@ -11,6 +12,8 @@ from eth_typing import URI, HexStr
 from hexbytes import HexBytes
 from web3.eth import Eth
 from web3.exceptions import Web3RPCError
+from web3.middleware import ExtraDataToPOAMiddleware
+from web3.providers import AsyncHTTPProvider, HTTPProvider
 from web3.types import TxParams
 
 from ...util.util import to_0x_hex_str
@@ -1251,6 +1254,37 @@ class TestEthereumClient(EthereumTestCaseMixin, TestCase):
             )
             self.assertEqual(eip_1559_tx["maxPriorityFeePerGas"], 5)
             self.assertEqual(eip_1559_tx["maxFeePerGas"], 7)
+
+
+UNREACHABLE_NODE_URL = URI("http://unreachable.invalid:8545")
+
+
+@contextmanager
+def forbid_rpc_calls():
+    """Fail the test if any JSON-RPC request is attempted, sync or async."""
+    side_effect = AssertionError("RPC should not be called")
+    with (
+        mock.patch.object(HTTPProvider, "make_request", side_effect=side_effect),
+        mock.patch.object(AsyncHTTPProvider, "make_request", side_effect=side_effect),
+    ):
+        yield
+
+
+class TestEthereumClientConstruction(TestCase):
+    """Construction must be free of network I/O, no node needed for these tests."""
+
+    ethereum_client_cls = EthereumClient
+
+    def get_w3_instances(self, ethereum_client):
+        return ethereum_client.w3, ethereum_client.slow_w3
+
+    def test_init_performs_no_network_requests(self):
+        with forbid_rpc_calls():
+            ethereum_client = self.ethereum_client_cls(UNREACHABLE_NODE_URL)
+
+        # POA middleware is always injected, for every network
+        for w3 in self.get_w3_instances(ethereum_client):
+            self.assertIn(ExtraDataToPOAMiddleware, w3.middleware_onion)
 
 
 class TestEthereumClientWithMainnetNode(EthereumTestCaseMixin, TestCase):


### PR DESCRIPTION
## Motivation

`AsyncEthereumClient.__init__` performed a synchronous `eth_chainId` call to decide whether to inject `ExtraDataToPOAMiddleware` (skipped on Mainnet). Building the client inside a running event loop (e.g. a FastAPI handler) blocked it, up to the provider timeout if the RPC was down. safe-queue-service builds clients lazily per request with RPC urls from the Config Service, so this blocked the loop in practice.

## Changes

- Always inject `ExtraDataToPOAMiddleware`, on every network, so no network detection is needed on `__init__`. Constructing `EthereumClient`/`AsyncEthereumClient` now performs zero network I/O. Middleware setup is shared in `EthereumClient._adjust_middlewares`.
- Add `AsyncMulticall.async_create` and `AsyncEthereumClient.async_get_multicall`: first use of Multicall on the async client (via `async_batch_call`/`async_batch_call_same_function`) detects the Multicall address with the async RPC methods instead of blocking the event loop with the sync ones. Sync `multicall` property and `async_get_multicall` share the same memoized instance.
- `Multicall.__init__` no longer calls `get_network()` when an explicit address is provided.
- Tests: construction with an unreachable RPC url performs no requests (sync and async providers are patched to fail on any call), works inside a running event loop, and `async_get_multicall` never uses the blocking sync methods.

## Behaviour change on Mainnet

`ExtraDataToPOAMiddleware` unconditionally renames `extraData` to `proofOfAuthorityData` in `eth_getBlockByHash`/`eth_getBlockByNumber`/`eth_subscribe` responses. Mainnet block dicts from `w3.eth.get_bl