### PR TITLE
Add Blockscout explorer URLs for Humanity Protocol chains

### DIFF
--- a/safe_eth/eth/clients/blockscout_client.py
+++ b/safe_eth/eth/clients/blockscout_client.py
@@ -50,6 +50,8 @@ class BlockscoutClient:
         EthereumNetwork.HAQQ_NETWORK: "https://explorer.haqq.network/api/v2/",
         EthereumNetwork.HASHKEY_CHAIN: "https://explorer.hsk.xyz/api/v2/",
         EthereumNetwork.HASHKEY_CHAIN_TESTNET: "https://hashkeychain-testnet-explorer.alt.technology/api/v2/",
+        EthereumNetwork.HUMANITY_PROTOCOL: "https://humanity-mainnet.explorer.alchemy.com/api/v2/",
+        EthereumNetwork.HUMANITY_PROTOCOL_TESTNET: "https://humanity-testnet.explorer.alchemy.com/api/v2/",
         EthereumNetwork.IOTA_EVM: "https://iota-evm.blockscout.com/api/v2/",
         EthereumNetwork.INK: "https://explorer.inkonchain.com/api/v2/",
         EthereumNetwork.INK_SEPOLIA: "https://explorer-sepolia.inkonchain.com/api/v2/",


### PR DESCRIPTION
## What

Registers the Blockscout API endpoints for **Humanity Protocol mainnet** (chain `6985385`) and **Humanity Protocol testnet** (chain `7080969`) in `BlockscoutClient.NETWORK_WITH_URL`.

## Why

The network enums and Safe deployment addresses for both chains are already present (added in v7.8), but no explorer client is registered, so contract metadata/ABI fetching is unavailable for these chains in downstream services (safe-transaction-service, safe-decoder-service).

## Verification

Both explorers are Alchemy-hosted Blockscout instances; the v2 API returns verified contract ABIs:

- mainnet: `https://humanity-mainnet.explorer.alchemy.com/api/v2/smart-contracts/0xD3f42c1DeBDCF75AB8204004b1CC9d7e7Ebf17Bd` → `UniswapV3Factory`, `is_verified: true`
- testnet: `https://humanity-testnet.explorer.alchemy.com/api/v2/smart-contracts/0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67` → `SafeProxyFactory`, `is_verified: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)