### PR TITLE
fix: Add missing HyperEVM entry to transaction service network map

### DIFF
--- a/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
+++ b/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
@@ -38,6 +38,7 @@ class TransactionServiceApi(SafeBaseAPI):
         EthereumNetwork.GNOSIS: "gno",
         EthereumNetwork.GNOSIS_CHIADO_TESTNET: "chi",
         EthereumNetwork.HEMI_NETWORK: "hemi",
+        EthereumNetwork.HYPEREVM: "hyper",
         EthereumNetwork.INK: "ink",
         EthereumNetwork.KATANA: "katana",
         EthereumNetwork.LENS: "lens",

--- a/safe_eth/safe/tests/api/test_transaction_service_api.py
+++ b/safe_eth/safe/tests/api/test_transaction_service_api.py
@@ -78,6 +78,14 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             transaction_service_api_calculated_base_url_with_env_api_key.api_key
         )
 
+        hyperevm_transaction_service_api = TransactionServiceApi(
+            EthereumNetwork.HYPEREVM
+        )
+        self.assertEqual(
+            hyperevm_transaction_service_api.base_url,
+            f"{hyperevm_transaction_service_api.TRANSACTION_SERVICE_BASE_URL}/hyper",
+        )
+
         with self.assertRaises(EthereumNetworkNotSupported):
             TransactionServiceApi(EthereumNetwork.BOBA_NETWORK)
 


### PR DESCRIPTION
HyperEVM (chain 999) is supported everywhere else in the library — it is
in the `EthereumNetwork` enum, and its 1.3.0/1.4.1 Safe deployments were
added in #2139-#2144 — but it was never added to
`TransactionServiceApi.NETWORK_SHORTNAME`.

Because `_get_url_by_network` resolves the base URL from that map,
`TransactionServiceApi(EthereumNetwork.HYPEREVM)` raises
`EthereumNetworkNotSupported`, which in turn makes `safe-cli` refuse to
enter tx-service mode on HyperEVM.

The endpoint exists and is live: safe-config lists chain 999 with
`transactionService: https://api.safe.global/tx-service/hyper`, and
`GET /tx-service/hyper/api/v1/about/` returns 200.
