### PR TITLE
Validate contract signatures against the verifying Safe's EIP-1271 convention

### DIFF
--- a/safe_eth/safe/safe_signature.py
+++ b/safe_eth/safe/safe_signature.py
@@ -621,6 +621,7 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
         function_signature: str,
         data: bytes,
         signature: bytes,
+        expected_magic_value: HexBytes,
     ) -> bool:
         """
         Attempt to validate an EIP-1271 signature using a specific CompatibilityFallbackHandler and function signature.
@@ -630,6 +631,11 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
         :param function_signature: The ABI function signature to call.
         :param data: The data or hash to be validated, depending on the Safe version.
         :param signature: The contract signature payload to validate.
+        :param expected_magic_value: The value the verifying Safe requires back for this
+            entrypoint. Each interface has its own: `ISignatureValidator` declares
+            `0x20c13b0b` up to 1.4.1 and `0x1626ba7e` from 1.5.0, and the Safe compares
+            against that one exactly. Accepting either would pass a signer that returns the
+            other, which then reverts `GS024` on the Safe.
         :return: True on successful validation; otherwise False.
         """
         fallback_handler = fallback_handler_getter(ethereum_client.w3, self.owner)
@@ -648,10 +654,7 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
             )
             return False
 
-        return result in (
-            self.EIP1271_MAGIC_VALUE,
-            self.EIP1271_MAGIC_VALUE_UPDATED,
-        )
+        return HexBytes(result) == expected_magic_value
 
     def is_valid(
         self,
@@ -691,6 +694,7 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
             "isValidSignature(bytes32,bytes)",
             bytes(self.safe_hash),
             bytes(self.contract_signature),
+            self.EIP1271_MAGIC_VALUE_UPDATED,
         ):
             return True
 
@@ -702,6 +706,7 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
             "isValidSignature(bytes,bytes)",
             bytes(self.safe_hash_preimage),
             bytes(self.contract_signature),
+            self.EIP1271_MAGIC_VALUE,
         ):
             return True
 
@@ -781,6 +786,7 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
         function_signature: str,
         data: bytes,
         signature: bytes,
+        expected_magic_value: HexBytes,
     ) -> bool:
         """
         Attempt to validate an EIP-1271 signature using a specific CompatibilityFallbackHandler and function signature.
@@ -790,6 +796,11 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
         :param function_signature: The ABI function signature to call
         :param data: The data or hash to be validated, depending on the Safe version.
         :param signature: The contract signature payload to validate.
+        :param expected_magic_value: The value the verifying Safe requires back for this
+            entrypoint. Each interface has its own: `ISignatureValidator` declares
+            `0x20c13b0b` up to 1.4.1 and `0x1626ba7e` from 1.5.0, and the Safe compares
+            against that one exactly. Accepting either would pass a signer that returns the
+            other, which then reverts `GS024` on the Safe.
         :return: True on successful validation; otherwise False.
         """
         fallback_handler = fallback_handler_getter(web3, self.owner)
@@ -808,10 +819,7 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
             )
             return False
 
-        return result in (
-            self.EIP1271_MAGIC_VALUE,
-            self.EIP1271_MAGIC_VALUE_UPDATED,
-        )
+        return HexBytes(result) == expected_magic_value
 
     async def is_valid(
         self,
@@ -849,6 +857,7 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
             "isValidSignature(bytes32,bytes)",
             bytes(self.safe_hash),
             bytes(self.contract_signature),
+            self.EIP1271_MAGIC_VALUE_UPDATED,
         ):
             return True
 
@@ -860,6 +869,7 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
             "isValidSignature(bytes,bytes)",
             bytes(self.safe_hash_preimage),
             bytes(self.contract_signature),
+            self.EIP1271_MAGIC_VALUE,
         ):
             return True
 

--- a/safe_eth/safe/safe_signature.py
+++ b/safe_eth/safe/safe_signature.py
@@ -22,6 +22,7 @@ from eth_abi.exceptions import DecodingError
 from eth_account.messages import defunct_hash_message
 from eth_typing import BlockIdentifier, ChecksumAddress, HexAddress, HexStr
 from hexbytes import HexBytes
+from packaging.version import InvalidVersion, Version
 from typing_extensions import Self
 from web3 import AsyncWeb3, Web3
 from web3.contract import Contract
@@ -337,10 +338,14 @@ class SafeSignature(SafeSignatureBase):
         self,
         ethereum_client: Optional[EthereumClient] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         """
         :param ethereum_client: Required for Contract Signature and Approved Hash check
         :param safe_address: Required for Approved Hash check
+        :param safe_version: Version of the Safe that will verify this signature. Required for
+            a correct Contract Signature check, as the version decides which EIP-1271 entrypoint
+            is called on-chain. Ignored by every other signature type.
         :return: `True` if signature is valid, `False` otherwise
         """
         raise NotImplementedError
@@ -352,8 +357,46 @@ class SafeSignatureAsync(SafeSignatureBase):
         self,
         web3: Optional[AsyncWeb3] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
+        """
+        :param web3: Required for Contract Signature and Approved Hash check
+        :param safe_address: Required for Approved Hash check
+        :param safe_version: Version of the Safe that will verify this signature. Required for
+            a correct Contract Signature check, as the version decides which EIP-1271 entrypoint
+            is called on-chain. Ignored by every other signature type.
+        :return: `True` if signature is valid, `False` otherwise
+        """
         raise NotImplementedError
+
+
+# From this version a Safe verifies contract signatures through
+# `isValidSignature(bytes32,bytes)`; below it, through the legacy
+# `isValidSignature(bytes,bytes)`.
+EIP1271_BYTES32_MIN_VERSION = Version("1.5.0")
+
+
+def uses_bytes32_eip1271(safe_version: str) -> bool:
+    """Whether a Safe of `safe_version` verifies contract signatures with the hash.
+
+    The single home for the rule: `checkContractSignature` on a Safe >= 1.5.0 calls
+    `isValidSignature(bytes32,bytes)` with `dataHash`, while `checkNSignatures` below that
+    calls the legacy `isValidSignature(bytes,bytes)` with the whole preimage. Callers that
+    report a rejection need the same answer to name the entrypoint, so they should ask here
+    rather than compare against `EIP1271_BYTES32_MIN_VERSION` themselves.
+
+    :param safe_version: Version of the Safe that verifies the signature.
+    :return: `True` from 1.5.0 on, `False` below.
+    :raises CannotCheckEIP1271ContractSignature: If `safe_version` cannot be compared. Raised
+        instead of `packaging`'s `InvalidVersion` so callers handle one Safe-domain error and
+        do not each reimplement the translation. `VERSION()` is an arbitrary on-chain string.
+    """
+    try:
+        return Version(safe_version) >= EIP1271_BYTES32_MIN_VERSION
+    except InvalidVersion as exc:
+        raise CannotCheckEIP1271ContractSignature(
+            f"Cannot tell which EIP-1271 entrypoint Safe version {safe_version!r} uses"
+        ) from exc
 
 
 class SafeSignatureContractMixin(SafeSignatureBase):
