### PR TITLE
Use Safe as eth_call sender for EIP-1271 contract signature validation

### DIFF
--- a/safe_eth/safe/safe_signature.py
+++ b/safe_eth/safe/safe_signature.py
@@ -578,6 +578,7 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
         function_signature: str,
         data: bytes,
         signature: bytes,
+        safe_address: Optional[str] = None,
     ) -> bool:
         """
         Attempt to validate an EIP-1271 signature using a specific CompatibilityFallbackHandler and function signature.
@@ -587,6 +588,11 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
         :param function_signature: The ABI function signature to call.
         :param data: The data or hash to be validated, depending on the Safe version.
         :param signature: The contract signature payload to validate.
+        :param safe_address: Optional Safe address used as the ``eth_call`` sender. On-chain the
+            Safe itself calls ``isValidSignature`` on its owner contracts (``checkSignatures``),
+            so calling with the Safe as ``msg.sender`` matches on-chain semantics and supports
+            owners that read their configuration through ``msg.sender``, like the
+            ``SafeWebAuthnSharedSigner``.
         :return: True on successful validation; otherwise False.
         """
         fallback_handler = fallback_handler_getter(ethereum_client.w3, self.owner)
@@ -595,7 +601,12 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
         )
 
         try:
-            result = is_valid_signature_fn(data, signature).call()
+            if safe_address:
+                result = is_valid_signature_fn(data, signature).call(
+                    {"from": ChecksumAddress(HexAddress(HexStr(safe_address)))}
+                )
+            else:
+                result = is_valid_signature_fn(data, signature).call()
         except (Web3Exception, DecodingError, Web3ValueError, Web3RPCError) as exc:
             logger.warning(
                 "Cannot check EIP1271 with %s on contract %s: %s",
@@ -621,7 +632,9 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
         Falls back to the legacy method (bytes,bytes).
 
         :param ethereum_client: EthereumClient instance
-        :param safe_address: Optional Safe EthereumAddress instance.
+        :param safe_address: Optional Safe address. When provided, the EIP-1271 check is
+            performed with the Safe as the ``eth_call`` sender, mirroring how the Safe calls
+            ``isValidSignature`` on-chain.
         """
         if ethereum_client is None:
             raise ValueError(
@@ -646,6 +659,7 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
                 function_signature,
                 data,
                 bytes(self.contract_signature),
+                safe_address=safe_address,
             ):
                 return True
 
@@ -721,6 +735,7 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
         function_signature: str,
         data: bytes,
         signature: bytes,
+        safe_address: Optional[str] = None,
     ) -> bool:
         """
         Attempt to validate an EIP-1271 signature using a specific CompatibilityFallbackHandler and function signature.
@@ -730,6 +745,11 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
         :param function_signature: The ABI function signature to call
         :param data: The data or hash to be validated, depending on the Safe version.
         :param signature: The contract signature payload to validate.
+        :param safe_address: Optional Safe address used as the ``eth_call`` sender. On-chain the
+            Safe itself calls ``isValidSignature`` on its owner contracts (``checkSignatures``),
+            so calling with the Safe as ``msg.sender`` matches on-chain semantics and supports
+            owners that read their configuration through ``msg.sender``, like the
+            ``SafeWebAuthnSharedSigner``.
         :return: True on successful validation; otherwise False.
         """
         fallback_handler = fallback_handler_getter(web3, self.owner)
@@ -738,7 +758,12 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
         )
 
         try:
-            result = await is_valid_signature_fn(data, signature).call()
+            if safe_address:
+                result = await is_valid_signature_fn(data, signature).call(
+                    {"from": ChecksumAddress(HexAddress(HexStr(safe_address)))}
+                )
+            else:
+                result = await is_valid_signature_fn(data, signature).call()
         except (Web3Exception, DecodingError, Web3ValueError, Web3RPCError) as exc:
             logger.warning(
                 "Cannot check EIP1271 with %s on contract %s: %s",
@@ -764,7 +789,9 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
         Falls back to the legacy method (bytes,bytes).
 
         :param web3: Optional EthereumClient instance.
-        :param safe_address: Optional Safe EthereumAddress instance.
+        :param safe_address: Optional Safe address. When provided, the EIP-1271 check is
+            performed with the Safe as the ``eth_call`` sender, mirroring how the Safe calls
+            ``isValidSignature`` on-chain.
         """
         if web3 is None:
             raise ValueError("web3 is required to validate contract signature")
@@ -787,6 +814,7 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
                 function_signature,
                 data,
                 bytes(self.contract_signature),
+                safe_address=safe_address,
             ):
                 return True
 

--- a/safe_eth/safe/tests/test_safe_signature.py
+++ b/safe_eth/safe/tests/test_safe_signature.py
@@ -70,6 +70,36 @@ def _approved_hash_signature_sample():
     return owner, safe_tx_hash, signature
 
 
