### PR TITLE
Add addresses 1.5.0 for chains BASE, MANTLE_SEPOLIA_TESTNET and MEGAETH_MAINNET

### DIFF
--- a/safe_eth/safe/addresses.py
+++ b/safe_eth/safe/addresses.py
@@ -645,6 +645,12 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
             "1.4.1+L2",
         ),  # v1.4.1+L2
         ("0x41675C099F32341bf84BFc5382aF534df5C7461a", 5854670, "1.4.1"),  # v1.4.1
+        ("0xFf51A5898e281Db6DfC7855790607438dF2ca44b", 34415958, "1.5.0"),  # v1.5.0
+        (
+            "0xEdd160fEBBD92E350D4D398fb636302fccd67C7e",
+            39121079,
+            "1.5.0+L2",
+        ),  # v1.5.0+L2
     ],
     EthereumNetwork.BASE_GOERLI_TESTNET: [
         ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 7330635, "1.4.1+L2"),
@@ -1481,6 +1487,12 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
             7826399,
             "1.4.1+L2",
         ),  # v1.4.1+L2
+        ("0xFf51A5898e281Db6DfC7855790607438dF2ca44b", 27044294, "1.5.0"),  # v1.5.0
+        (
+            "0xEdd160fEBBD92E350D4D398fb636302fccd67C7e",
+            34714047,
+            "1.5.0+L2",
+        ),  # v1.5.0+L2
     ],
     EthereumNetwork.OP_SEPOLIA_TESTNET: [
         ("0x29fcB43b46531BcA003ddC8FCB67FFE91900C762", 7162879, "1.4.1+L2"),
@@ -3751,6 +3763,8 @@ MASTER_COPIES: Dict[EthereumNetwork, List[Tuple[str, int, str]]] = {
         ("0x3E5c63644E683549055b9Be8653de26E0B4CD36E", 591969, "1.3.0+L2"),  # v1.3.0+L2
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 854088, "1.3.0"),  # v1.3.0
         ("0xfb1bffC9d739B8D520DaF37dF666da4C687191EA", 854090, "1.3.0+L2"),  # v1.3.0+L2
+        ("0xFf51A5898e281Db6DfC7855790607438dF2ca44b", 331689, "1.5.0"),  # v1.5.0
+        ("0xEdd160fEBBD92E350D4D398fb636302fccd67C7e", 331693, "1.5.0+L2"),  # v1.5.0+L2
     ],
     EthereumNetwork.MORPH_HOODI: [
         ("0x69f4D1788e39c87893C980c06EdF4b7f686e2938", 1308358, "1.3.0"),  # v1.3.0
@@ -4540,6 +4554,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
             2156359,
         ),  # v1.3.0 default singleton address
         ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 3024579),  # v1.4.1
+        ("0x14F2982D601c9458F93bd70B218933A6f8165e7b", 34415957),  # v1.5.0
     ],
     EthereumNetwork.BASE_GOERLI_TESTNET: [
         ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 7330598),  # v1.4.1
@@ -4866,6 +4881,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
     EthereumNetwork.MANTLE_SEPOLIA_TESTNET: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 1927649),  # v1.3.0
         ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 7826372),  # v1.4.1
+        ("0x14F2982D601c9458F93bd70B218933A6f8165e7b", 27044215),  # v1.5.0
     ],
     EthereumNetwork.OP_SEPOLIA_TESTNET: [
         ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 7162843),  # v1.4.1