@@ -614,40 +657,53 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
         self,
         ethereum_client: Optional[EthereumClient] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         """
-        Validate the signature using the appropriate EIP-1271 path.
-        First tries the updated method (bytes32,bytes).
-        Falls back to the legacy method (bytes,bytes).
+        Validate the signature through the EIP-1271 entrypoint the verifying Safe uses.
 
         :param ethereum_client: EthereumClient instance
         :param safe_address: Optional Safe EthereumAddress instance.
+        :param safe_version: Version of the Safe that will verify this signature. Only the
+            entrypoint that version calls on-chain is checked. Defaults to `None`, which checks
+            both and so can return `True` for a signature that reverts `GS024` on that Safe;
+            pass a version whenever it is known.
+        :raises CannotCheckEIP1271ContractSignature: If `safe_version` cannot be compared.
         """
         if ethereum_client is None:
             raise ValueError(
                 "ethereum_client is required to validate contract signature"
             )
 
-        for fallback_handler_getter, function_signature, data in (
-            (
-                get_compatibility_fallback_handler_contract,
-                "isValidSignature(bytes32,bytes)",
-                bytes(self.safe_hash),
-            ),
-            (
-                get_compatibility_fallback_handler_V1_4_1_contract,
-                "isValidSignature(bytes,bytes)",
-                bytes(self.safe_hash_preimage),
-            ),
+        # Only one entrypoint is ever called on-chain and the verifying Safe's version
+        # decides which: `checkContractSignature` on a Safe >= 1.5.0 hands `dataHash` to the
+        # signer, while `checkNSignatures` below that hands over the whole preimage. `None`
+        # means the caller does not know, so both are tried.
+        if safe_version is None:
+            try_bytes32 = try_legacy = True
+        else:
+            try_bytes32 = uses_bytes32_eip1271(safe_version)
+            try_legacy = not try_bytes32
+
+        if try_bytes32 and self._check_eip1271(
+            ethereum_client,
+            get_compatibility_fallback_handler_contract,
+            "isValidSignature(bytes32,bytes)",
+            bytes(self.safe_hash),
+            bytes(self.contract_signature),
         ):
-            if self._check_eip1271(
-                ethereum_client,
-                fallback_handler_getter,
-                function_signature,
-                data,
-                bytes(self.contract_signature),
-            ):
-                return True
+            return True
+
+        # Dropped from the 1.5.0 `CompatibilityFallbackHandler`, so a 1.5.0 signer does not
+        # declare this overload at all and can never answer here
+        if try_legacy and self._check_eip1271(
+            ethereum_client,
+            get_compatibility_fallback_handler_V1_4_1_contract,
+            "isValidSignature(bytes,bytes)",
+            bytes(self.safe_hash_preimage),
+            bytes(self.contract_signature),
+        ):
+            return True
 
         return False
 
@@ -657,6 +713,7 @@ class SafeSignatureApprovedHash(SafeSignatureApprovedHashMixin, SafeSignature):
         self,
         ethereum_client: Optional[EthereumClient] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         if ethereum_client is None:
             raise ValueError("ethereum_client is required to validate approved hash")
@@ -689,6 +746,7 @@ class SafeSignatureEthSign(SafeSignatureEthSignMixin, SafeSignature):
         self,
         ethereum_client: Optional[EthereumClient] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         return True
 
@@ -698,6 +756,7 @@ class SafeSignatureEOA(SafeSignatureEOAMixin, SafeSignature):
         self,
         ethereum_client: Optional[EthereumClient] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         return True
 
@@ -707,6 +766,7 @@ class SafeSignatureP256(SafeSignatureP256Mixin, SafeSignature):
         self,
         ethereum_client: Optional[EthereumClient] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         return self._is_valid()
 
@@ -757,38 +817,51 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
         self,
         web3: Optional[AsyncWeb3] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         """
-        Validate the signature using the appropriate EIP-1271 path.
-        First tries the updated method (bytes32,bytes).
-        Falls back to the legacy method (bytes,bytes).
+        Validate the signature through the EIP-1271 entrypoint the verifying Safe uses.
 
         :param web3: Optional EthereumClient instance.
         :param safe_address: Optional Safe EthereumAddress instance.
+        :param safe_version: Version of the Safe that will verify this signature. Only the
+            entrypoint that version calls on-chain is checked. Defaults to `None`, which checks
+            both and so can return `True` for a signature that reverts `GS024` on that Safe;
+            pass a version whenever it is known.
+        :raises CannotCheckEIP1271ContractSignature: If `safe_version` cannot be compared.
         """
         if web3 is None:
             raise ValueError("web3 is required to validate contract signature")
 
-        for fallback_handler_getter, function_signature, data in (
-            (
-                get_compatibility_fallback_handler_contract,
-                "isValidSignature(bytes32,bytes)",
-                bytes(self.safe_hash),
-            ),
-            (
-                get_compatibility_fallback_handler_V1_4_1_contract,
-                "isValidSignature(bytes,bytes)",
-                bytes(self.safe_hash_preimage),
-            ),
+        # Only one entrypoint is ever called on-chain and the verifying Safe's version
+        # decides which: `checkContractSignature` on a Safe >= 1.5.0 hands `dataHash` to the
+        # signer, while `checkNSignatures` below that hands over the whole preimage. `None`
+        # means the caller does not know, so both are tried.
+        if safe_version is None:
+            try_bytes32 = try_legacy = True
+        else:
+            try_bytes32 = uses_bytes32_eip1271(safe_version)
+            try_legacy = not try_bytes32
+
+        if try_bytes32 and await self._check_eip1271(
+            web3,
+            get_compatibility_fallback_handler_contract,
+            "isValidSignature(bytes32,bytes)",
+            bytes(self.safe_hash),
+            bytes(self.contract_signature),
         ):
-            if await self._check_eip1271(
-                web3,
-                fallback_handler_getter,
-                function_signature,
-                data,
-                bytes(self.contract_signature),
-            ):
-                return True
+            return True
+
+        # Dropped from the 1.5.0 `CompatibilityFallbackHandler`, so a 1.5.0 signer does not
+        # declare this overload at all and can never answer here
+        if try_legacy and await self._check_eip1271(
+            web3,
+            get_compatibility_fallback_handler_V1_4_1_contract,
+            "isValidSignature(bytes,bytes)",
+            bytes(self.safe_hash_preimage),
+            bytes(self.contract_signature),
+        ):
+            return True
 
         return False
 
@@ -800,6 +873,7 @@ class SafeSignatureApprovedHashAsync(
         self,
         web3: Optional[AsyncWeb3] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         if web3 is None:
             raise ValueError("web3 is required to validate approved hash")
@@ -830,6 +904,7 @@ class SafeSignatureEthSignAsync(SafeSignatureEthSignMixin, SafeSignatureAsync):
         self,
         web3: Optional[AsyncWeb3] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         return True
 
@@ -839,6 +914,7 @@ class SafeSignatureEOAAsync(SafeSignatureEOAMixin, SafeSignatureAsync):
         self,
         web3: Optional[AsyncWeb3] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         return True
 
@@ -848,6 +924,7 @@ class SafeSignatureP256Async(SafeSignatureP256Mixin, SafeSignatureAsync):
         self,
         web3: Optional[AsyncWeb3] = None,
         safe_address: Optional[str] = None,
+        safe_version: Optional[str] = None,
     ) -> bool:
         return self._is_valid()
 

--- a/safe_eth/safe/safe_signature.py
+++ b/safe_eth/safe/safe_signature.py
@@ -137,7 +137,11 @@ class SafeSignatureBase(ABC):
         """
         :param signatures: One or more signatures appended. EIP1271 data at the end is supported.
         :param safe_hash: Signed hash for the Safe (message or transaction)
-        :param safe_hash_preimage: ``safe_hash`` preimage for EIP1271 validation
+        :param safe_hash_preimage: ``safe_hash`` preimage for EIP1271 validation. A Safe below
+            1.5.0 hands the whole preimage to the signer, so validating a contract signature
+            against one of those versions needs it. Defaults to ``None``, and
+            ``SafeSignatureContract.is_valid`` then raises for such a version instead of
+            reporting a valid signature as invalid.
         :param ignore_trailing: Ignore trailing data on the signature. Some libraries pad it and add some zeroes at
             the end
         :return: List of SafeSignatures decoded
@@ -180,7 +184,7 @@ class SafeSignatureBase(ABC):
                     cast(Type[Any], safe_signature_cls)(
                         signature,
                         safe_hash,
-                        safe_hash_preimage or safe_hash,
+                        safe_hash_preimage,
                         contract_signature,
                     ),
                 )
@@ -407,11 +411,16 @@ class SafeSignatureContractMixin(SafeSignatureBase):
         self,
         signature: EthereumBytes,
         safe_hash: EthereumBytes,
-        safe_hash_preimage: EthereumBytes,
+        safe_hash_preimage: Optional[EthereumBytes],
         contract_signature: EthereumBytes,
     ):
         super().__init__(signature, safe_hash)
-        self.safe_hash_preimage: HexBytes = HexBytes(safe_hash_preimage)
+        # `None` means the caller did not have it. It is only needed to reach the legacy
+        # entrypoint, so it stays unknown instead of falling back to `safe_hash`, which
+        # would make a Safe below 1.5.0 hash the wrong data and reject a valid signature.
+        self.safe_hash_preimage: Optional[HexBytes] = (
+            HexBytes(safe_hash_preimage) if safe_hash_preimage is not None else None
+        )
         self.contract_signature: HexBytes = HexBytes(contract_signature)
 
     @classmethod
@@ -419,7 +428,7 @@ class SafeSignatureContractMixin(SafeSignatureBase):
         cls,
         safe_owner: ChecksumAddress,
         safe_hash: EthereumBytes,
-        safe_hash_preimage: EthereumBytes,
+        safe_hash_preimage: Optional[EthereumBytes],
         contract_signature: EthereumBytes,
     ) -> Self:
         signature = signature_to_bytes(
@@ -434,6 +443,22 @@ class SafeSignatureContractMixin(SafeSignatureBase):
     @property
     def signature_type(self) -> SafeSignatureType:
         return SafeSignatureType.CONTRACT_SIGNATURE
+
+    def _legacy_eip1271_data(self) -> bytes:
+        """
+        Data for the legacy ``isValidSignature(bytes,bytes)`` entrypoint: the whole
+        ``safe_hash`` preimage, which is what a Safe below 1.5.0 hands to the signer.
+
+        :return: ``safe_hash_preimage``
+        :raises CannotCheckEIP1271ContractSignature: If the preimage is unknown. The signer
+            hashes whatever it receives, so any stand-in makes it reject a valid signature.
+        """
+        if self.safe_hash_preimage is None:
+            raise CannotCheckEIP1271ContractSignature(
+                "safe_hash_preimage is required to check the legacy EIP-1271 "
+                f"entrypoint on contract {self.owner}"
+            )
+        return bytes(self.safe_hash_preimage)
 
     def export_signature(self) -> HexBytes:
         """
@@ -671,7 +696,9 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
             entrypoint that version calls on-chain is checked. Defaults to `None`, which checks
             both and so can return `True` for a signature that reverts `GS024` on that Safe;
             pass a version whenever it is known.
-        :raises CannotCheckEIP1271ContractSignature: If `safe_version` cannot be compared.
+        :raises CannotCheckEIP1271ContractSignature: If `safe_version` cannot be compared, or
+            if it names a Safe that uses the legacy entrypoint and `safe_hash_preimage` is
+            unknown.
         """
         if ethereum_client is None:
             raise ValueError(
@@ -683,7 +710,10 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
         # signer, while `checkNSignatures` below that hands over the whole preimage. `None`
         # means the caller does not know, so both are tried.
         if safe_version is None:
-            try_bytes32 = try_legacy = True
+            try_bytes32 = True
+            # The legacy entrypoint takes the whole preimage, so with an unknown one there
+            # is nothing to call here; the `bytes32` attempt still answers
+            try_legacy = self.safe_hash_preimage is not None
         else:
             try_bytes32 = uses_bytes32_eip1271(safe_version)
             try_legacy = not try_bytes32
@@ -704,7 +734,7 @@ class SafeSignatureContract(SafeSignatureContractMixin, SafeSignature):
             ethereum_client,
             get_compatibility_fallback_handler_V1_4_1_contract,
             "isValidSignature(bytes,bytes)",
-            bytes(self.safe_hash_preimage),
+            self._legacy_eip1271_data(),
             bytes(self.contract_signature),
             self.EIP1271_MAGIC_VALUE,
         ):
@@ -836,7 +866,9 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
             entrypoint that version calls on-chain is checked. Defaults to `None`, which checks
             both and so can return `True` for a signature that reverts `GS024` on that Safe;
             pass a version whenever it is known.
-        :raises CannotCheckEIP1271ContractSignature: If `safe_version` cannot be compared.
+        :raises CannotCheckEIP1271ContractSignature: If `safe_version` cannot be compared, or
+            if it names a Safe that uses the legacy entrypoint and `safe_hash_preimage` is
+            unknown.
         """
         if web3 is None:
             raise ValueError("web3 is required to validate contract signature")
@@ -846,7 +878,10 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
         # signer, while `checkNSignatures` below that hands over the whole preimage. `None`
         # means the caller does not know, so both are tried.
         if safe_version is None:
-            try_bytes32 = try_legacy = True
+            try_bytes32 = True
+            # The legacy entrypoint takes the whole preimage, so with an unknown one there
+            # is nothing to call here; the `bytes32` attempt still answers
+            try_legacy = self.safe_hash_preimage is not None
         else:
             try_bytes32 = uses_bytes32_eip1271(safe_version)
             try_legacy = not try_bytes32
@@ -867,7 +902,7 @@ class SafeSignatureContractAsync(SafeSignatureContractMixin, SafeSignatureAsync)
             web3,
             get_compatibility_fallback_handler_V1_4_1_contract,
             "isValidSignature(bytes,bytes)",
-            bytes(self.safe_hash_preimage),
+            self._legacy_eip1271_data(),
             bytes(self.contract_signature),
             self.EIP1271_MAGIC_VALUE,
         ):

--- a/safe_eth/safe/tests/test_safe_signature.py
+++ b/safe_eth/safe/tests/test_safe_signature.py
@@ -1,6 +1,7 @@
 import asyncio
 import hashlib
 import logging
+from typing import Optional
 
 from django.test import TestCase
 
@@ -156,6 +157,63 @@ def setup_safe_contract_signature_case_v1_1_1(test_case: "SafeTestCaseMixin"):
     }
 
 
