### PR TITLE
Add Tempo transaction service network slugs

### DIFF
--- a/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
+++ b/safe_eth/safe/api/transaction_service_api/transaction_service_api.py
@@ -50,6 +50,8 @@ class TransactionServiceApi(SafeBaseAPI):
         EthereumNetwork.SCROLL: "scr",
         EthereumNetwork.SEPOLIA: "sep",
         EthereumNetwork.SONIC_MAINNET: "sonic",
+        EthereumNetwork.TEMPO_MAINNET: "tempo",
+        EthereumNetwork.TEMPO_TESTNET_MODERATO: "tempo-moderato",
         EthereumNetwork.UNICHAIN: "unichain",
         EthereumNetwork.WORLD_CHAIN: "wc",
         EthereumNetwork.X_LAYER_MAINNET: "okb",

--- a/safe_eth/safe/tests/api/test_transaction_service_api.py
+++ b/safe_eth/safe/tests/api/test_transaction_service_api.py
@@ -78,6 +78,16 @@ class TestTransactionServiceAPI(EthereumTestCaseMixin, TestCase):
             transaction_service_api_calculated_base_url_with_env_api_key.api_key
         )
 
+        for ethereum_network, short_name in (
+            (EthereumNetwork.TEMPO_MAINNET, "tempo"),
+            (EthereumNetwork.TEMPO_TESTNET_MODERATO, "tempo-moderato"),
+        ):
+            transaction_service_api = TransactionServiceApi(ethereum_network)
+            self.assertEqual(
+                transaction_service_api.base_url,
+                f"{transaction_service_api.TRANSACTION_SERVICE_BASE_URL}/{short_name}",
+            )
+
         with self.assertRaises(EthereumNetworkNotSupported):
             TransactionServiceApi(EthereumNetwork.BOBA_NETWORK)
 


### PR DESCRIPTION
## Summary

Safe Transaction Service endpoints are live for both Tempo networks, but the client-side network map did not include their service slugs. As a result, constructing `TransactionServiceApi` for either network raised `EthereumNetworkNotSupported`.

This change adds:

- `EthereumNetwork.TEMPO_MAINNET` -> `tempo`
- `EthereumNetwork.TEMPO_TESTNET_MODERATO` -> `tempo-moderato`

The resulting base URLs are:

- `https://api.safe.global/tx-service/tempo/`
- `https://api.safe.global/tx-service/tempo-moderato/`

## Testing

- Added constructor coverage for both Tempo service URLs.
- Python syntax compilation passed.
- `git diff --check` passed.
- Full pytest could not run because the environment cannot download unavailable dependencies.