@@ -5725,6 +5741,7 @@ PROXY_FACTORIES: Dict[EthereumNetwork, List[Tuple[str, int]]] = {
         ("0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67", 592359),  # v1.4.1
         ("0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2", 592012),  # v1.3.0
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 854086),  # v1.3.0
+        ("0x14F2982D601c9458F93bd70B218933A6f8165e7b", 331685),  # v1.5.0
     ],
     EthereumNetwork.MORPH_HOODI: [
         ("0xC22834581EbC8527d974F8a1c97E1bEA4EF910BC", 1308342),  # v1.3.0


### PR DESCRIPTION
## Summary

Add missing Safe **v1.5.0** deployment addresses for:

- Base (`8453`)
- Mantle Sepolia Testnet (`5003`)
- MegaETH Mainnet (`4326`)

Updates `MASTER_COPIES` (Safe + SafeL2) and `PROXY_FACTORIES` (SafeProxyFactory) in `safe_eth/safe/addresses.py`. All three chains use the canonical CREATE2 addresses deployed via the Safe Singleton Factory (`0x914d7Fec6aaC8cd542e72Bca78B30650d45643d7`), consistent with every other supported network. Each block number was independently verified via RPC (`eth_getCode` diff immediately before/after the block).

## Addresses added

| Chain | Contract | Version | Address | Block | Creation Tx |
|---|---|---|---|---|---|
| Base (8453) | Safe | 1.5.0 | `0xFf51A5898e281Db6DfC7855790607438dF2ca44b` | 34415958 | [basescan.org](https://basescan.org/tx/0xfadbdcc3c206db55d826dacc91ec8cdc7a188d72ef948d1c4144bedeed9f0aeb) |
| Base (8453) | SafeL2 | 1.5.0+L2 | `0xEdd160fEBBD92E350D4D398fb636302fccd67C7e` | 39121079 | [basescan.org](https://basescan.org/tx/0xaf73b5766bb1bb229cd43cf1ee13215f4c3a732c4fe2ba280bd599fa823c63d2) |
| Base (8453) | SafeProxyFactory | 1.5.0 | `0x14F2982D601c9458F93bd70B218933A6f8165e7b` | 34415957 | [basescan.org](https://basescan.org/tx/0x400027dd0e3df0d126926302be966c1d25e2fe9fe5f19ede7a0a41586b165046) |
| Mantle Sepolia Testnet (5003) | Safe | 1.5.0 | `0xFf51A5898e281Db6DfC7855790607438dF2ca44b` | 27044294 | [sepolia.mantlescan.xyz](https://sepolia.mantlescan.xyz/tx/0x110085e96a4188953a124963c8e292086987ae713f9330dcbb3fb1312a38cdc2) |
| Mantle Sepolia Testnet (5003) | SafeL2 | 1.5.0+L2 | `0xEdd160fEBBD92E350D4D398fb636302fccd67C7e` | 34714047 | [sepolia.mantlescan.xyz](https://sepolia.mantlescan.xyz/tx/0xe2de5d976dc043baa6e0033f2b055a47ad8fe3d0c5038ec299623b14c81daa83) |
| Mantle Sepolia Testnet (5003) | SafeProxyFactory | 1.5.0 | `0x14F2982D601c9458F93bd70B218933A6f8165e7b` | 27044215 | [sepolia.mantlescan.xyz](https://sepolia.mantlescan.xyz/tx/0xc59cb58f63b1cb97a06f388343db8973f3f453f04eeeb7bc63ab39433bd1e839) |
| MegaETH Mainnet (4326) | Safe | 1.5.0 | `0xFf51A5898e281Db6DfC7855790607438dF2ca44b` | 331689 | [megaeth.blockscout.com](https://megaeth.blockscout.com/tx/0xa80cd09b21c9897e6fdb6c14fe63b5e64a2a482c08c0cee7951dd6e1ba5e4b24) |
| MegaETH Mainnet (4326) | SafeL2 | 1.5.0+L2 | `0xEdd160fEBBD92E350D4D398fb636302fccd67C7e` | 331693 | [megaeth.blockscout.com](https://megaeth.blockscout.com/tx/0x7f0d85879712116db78e497cfea1d7fc154a8fbe534ed3cae82a9462fed102e7) |
| MegaETH Mainnet (4326) | SafeProxyFactory | 1.5.0 | `0x14F2982D601c9458F93bd70B218933A6f8165e7b` | 331685 | [megaeth.blockscout.com](https://megaeth.blockscout.com/tx/0x2706c7b5181da95f27dfc5043b980a40b2cd081cbf8c4226f099b215c9181034) |

Closes PLA-1860