+def build_nested_contract_signatures(
+    test_case: "SafeTestCaseMixin",
+    *,
+    safe_version: str,
+    owner_safe_version: Optional[str] = None,
+):
+    """Build both nestings of an EIP-1271 signature from an owner Safe.
+
+    A Safe owner signs the verifying Safe's transaction as its own message. Which payload
+    it must nest is decided by the *verifying* Safe: below 1.5.0 `checkNSignatures` calls
+    `isValidSignature(bytes,bytes)` with the whole preimage, from 1.5.0
+    `checkContractSignature` calls `isValidSignature(bytes32,bytes)` with the hash. Both
+    are built here so a single deployment covers the valid and the invalid case.
+
+    :param test_case: Test case providing the deployment helpers.
+    :param safe_version: Version of the Safe that verifies the signature.
+    :param owner_safe_version: Version of the owner Safe producing it. Defaults to
+        `safe_version`; set it apart to build a cross-version pair.
+    :return: Dict with the `preimage` and `hash` nestings, and the hash and preimage they
+        were built for.
+    """
+
+    def deploy(version: str, owners):
+        deployer = getattr(test_case, f"deploy_test_safe_v{version.replace('.', '_')}")
+        return deployer(owners=owners, threshold=1)
+
+    owner_account = Account.create()
+    safe_owner = deploy(owner_safe_version or safe_version, [owner_account.address])
+    safe = deploy(safe_version, [safe_owner.address])
+
+    safe_tx = safe.build_multisig_tx(to=Account.create().address, value=0, data=b"")
+    safe_tx_hash = safe_tx.safe_tx_hash
+    safe_tx_hash_preimage = safe_tx.safe_tx_hash_preimage
+
+    def nest(nested_payload: bytes) -> bytes:
+        # The owner Safe signs `nested_payload` as its own message, which is what its
+        # `isValidSignature` reconstructs before running `checkSignatures`
+        inner_signature = owner_account.unsafe_sign_hash(
+            safe_owner.get_message_hash(nested_payload)
+        )["signature"]
+        return bytes(
+            SafeSignatureContract.from_values(
+                safe_owner.address,
+                safe_tx_hash,
+                safe_tx_hash_preimage,
+                inner_signature,
+            ).export_signature()
+        )
+
+    return {
+        "preimage": nest(safe_tx_hash_preimage),
+        "hash": nest(safe_tx_hash),
+        "safe_tx_hash": safe_tx_hash,
+        "safe_tx_hash_preimage": safe_tx_hash_preimage,
+    }
+
+
 class AsyncSignatureTestMixin:
     async_w3: AsyncWeb3
 
