### PR TITLE
Fix typo in generated contract functions comment

### DIFF
--- a/safe_eth/eth/contracts/__init__.py
+++ b/safe_eth/eth/contracts/__init__.py
@@ -136,7 +136,7 @@ def generate_contract_fn(
     return fn
 
 
-# Anotate functions that will be generated later with `setattr` so typing does not complain
+# Annotate functions that will be generated later with `setattr` so typing does not complain
 def get_safe_contract(w3: Web3, address: Optional[ChecksumAddress] = None) -> Contract:
     """
     :param w3:


### PR DESCRIPTION
Correct `Anotate` to `Annotate` in the comment describing the dynamically generated contract helper functions.

This is a comment-only change and does not affect runtime behavior.