+def deploy_caller_gated_eip1271_signer(
+    test_case: EthereumTestCaseMixin, expected_caller: str
+) -> str:
+    """
+    Deploy a minimal EIP-1271 signer that returns the magic value only when ``msg.sender``
+    matches ``expected_caller`` (and 32 zero bytes otherwise). It emulates signers like the
+    ``SafeWebAuthnSharedSigner``, which stores its configuration in the Safe's storage and
+    reads it back through ``msg.sender``, so it can only validate when called by the Safe.
+    """
+    runtime_code = (
+        b"\x33"  # CALLER
+        + b"\x73"
+        + HexBytes(expected_caller)  # PUSH20 expected_caller
+        + b"\x14"  # EQ
+        + b"\x60\x1f\x57"  # PUSH1 0x1f JUMPI
+        + b"\x60\x20\x60\x00\xf3"  # RETURN 32 zero bytes (caller mismatch)
+        + b"\x5b"  # JUMPDEST (offset 0x1f)
+        + b"\x63\x16\x26\xba\x7e"  # PUSH4 EIP-1271 magic value
+        + b"\x60\xe0\x1b"  # PUSH1 0xe0 SHL
+        + b"\x60\x00\x52"  # MSTORE at offset 0
+        + b"\x60\x20\x60\x00\xf3"  # RETURN memory[0:32]
+    )
+    # CODECOPY the 0x30-byte runtime (starting at init code offset 0x0c) and return it
+    init_code = b"\x60\x30\x60\x0c\x60\x00\x39\x60\x30\x60\x00\xf3" + runtime_code
+
+    tx_hash = test_case.send_tx({"data": init_code}, test_case.ethereum_test_account)
+    tx_receipt = test_case.w3.eth.get_transaction_receipt(tx_hash)
+    return tx_receipt["contractAddress"]
+
+
 def build_eip1271_signature_for_message(test_case: "SafeTestCaseMixin"):
     account = Account.create()
     safe_owner = test_case.deploy_test_safe(owners=[account.address])
@@ -193,6 +223,20 @@ class TestSafeSignature(EthereumTestCaseMixin, TestCase):
         )
         self.assertTrue(str(safe_signature))  # Test __str__
         self.assertFalse(safe_signature.is_valid(self.ethereum_client))
+
+    def test_contract_signature_with_msg_sender_dependent_signer(self):
+        safe_address = Account.create().address
+        signer_address = deploy_caller_gated_eip1271_signer(self, safe_address)
+
+        safe_tx_hash = fast_keccak_text("safe-tx")
+        safe_signature = SafeSignatureContract.from_values(
+            signer_address, safe_tx_hash, b"", b""
+        )
+        # A from-less `eth_call` reaches the signer with `msg.sender = address(0)`,
+        # so it cannot find its configuration
+        self.assertFalse(safe_signature.is_valid(self.ethereum_client))
+        # Calling with the Safe as sender mirrors on-chain `checkSignatures`
+        self.assertTrue(safe_signature.is_valid(self.ethereum_client, safe_address))
 
     def test_approved_hash_signature(self):
         owner, safe_tx_hash, signature = _approved_hash_signature_sample()
@@ -834,6 +878,20 @@ class TestSafeSignatureAsync(AsyncSignatureTestMixin, EthereumTestCaseMixin, Tes
         )
         self.assertTrue(str(safe_signature))
         self.assertFalse(self._is_valid_async(safe_signature))
+
+    def test_contract_signature_with_msg_sender_dependent_signer(self):
+        safe_address = Account.create().address
+        signer_address = deploy_caller_gated_eip1271_signer(self, safe_address)
+
+        safe_tx_hash = fast_keccak_text("safe-tx")
+        safe_signature = SafeSignatureContractAsync.from_values(
+            signer_address, safe_tx_hash, b"", b""
+        )
+        # A from-less `eth_call` reaches the signer with `msg.sender = address(0)`,
+        # so it cannot find its configuration
+        self.assertFalse(self._is_valid_async(safe_signature))
+        # Calling with the Safe as sender mirrors on-chain `checkSignatures`
+        self.assertTrue(self._is_valid_async(safe_signature, safe_address))
 
     def test_approved_hash_signature(self):
         owner, safe_tx_hash, signature = _approved_hash_signature_sample()


### PR DESCRIPTION
## Motivation

Fixes the root cause behind safe-global/safe-transaction-service#2937.

On-chain, `checkSignatures` has the **Safe itself** call `isValidSignature` on its owner contracts, so `msg.sender` is always the Safe. The off-chain check in `SafeSignatureContract._check_eip1271` performs a from-less `eth_call` (`msg.sender = address(0)`), which diverges from the on-chain semantics it is meant to predict.

For most owner contracts this makes no difference, but signatures from **`msg.sender`-dependent owners always fail validation**. The canonical example is the `SafeWebAuthnSharedSigner` from safe-modules (the standard gas-optimized ERC-4337 passkey setup): it stores each Safe's P-256 public key in the *Safe's* storage and reads it back via `ISafe(msg.sender).getStorageAt(...)` — in a from-less call there is no configuration to find, so pure-passkey Safes cannot propose transactions or register delegates with the Transaction Service at all.

## Change

`SafeSignatureContract.is_valid()` (sync and async) already receives `safe_address` — other signature types like `SafeSignatureApprovedHash` use it — but the contract-signature path ignored it. This PR threads it into the EIP-1271 `eth_call` as the sender when provided:

- `safe_address` given → `isValidSignature` is called with `from = safe_address`, mirroring on-chain `checkSignatures`.
- `safe_address` not given → unchanged from-less call.

Owner contracts that ignore `msg.sender` (e.g. a Safe validating through its fallback handler) are unaffected.

## Tests

Added sync + async tests deploying a minimal EIP-1271 signer that returns the magic value only when `msg.sender` matches a configured address (emulating the shared signer's behavior), asserting that validation fails without `safe_address` and succeeds with it. All existing tests in `test_safe_signature.py` pass (38 passed locally against a local node).

## Notes for safe-transaction-service

The service's proposal endpoints already pass `safe_address` to `is_valid`, so they gain shared-signer support with a dependency bump and no code change. The delegates v2 endpoint currently passes the delegator as second argument (`is_valid(ethereum_client, owner)`); supporting shared-signer delegators there needs a small follow-up passing the request's `safe` — happy to submit that PR as well.