@@ -176,9 +234,9 @@ class AsyncSignatureTestMixin:
     def _run_async(self, coroutine):
         return asyncio.run(coroutine)
 
-    def _is_valid_async(self, signature, *args):
+    def _is_valid_async(self, signature, *args, **kwargs):
         async def runner():
-            return await signature.is_valid(self.async_w3, *args)
+            return await signature.is_valid(self.async_w3, *args, **kwargs)
 
         return self._run_async(runner())
 
@@ -823,6 +881,68 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
             count += 1
         self.assertEqual(count, 2)
 
+    def test_contract_signature_entrypoint_by_safe_version(self):
+        """Only the entrypoint the verifying Safe calls on-chain is checked.
+
+        Below 1.5.0 that is `isValidSignature(bytes,bytes)` with the preimage, from 1.5.0
+        `isValidSignature(bytes32,bytes)` with the hash. Accepting the other nesting lets
+        through a signature that reverts `GS024` when the Safe is finally executed.
+        """
+        for safe_version, valid_nesting in (
+            ("1.3.0", "preimage"),
+            ("1.4.1", "preimage"),
+            ("1.5.0", "hash"),
+        ):
+            signatures = build_nested_contract_signatures(
+                self, safe_version=safe_version
+            )
+            for nesting in ("preimage", "hash"):
+                with self.subTest(safe_version=safe_version, nesting=nesting):
+                    safe_signature = SafeSignature.parse_signature(
+                        signatures[nesting],
+                        signatures["safe_tx_hash"],
+                        signatures["safe_tx_hash_preimage"],
+                    )[0]
+                    self.assertEqual(
+                        safe_signature.is_valid(
+                            self.ethereum_client, safe_version=safe_version
+                        ),
+                        nesting == valid_nesting,
+                    )
+                    # Without a version both entrypoints are checked, so a signer below
+                    # 1.5.0 (which declares both overloads) answers either nesting
+                    if valid_nesting == "preimage":
+                        self.assertTrue(safe_signature.is_valid(self.ethereum_client))
+
+    def test_contract_signature_from_v1_5_0_owner_on_older_safe(self):
+        """A 1.5.0 owner Safe can never sign for a Safe below 1.5.0.
+
+        The verifying Safe calls `isValidSignature(bytes,bytes)`, which the 1.5.0
+        `CompatibilityFallbackHandler` no longer declares, so no nesting can work.
+        """
+        signatures = build_nested_contract_signatures(
+            self, safe_version="1.4.1", owner_safe_version="1.5.0"
+        )
+        for nesting in ("preimage", "hash"):
+            with self.subTest(nesting=nesting):
+                safe_signature = SafeSignature.parse_signature(
+                    signatures[nesting],
+                    signatures["safe_tx_hash"],
+                    signatures["safe_tx_hash_preimage"],
+                )[0]
+                self.assertFalse(
+                    safe_signature.is_valid(self.ethereum_client, safe_version="1.4.1")
+                )
+
+        # Without a version the `bytes32` entrypoint answers on the 1.5.0 owner, so the
+        # signature is accepted even though no Safe below 1.5.0 can ever verify it
+        hash_signature = SafeSignature.parse_signature(
+            signatures["hash"],
+            signatures["safe_tx_hash"],
+            signatures["safe_tx_hash_preimage"],
+        )[0]
+        self.assertTrue(hash_signature.is_valid(self.ethereum_client))
+
 
 class TestSafeSignatureAsync(AsyncSignatureTestMixin, EthereumTestCaseMixin, TestCase):
     def test_contract_signature(self):
@@ -1233,3 +1353,52 @@ class TestSafeContractSignatureAsync(AsyncSignatureTestMixin, SafeTestCaseMixin)
             self.assertTrue(self._is_valid_async(exported_signature, None))
             count += 1
         self.assertEqual(count, 2)
+
+    def test_contract_signature_entrypoint_by_safe_version(self):
+        """Only the entrypoint the verifying Safe calls on-chain is checked."""
+        for safe_version, valid_nesting in (
+            ("1.3.0", "preimage"),
+            ("1.4.1", "preimage"),
+            ("1.5.0", "hash"),
+        ):
+            signatures = build_nested_contract_signatures(
+                self, safe_version=safe_version
+            )
+            for nesting in ("preimage", "hash"):
+                with self.subTest(safe_version=safe_version, nesting=nesting):
+                    safe_signature = SafeSignatureAsync.parse_signature(
+                        signatures[nesting],
+                        signatures["safe_tx_hash"],
+                        signatures["safe_tx_hash_preimage"],
+                    )[0]
+                    self.assertEqual(
+                        self._is_valid_async(safe_signature, safe_version=safe_version),
+                        nesting == valid_nesting,
+                    )
+                    # Without a version both entrypoints are checked, so a signer below
+                    # 1.5.0 (which declares both overloads) answers either nesting
+                    if valid_nesting == "preimage":
+                        self.assertTrue(self._is_valid_async(safe_signature))
+
+    def test_contract_signature_from_v1_5_0_owner_on_older_safe(self):
+        """A 1.5.0 owner Safe can never sign for a Safe below 1.5.0."""
+        signatures = build_nested_contract_signatures(
+            self, safe_version="1.4.1", owner_safe_version="1.5.0"
+        )
+        for nesting in ("preimage", "hash"):
+            with self.subTest(nesting=nesting):
+                safe_signature = SafeSignatureAsync.parse_signature(
+                    signatures[nesting],
+                    signatures["safe_tx_hash"],
+                    signatures["safe_tx_hash_preimage"],
+                )[0]
+                self.assertFalse(
+                    self._is_valid_async(safe_signature, safe_version="1.4.1")
+                )
+
+        hash_signature = SafeSignatureAsync.parse_signature(
+            signatures["hash"],
+            signatures["safe_tx_hash"],
+            signatures["safe_tx_hash_preimage"],
+        )[0]
+        self.assertTrue(self._is_valid_async(hash_signature))

--- a/safe_eth/safe/tests/test_safe_signature.py
+++ b/safe_eth/safe/tests/test_safe_signature.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import logging
 from typing import Optional
+from unittest import mock
 
 from django.test import TestCase
 
@@ -26,6 +27,7 @@ from ...eth.contracts import (
 )
 from ...eth.tests.ethereum_test_case import EthereumTestCaseMixin
 from .. import SafeOperationEnum
+from .. import safe_signature as safe_signature_module
 from ..safe_signature import (
     SafeSignature,
     SafeSignatureApprovedHash,
@@ -212,6 +214,25 @@ def build_nested_contract_signatures(
         "safe_tx_hash": safe_tx_hash,
         "safe_tx_hash_preimage": safe_tx_hash_preimage,
     }
+
+
+def fallback_handler_getter_returning(magic_value: bytes, *, is_async: bool):
+    """Stand in for the fallback handler getter, answering `magic_value` verbatim.
+
+    No Safe returns the wrong magic value for an entrypoint, so reaching that branch needs
+    a stub. An owner can be any EIP-1271 contract, not only a Safe, which is where it bites.
+    """
+    call = (
+        mock.AsyncMock(return_value=magic_value)
+        if is_async
+        else mock.MagicMock(return_value=magic_value)
+    )
+    bound_function = mock.MagicMock(call=call)
+    handler = mock.MagicMock()
+    handler.get_function_by_signature.return_value = mock.MagicMock(
+        return_value=bound_function
+    )
+    return mock.MagicMock(return_value=handler)
 
 
 class AsyncSignatureTestMixin:
@@ -943,6 +964,33 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
         )[0]
         self.assertTrue(hash_signature.is_valid(self.ethereum_client))
 
+    def test_contract_signature_rejects_other_interfaces_magic_value(self):
+        """A signer answering with the other interface's magic value is rejected.
+
+        `ISignatureValidator` declares `0x20c13b0b` up to 1.4.1 and `0x1626ba7e` from 1.5.0,
+        and the verifying Safe compares against its own one exactly. Accepting either would
+        pass a signer whose answer then reverts `GS024` on that Safe.
+        """
+        signatures = build_nested_contract_signatures(self, safe_version="1.5.0")
+        safe_signature = SafeSignature.parse_signature(
+            signatures["hash"],
+            signatures["safe_tx_hash"],
+            signatures["safe_tx_hash_preimage"],
+        )[0]
+        self.assertTrue(
+            safe_signature.is_valid(self.ethereum_client, safe_version="1.5.0")
+        )
+
+        legacy_magic_value = bytes(SafeSignatureContract.EIP1271_MAGIC_VALUE)
+        with mock.patch.object(
+            safe_signature_module,
+            "get_compatibility_fallback_handler_contract",
+            fallback_handler_getter_returning(legacy_magic_value, is_async=False),
+        ):
+            self.assertFalse(
+                safe_signature.is_valid(self.ethereum_client, safe_version="1.5.0")
+            )
+
 
 class TestSafeSignatureAsync(AsyncSignatureTestMixin, EthereumTestCaseMixin, TestCase):
     def test_contract_signature(self):
@@ -1402,3 +1450,26 @@ class TestSafeContractSignatureAsync(AsyncSignatureTestMixin, SafeTestCaseMixin)
             signatures["safe_tx_hash_preimage"],
         )[0]
         self.assertTrue(self._is_valid_async(hash_signature))
+
+    def test_contract_signature_rejects_other_interfaces_magic_value(self):
+        """A signer answering with the other interface's magic value is rejected.
+
+        `ISignatureValidator` declares `0x20c13b0b` up to 1.4.1 and `0x1626ba7e` from 1.5.0,
+        and the verifying Safe compares against its own one exactly. Accepting either would
+        pass a signer whose answer then reverts `GS024` on that Safe.
+        """
+        signatures = build_nested_contract_signatures(self, safe_version="1.5.0")
+        safe_signature = SafeSignatureAsync.parse_signature(
+            signatures["hash"],
+            signatures["safe_tx_hash"],
+            signatures["safe_tx_hash_preimage"],
+        )[0]
+        self.assertTrue(self._is_valid_async(safe_signature, safe_version="1.5.0"))
+
+        legacy_magic_value = bytes(SafeSignatureContract.EIP1271_MAGIC_VALUE)
+        with mock.patch.object(
+            safe_signature_module,
+            "get_compatibility_fallback_handler_contract",
+            fallback_handler_getter_returning(legacy_magic_value, is_async=True),
+        ):
+            self.assertFalse(self._is_valid_async(safe_signature, safe_version="1.5.0"))

--- a/safe_eth/safe/tests/test_safe_signature.py
+++ b/safe_eth/safe/tests/test_safe_signature.py
@@ -29,6 +29,7 @@ from ...eth.tests.ethereum_test_case import EthereumTestCaseMixin
 from .. import SafeOperationEnum
 from .. import safe_signature as safe_signature_module
 from ..safe_signature import (
+    CannotCheckEIP1271ContractSignature,
     SafeSignature,
     SafeSignatureApprovedHash,
     SafeSignatureApprovedHashAsync,
@@ -622,7 +623,11 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
         signature_s = fixture["signature_s"]
         signature_v = fixture["signature_v"]
 
-        safe_signature = SafeSignature.parse_signature(signature, safe_tx_hash)[0]
+        # The owner Safe signed `safe_tx_hash` itself as its message, so that hash is
+        # also the data the legacy `isValidSignature(bytes,bytes)` entrypoint takes
+        safe_signature = SafeSignature.parse_signature(
+            signature, safe_tx_hash, safe_tx_hash
+        )[0]
         self.assertIsInstance(safe_signature, SafeSignatureContract)
         self.assertFalse(safe_signature.is_valid(self.ethereum_client, None))
 
@@ -634,13 +639,17 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
         safe_tx.sign(owner_1.key)
         safe_tx.execute(owner_1.key)
 
-        safe_signature = SafeSignature.parse_signature(signature, safe_tx_hash)[0]
+        safe_signature = SafeSignature.parse_signature(
+            signature, safe_tx_hash, safe_tx_hash
+        )[0]
         self.assertTrue(safe_signature.is_valid(self.ethereum_client, None))
         self.assertIsInstance(safe_signature, SafeSignatureContract)
 
         # Check with crafted signature
         safe_tx_hash_2 = fast_keccak_text("test2")
-        safe_signature = SafeSignature.parse_signature(signature, safe_tx_hash_2)[0]
+        safe_signature = SafeSignature.parse_signature(
+            signature, safe_tx_hash_2, safe_tx_hash_2
+        )[0]
         self.assertFalse(safe_signature.is_valid(self.ethereum_client, None))
 
         safe_tx_hash_2_message_hash = safe_contract.functions.getMessageHash(
@@ -661,7 +670,7 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
             signature_r + signature_s + signature_v + encoded_contract_signature
         )
         safe_signature = SafeSignature.parse_signature(
-            crafted_signature, safe_tx_hash_2
+            crafted_signature, safe_tx_hash_2, safe_tx_hash_2
         )[0]
         self.assertEqual(contract_signature, safe_signature.contract_signature)
         self.assertTrue(safe_signature.is_valid(self.ethereum_client, None))
@@ -796,7 +805,9 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
 
         count = 0
         for safe_signature, contract_signature in zip(
-            SafeSignature.parse_signature(signature, safe_tx_hash),
+            # The owner Safe signed `safe_tx_hash` itself as its message, so that hash is
+            # also the data the legacy `isValidSignature(bytes,bytes)` entrypoint takes
+            SafeSignature.parse_signature(signature, safe_tx_hash, safe_tx_hash),
             [contract_signature_1, contract_signature_2],
         ):
             self.assertEqual(safe_signature.contract_signature, contract_signature)
@@ -806,7 +817,7 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
             )
             # Test exported signature
             exported_signature = SafeSignature.parse_signature(
-                safe_signature.export_signature(), safe_tx_hash
+                safe_signature.export_signature(), safe_tx_hash, safe_tx_hash
             )[0]
             self.assertEqual(
                 exported_signature.contract_signature, safe_signature.contract_signature
@@ -991,6 +1002,47 @@ class TestSafeContractSignature(SafeTestCaseMixin, TestCase):
                 safe_signature.is_valid(self.ethereum_client, safe_version="1.5.0")
             )
 
+    def test_contract_signature_without_preimage(self):
+        """An unknown preimage raises for a Safe below 1.5.0 instead of reporting invalid.
+
+        `parse_signature` leaves `safe_hash_preimage` unknown when the caller does not have
+        it. `safe_hash` cannot stand in for it on the legacy entrypoint: the signer hashes
+        whatever it receives, so it would reject a valid signature.
+        """
+        signatures = build_nested_contract_signatures(self, safe_version="1.4.1")
+        safe_signature = SafeSignature.parse_signature(
+            signatures["preimage"], signatures["safe_tx_hash"]
+        )[0]
+        self.assertIsNone(safe_signature.safe_hash_preimage)
+
+        with self.assertRaises(CannotCheckEIP1271ContractSignature):
+            safe_signature.is_valid(self.ethereum_client, safe_version="1.4.1")
+
+        # Without a version only the `bytes32` entrypoint is left to check, and the preimage
+        # nesting does not answer there
+        self.assertFalse(safe_signature.is_valid(self.ethereum_client))
+
+        # The same signature is valid once the preimage is known
+        with_preimage = SafeSignature.parse_signature(
+            signatures["preimage"],
+            signatures["safe_tx_hash"],
+            signatures["safe_tx_hash_preimage"],
+        )[0]
+        self.assertTrue(
+            with_preimage.is_valid(self.ethereum_client, safe_version="1.4.1")
+        )
+
+    def test_contract_signature_without_preimage_from_v1_5_0(self):
+        """A Safe from 1.5.0 verifies with the hash, so it needs no preimage."""
+        signatures = build_nested_contract_signatures(self, safe_version="1.5.0")
+        safe_signature = SafeSignature.parse_signature(
+            signatures["hash"], signatures["safe_tx_hash"]
+        )[0]
+        self.assertIsNone(safe_signature.safe_hash_preimage)
+        self.assertTrue(
+            safe_signature.is_valid(self.ethereum_client, safe_version="1.5.0")
+        )
+
 
 class TestSafeSignatureAsync(AsyncSignatureTestMixin, EthereumTestCaseMixin, TestCase):
     def test_contract_signature(self):
@@ -1142,7 +1194,11 @@ class TestSafeContractSignatureAsync(AsyncSignatureTestMixin, SafeTestCaseMixin)
         signature_s = fixture["signature_s"]
         signature_v = fixture["signature_v"]
 
-        safe_signature = SafeSignatureAsync.parse_signature(signature, safe_tx_hash)[0]
+        # The owner Safe signed `safe_tx_hash` itself as its message, so that hash is
+        # also the data the legacy `isValidSignature(bytes,bytes)` entrypoint takes
+        safe_signature = SafeSignatureAsync.parse_signature(
+            signature, safe_tx_hash, safe_tx_hash
+        )[0]
         self.assertIsInstance(safe_signature, SafeSignatureContractAsync)
         self.assertFalse(self._is_valid_async(safe_signature, None))
 
@@ -1153,14 +1209,16 @@ class TestSafeContractSignatureAsync(AsyncSignatureTestMixin, SafeTestCaseMixin)
         safe_tx.sign(owner.key)
         safe_tx.execute(owner.key)
 
-        safe_signature = SafeSignatureAsync.parse_signature(signature, safe_tx_hash)[0]
+        safe_signature = SafeSignatureAsync.parse_signature(
+            signature, safe_tx_hash, safe_tx_hash
+        )[0]
         self.assertTrue(self._is_valid_async(safe_signature, None))
         self.assertIsInstance(safe_signature, SafeSignatureContractAsync)
 
         safe_tx_hash_2 = fast_keccak_text("test2")
-        safe_signature = SafeSignatureAsync.parse_signature(signature, safe_tx_hash_2)[
-            0
-        ]
+        safe_signature = SafeSignatureAsync.parse_signature(
+            signature, safe_tx_hash_2, safe_tx_hash_2
+        )[0]
         self.assertFalse(self._is_valid_async(safe_signature, None))
 
         safe_tx_hash_2_message_hash = safe_contract.functions.getMessageHash(
@@ -1178,7 +1236,7 @@ class TestSafeContractSignatureAsync(AsyncSignatureTestMixin, SafeTestCaseMixin)
             signature_r + signature_s + signature_v + encoded_contract_signature
         )
         safe_signature = SafeSignatureAsync.parse_signature(
-            crafted_signature, safe_tx_hash_2
+            crafted_signature, safe_tx_hash_2, safe_tx_hash_2
         )[0]
         self.assertEqual(contract_signature, safe_signature.contract_signature)
         self.assertTrue(self._is_valid_async(safe_signature, None))
@@ -1304,7 +1362,9 @@ class TestSafeContractSignatureAsync(AsyncSignatureTestMixin, SafeTestCaseMixin)
 
         count = 0
         for safe_signature, contract_signature in zip(
-            SafeSignatureAsync.parse_signature(signature, safe_tx_hash),
+            # The owner Safe signed `safe_tx_hash` itself as its message, so that hash is
+            # also the data the legacy `isValidSignature(bytes,bytes)` entrypoint takes
+            SafeSignatureAsync.parse_signature(signature, safe_tx_hash, safe_tx_hash),
             [contract_signature_1, contract_signature_2],
         ):
             self.assertEqual(safe_signature.contract_signature, contract_signature)
@@ -1313,7 +1373,7 @@ class TestSafeContractSignatureAsync(AsyncSignatureTestMixin, SafeTestCaseMixin)
                 safe_signature.signature_type, SafeSignatureType.CONTRACT_SIGNATURE
             )
             exported_signature = SafeSignatureAsync.parse_signature(
-                safe_signature.export_signature(), safe_tx_hash
+                safe_signature.export_signature(), safe_tx_hash, safe_tx_hash
             )[0]
             self.assertEqual(
                 exported_signature.contract_signature, safe_signature.contract_signature
@@ -1473,3 +1533,40 @@ class TestSafeContractSignatureAsync(AsyncSignatureTestMixin, SafeTestCaseMixin)
             fallback_handler_getter_returning(legacy_magic_value, is_async=True),
         ):
             self.assertFalse(self._is_valid_async(safe_signature, safe_version="1.5.0"))
+
+    def test_contract_signature_without_preimage(self):
+        """An unknown preimage raises for a Safe below 1.5.0 instead of reporting invalid.
+
+        `parse_signature` leaves `safe_hash_preimage` unknown when the caller does not have
+        it. `safe_hash` cannot stand in for it on the legacy entrypoint: the signer hashes
+        whatever it receives, so it would reject a valid signature.
+        """
+        signatures = build_nested_contract_signatures(self, safe_version="1.4.1")
+        safe_signature = SafeSignatureAsync.parse_signature(
+            signatures["preimage"], signatures["safe_tx_hash"]
+        )[0]
+        self.assertIsNone(safe_signature.safe_hash_preimage)
+
+        with self.assertRaises(CannotCheckEIP1271ContractSignature):
+            self._is_valid_async(safe_signature, safe_version="1.4.1")
+
+        # Without a version only the `bytes32` entrypoint is left to check, and the preimage
+        # nesting does not answer there
+        self.assertFalse(self._is_valid_async(safe_signature))
+
+        # The same signature is valid once the preimage is known
+        with_preimage = SafeSignatureAsync.parse_signature(
+            signatures["preimage"],
+            signatures["safe_tx_hash"],
+            signatures["safe_tx_hash_preimage"],
+        )[0]
+        self.assertTrue(self._is_valid_async(with_preimage, safe_version="1.4.1"))
+
+    def test_contract_signature_without_preimage_from_v1_5_0(self):
+        """A Safe from 1.5.0 verifies with the hash, so it needs no preimage."""
+        signatures = build_nested_contract_signatures(self, safe_version="1.5.0")
+        safe_signature = SafeSignatureAsync.parse_signature(
+            signatures["hash"], signatures["safe_tx_hash"]
+        )[0]
+        self.assertIsNone(safe_signature.safe_hash_preimage)
+        self.assertTrue(self._is_valid_async(safe_signature, safe_version="1.5.0"))


### PR DESCRIPTION
# Validate contract signatures against the verifying Safe's EIP-1271 convention

## Problem

`SafeSignatureContract.is_valid` tries both EIP-1271 entrypoints and returns `True` if **either** answers:

1. `isValidSignature(bytes32,bytes)` with `safe_hash`
2. `isValidSignature(bytes,bytes)` with `safe_hash_preimage`

On-chain only one is ever called, and the version of the Safe **doing the verifying** decides which:

- **Below 1.5.0** (1.3.0, 1.4.x) — `checkNSignatures` calls the legacy `isValidSignature(data, contractSignature)` with the whole preimage (`Safe.sol:315` in v1.4.1, `GnosisSafe.sol:285` in v1.3.0 — identical branches, the only v1.4.1 addition is the `GS027` preimage assertion).
- **From 1.5.0** — `checkContractSignature` calls `isValidSignature(bytes32 dataHash, ...)` only (`Safe.sol:270`), and its `CompatibilityFallbackHandler` no longer declares the legacy overload at all.

So a signature can be "valid" here and still revert `GS024` on the Safe that has to verify it. Consumers that store it end up below threshold with nothing reported at write time.

## What this changes

**`safe_version` on `is_valid`.** Only the entrypoint that version calls on-chain is checked. It goes on the abstract `SafeSignature` / `SafeSignatureAsync` and on all ten implementations, the same way `safe_address` already works: validation-time context that only one signature type reads and the rest ignore.

**`safe_version=None` keeps the current behaviour.** Existing callers are unaffected — the library cannot always know the verifying Safe's version, so the permissive default stays. Callers that do know should pass it.

**`uses_bytes32_eip1271()`** is the single home for the version rule and for its failure mode. `VERSION()` is an arbitrary on-chain string, so it raises `CannotCheckEIP1271ContractSignature` (an existing, until now unused, `SafeSignatureException` subclass) instead of leaking `packaging`'s `InvalidVersion` and making every consumer reimplement the same translation.

## The cross-version case comes out for free

A verifying Safe below 1.5.0 with an owner Safe on 1.5.0 can never work: the verifying Safe calls the legacy overload, which a 1.5.0 signer does not declare. Today `is_valid` accepts it through attempt 1, which is a permanent false accept. Keying only off the verifying Safe's version rejects it with no extra logic, because we call the entrypoint that will actually be used and it reverts.

| Verifying Safe | Owner Safe | Called on-chain | Works | Before | After |
| --- | --- | --- | --- | --- | --- |
| pre-1.5.0 | pre-1.5.0 | `(bytes preimage, sig)` | yes | accepts preimage and hash | preimage only |
| pre-1.5.0 | 1.5.0+ | `(bytes preimage, sig)`, overload missing | never | **accepts** | rejected |
| 1.5.0+ | pre-1.5.0 | `(bytes32 hash, sig)` | yes | accepts hash and preimage | hash only |
| 1.5.0+ | 1.5.0+ | `(bytes32 hash, sig)` | yes | accepts hash only | hash only |

## Tests

`TestSafeContractSignature` and `TestSafeContractSignatureAsync` cover v1.3.0, v1.4.1 and v1.5.0 against the deployed contracts:

- the version-correct nesting is accepted, the other is rejected
- `safe_version=None` still accepts both on a pre-1.5.0 signer (back-compat guard)
- a 1.5.0 owner Safe is rejected for a 1.4.1 verifier, and the test pins that without a version it is still accepted, which is the false accept above

`277 passed, 12 skipped` in `safe_eth/safe/tests/`.

## Notes for the reviewer

- No production code in this repo calls `is_valid`, so the change is additive to the public API.
- The `mypy` pre-commit hook is `language: system` and fails locally with `Executable mypy not found`. Ran separately with the hook's flags: both changed files clean. The one error reported, `safe_eth/eth/tests/utils.py:56`, is pre-existing in a file this PR does not touch.

Consumed by safe-global/safe-queue-service PLA-1907, which needs a release of this.
